### PR TITLE
Janzill/correct conjugate direction

### DIFF
--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -147,13 +147,22 @@ class LinearApproximation(WorkerThread):
         # this needs more work
         numerator = 0.0
         denominator = 0.0
+        prev_dir_minus_current_sol = {}
+        aon_minus_current_sol = {}
+        aon_minus_prev_dir = {}
+
         for c in self.traffic_classes:
             stp_dir = self.step_direction[c.__id__]
-            prev_dir_minus_current_sol = np.sum(stp_dir.link_loads[:, :] - c.results.link_loads[:, :], axis=1)
-            aon_minus_current_sol = np.sum(c._aon_results.link_loads[:, :] - c.results.link_loads[:, :], axis=1)
-            aon_minus_prev_dir = np.sum(c._aon_results.link_loads[:, :] - stp_dir.link_loads[:, :], axis=1)
-            numerator += prev_dir_minus_current_sol * aon_minus_current_sol
-            denominator += prev_dir_minus_current_sol * aon_minus_prev_dir
+            prev_dir_minus_current_sol[c.__id__] = np.sum(stp_dir.link_loads[:, :] - c.results.link_loads[:, :], axis=1)
+            aon_minus_current_sol[c.__id__] = np.sum(
+                c._aon_results.link_loads[:, :] - c.results.link_loads[:, :], axis=1
+            )
+            aon_minus_prev_dir[c.__id__] = np.sum(c._aon_results.link_loads[:, :] - stp_dir.link_loads[:, :], axis=1)
+
+        for c_0 in self.traffic_classes:
+            for c_1 in self.traffic_classes:
+                numerator += prev_dir_minus_current_sol[c_0] * aon_minus_current_sol[c_1]
+                denominator += prev_dir_minus_current_sol[c_0] * aon_minus_prev_dir[c_1]
 
         numerator = np.sum(numerator * self.vdf_der)
         denominator = np.sum(denominator * self.vdf_der)

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -161,8 +161,8 @@ class LinearApproximation(WorkerThread):
 
         for c_0 in self.traffic_classes:
             for c_1 in self.traffic_classes:
-                numerator += prev_dir_minus_current_sol[c_0] * aon_minus_current_sol[c_1]
-                denominator += prev_dir_minus_current_sol[c_0] * aon_minus_prev_dir[c_1]
+                numerator += prev_dir_minus_current_sol[c_0.__id__] * aon_minus_current_sol[c_1.__id__]
+                denominator += prev_dir_minus_current_sol[c_0.__id__] * aon_minus_prev_dir[c_1.__id__]
 
         numerator = np.sum(numerator * self.vdf_der)
         denominator = np.sum(denominator * self.vdf_der)
@@ -213,10 +213,10 @@ class LinearApproximation(WorkerThread):
 
         for c_0 in self.traffic_classes:
             for c_1 in self.traffic_classes:
-                mu_numerator += x_[c_0] * y_[c_1]
-                mu_denominator += x_[c_0] * w_[c_1]
-                nu_nom += z_[c_0] * y_[c_1]
-                nu_denom += z_[c_0] * z_[c_1]
+                mu_numerator += x_[c_0.__id__] * y_[c_1.__id__]
+                mu_denominator += x_[c_0.__id__] * w_[c_1.__id__]
+                nu_nom += z_[c_0.__id__] * y_[c_1.__id__]
+                nu_denom += z_[c_0.__id__] * z_[c_1.__id__]
 
         mu_numerator = np.sum(mu_numerator * self.vdf_der)
         mu_denominator = np.sum(mu_denominator * self.vdf_der)


### PR DESCRIPTION
For multi-class assignment, the second order linear approximation step direction finder did not include some cross-class terms. Specifically, the implementation of Eq. 18 in our TRB paper only used diagonal elements with respect to traffic classes. This PR includes off-diagonal elements, which will hopefully speed up convergence.