### PR TITLE
Fixes assignment with compressed graph and multiple classes

### DIFF
--- a/aequilibrae/paths/all_or_nothing.py
+++ b/aequilibrae/paths/all_or_nothing.py
@@ -78,7 +78,6 @@ class allOrNothing(WorkerThread):
         self.results.compact_link_loads = np.sum(self.aux_res.temp_link_loads, axis=2)
         assign_link_loads(self.results.link_loads, self.results.compact_link_loads,
                           self.results.crosswalk, self.results.cores)
-        self.results.total_flows()
         if pyqt:
             self.assignment.emit(["finished_threaded_procedure", None])
 

--- a/aequilibrae/paths/parallel_numpy.pyx
+++ b/aequilibrae/paths/parallel_numpy.pyx
@@ -194,8 +194,8 @@ cpdef void copy_two_dimensions_cython(double[:, :] target,
     cdef long long l = target.shape[0]
     cdef long long k = target.shape[1]
 
-    for i in prange(l, nogil=True, num_threads=cores):
-        for j in range(k):
+    for j in range(k):
+        for i in prange(l, nogil=True, num_threads=cores):
             target[i, j] = source[i, j]
 
 

--- a/aequilibrae/paths/traffic_assignment.py
+++ b/aequilibrae/paths/traffic_assignment.py
@@ -182,9 +182,9 @@ class TrafficAssignment(object):
             classes (:obj:`List[TrafficClass]`:) List of Traffic classes for assignment
         """
 
-        ids = set([x._id for x in classes])
+        ids = set([x.__id__ for x in classes])
         if len(ids) < len(classes):
-            raise Exception("Classes need to be unique. Your list of classes has repeated items")
+            raise Exception("Classes need to be unique. Your list of classes has repeated items/IDs")
         self.classes = classes  # type: List[TrafficClass]
 
     def add_class(self, traffic_class: TrafficClass) -> None:
@@ -195,7 +195,7 @@ class TrafficAssignment(object):
             traffic_class (:obj:`TrafficClass`:) Traffic class
         """
 
-        ids = [x._id for x in self.classes if x._id == traffic_class._id]
+        ids = [x.__id__ for x in self.classes if x.__id__ == traffic_class.__id__]
         if len(ids) > 0:
             raise Exception("Traffic class already in the assignment")
 

--- a/aequilibrae/paths/traffic_class.py
+++ b/aequilibrae/paths/traffic_class.py
@@ -16,6 +16,7 @@ class TrafficClass():
         tc = TrafficClass(graph, demand_matrix)
         tc.set_pce(1.3)
     """
+
     def __init__(self, graph: Graph, matrix: AequilibraeMatrix) -> None:
         """
         Instantiates the class
@@ -41,7 +42,7 @@ class TrafficClass():
         self.results.reset()
         self._aon_results = AssignmentResults()
         self._aon_results.prepare(self.graph, self.matrix)
-        self._id = uuid4().hex
+        self.__id__ = uuid4().hex
 
     def set_pce(self, pce: Union[float, int]) -> None:
         """Sets Passenger Car equivalent
@@ -52,3 +53,9 @@ class TrafficClass():
         if not isinstance(pce, (float, int)):
             raise ValueError('PCE needs to be either integer or float ')
         self.pce = pce
+
+    def __setattr__(self, key, value):
+
+        if key not in ['graph', 'matrix', 'pce', 'mode', 'class_flow', 'results', '_aon_results', '__id__']:
+            raise KeyError('Traffic Class does not have that element')
+        self.__dict__[key] = value

--- a/tests/aequilibrae/paths/test_traffic_assignment.py
+++ b/tests/aequilibrae/paths/test_traffic_assignment.py
@@ -167,14 +167,14 @@ class TestTrafficAssignment(TestCase):
         correl = np.corrcoef(self.assigclass.results.total_link_loads, results.volume.values)[0, 1]
         self.assertLess(0.8, correl)
 
-        self.assignment.max_iter = 30
+        self.assignment.max_iter = 50
         self.assignment.set_algorithm("msa")
         self.assignment.execute()
         msa25 = self.assignment.assignment.rgap
 
         self.assigclass.results.total_flows()
         correl = np.corrcoef(self.assigclass.results.total_link_loads, results.volume)[0, 1]
-        self.assertLess(0.95, correl)
+        self.assertLess(0.98, correl)
 
         self.assignment.set_algorithm("frank-wolfe")
         self.assignment.execute()
@@ -183,7 +183,7 @@ class TestTrafficAssignment(TestCase):
 
         self.assigclass.results.total_flows()
         correl = np.corrcoef(self.assigclass.results.total_link_loads, results.volume)[0, 1]
-        self.assertLess(0.97, correl)
+        self.assertLess(0.99, correl)
 
         self.assignment.set_algorithm("cfw")
         self.assignment.execute()
@@ -191,7 +191,7 @@ class TestTrafficAssignment(TestCase):
 
         self.assigclass.results.total_flows()
         correl = np.corrcoef(self.assigclass.results.total_link_loads, results.volume)[0, 1]
-        self.assertLess(0.98, correl)
+        self.assertLess(0.999, correl)
 
         # For the last algorithm, we set skimming
         self.car_graph.set_skimming(["free_flow_time", "distance"])
@@ -204,7 +204,7 @@ class TestTrafficAssignment(TestCase):
 
         self.assigclass.results.total_flows()
         correl = np.corrcoef(self.assigclass.results.total_link_loads, results.volume)[0, 1]
-        self.assertLess(0.99, correl)
+        self.assertLess(0.9998, correl)
 
         self.assertLess(msa25, msa10)
         self.assertLess(fw25, msa25)


### PR DESCRIPTION
The issue I was facing was that we were using the traffic classes' modes as dictionary keys.  Since the modes were derived from the graphs, things would go haywire when we had the same graph used for more than one class (Truck, in our case here).  I have replaced the dictionary keys with the classes' IDs, which are randomly generated using the **uuid** library and I still check if all classes have unique IDs.
Since I was at it, I introduced the multiplication of PCE at the beginning (right after the AoN), and just dividing the final result by it, as it reduces the chances of mixing up what are step directions (actual flows) Vs. congestion-causing flows for the purpose of speed computation (**with** PCEs).