### PR TITLE
Update depreciated warn method calls

### DIFF
--- a/aequilibrae/paths/__init__.py
+++ b/aequilibrae/paths/__init__.py
@@ -14,4 +14,4 @@ try:
     from aequilibrae.paths.AoN import one_to_all, skimming_single_origin, path_computation, VERSION_COMPILED, \
         update_path_trace
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')

--- a/aequilibrae/paths/all_or_nothing.py
+++ b/aequilibrae/paths/all_or_nothing.py
@@ -11,7 +11,7 @@ from aequilibrae import logger
 try:
     from aequilibrae.paths.AoN import one_to_all
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')
 
 spec = iutil.find_spec("PyQt5")
 pyqt = spec is not None

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -13,7 +13,7 @@ try:
     from aequilibrae.paths.AoN import triple_linear_combination, triple_linear_combination_skims
     from aequilibrae.paths.AoN import copy_one_dimension, copy_two_dimensions, copy_three_dimensions
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')
 
 import scipy
 
@@ -25,7 +25,7 @@ else:
     from scipy.optimize import root as root_scalar
 
     recent_scipy = False
-    logger.warn(f"Using older version of Scipy. For better performance, use Scipy >= 1.4")
+    logger.warning(f"Using older version of Scipy. For better performance, use Scipy >= 1.4")
 
 if False:
     from aequilibrae.paths.traffic_assignment import TrafficAssignment
@@ -371,11 +371,11 @@ class LinearApproximation(WorkerThread):
                 min_res = root_scalar(derivative_of_objective, bracket=[0, 1])
                 self.stepsize = min_res.root
                 if not min_res.converged:
-                    logger.warn("Descent direction stepsize finder is not converged")
+                    logger.warning("Descent direction stepsize finder is not converged")
             else:
                 min_res = root_scalar(derivative_of_objective, 1 / self.iter)
                 if not min_res.success:
-                    logger.warn("Descent direction stepsize finder is not converged")
+                    logger.warning("Descent direction stepsize finder is not converged")
                 self.stepsize = min_res.x[0]
                 if self.stepsize <= 0.0 or self.stepsize >= 1.0:
                     raise ValueError('wrong root')
@@ -389,7 +389,7 @@ class LinearApproximation(WorkerThread):
             if derivative_of_objective(0.0) < derivative_of_objective(1.0):
                 if self.algorithm == "frank-wolfe":
                     heuristic_stepsize_at_zero = 1.0 / self.iter
-                    logger.warn("# Alert: Adding {} to stepsize to make it non-zero".format(heuristic_stepsize_at_zero))
+                    logger.warning("# Alert: Adding {} to stepsize to make it non-zero".format(heuristic_stepsize_at_zero))
                     self.stepsize = heuristic_stepsize_at_zero
                 else:
                     # for cf/bfw: don't add a bad step, just reset the stepdirection calculation to start with fw again

--- a/aequilibrae/paths/network_skimming.py
+++ b/aequilibrae/paths/network_skimming.py
@@ -9,7 +9,7 @@ from aequilibrae import logger
 try:
     from aequilibrae.paths.AoN import skimming_single_origin
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')
 
 spec = iutil.find_spec("PyQt5")
 pyqt = spec is not None

--- a/aequilibrae/paths/results/assignment_results.py
+++ b/aequilibrae/paths/results/assignment_results.py
@@ -9,7 +9,7 @@ from aequilibrae import logger
 try:
     from aequilibrae.paths.AoN import sum_axis1
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')
 
 """
 TO-DO:

--- a/aequilibrae/paths/results/path_results.py
+++ b/aequilibrae/paths/results/path_results.py
@@ -5,7 +5,7 @@ from aequilibrae import logger
 try:
     from aequilibrae.paths.AoN import update_path_trace, path_computation
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')
 
 
 class PathResults:

--- a/aequilibrae/paths/vdf.py
+++ b/aequilibrae/paths/vdf.py
@@ -3,7 +3,7 @@ from aequilibrae import logger
 try:
     from aequilibrae.paths.AoN import bpr, delta_bpr
 except ImportError as ie:
-    logger.warn(f'Could not import procedures from the binary. {ie.args}')
+    logger.warning(f'Could not import procedures from the binary. {ie.args}')
 
 all_vdf_functions = ['bpr']
 

--- a/aequilibrae/project/network/network.py
+++ b/aequilibrae/project/network/network.py
@@ -144,7 +144,7 @@ class Network():
             if bbox is None:
                 msg = f'We could not find a reference for place name "{place_name}"'
                 warn(msg)
-                logger.warn(msg)
+                logger.warning(msg)
                 return
             for i in report:
                 if "PLACE FOUND" in i:

--- a/aequilibrae/project/spatialite_connection.py
+++ b/aequilibrae/project/spatialite_connection.py
@@ -12,5 +12,5 @@ def spatialite_connection(conn):
     try:
         conn.load_extension("mod_spatialite")
     except Exception as e:
-        logger.warn(f"AequilibraE might not work as intended without spatialite. {e.args}")
+        logger.warning(f"AequilibraE might not work as intended without spatialite. {e.args}")
     return conn

--- a/aequilibrae/starts_logging.py
+++ b/aequilibrae/starts_logging.py
@@ -41,7 +41,7 @@ def cleaning():
         try:
             os.unlink(f)
         except Exception as err:
-            logger.warn(err.__str__())
+            logger.warning(err.__str__())
 
 
 logger = StartsLogging()


### PR DESCRIPTION
logger.warn() has been depreciated since python 3.3. This replaces
logger.warn() with logger.warning()