### PR TITLE
Fix volume over capacity calculation for assignment results

### DIFF
--- a/aequilibrae/paths/traffic_assignment.py
+++ b/aequilibrae/paths/traffic_assignment.py
@@ -409,7 +409,7 @@ class TrafficAssignment(object):
         res1 = assig_results[0]
 
         tot_flow = self.assignment.fw_total_flow[idx]
-        voc = self.assignment.fw_total_flow / self.capacity[idx]
+        voc = tot_flow / self.capacity[idx]
         congested_time = self.congested_time[idx]
         free_flow_tt = self.free_flow_tt[idx]
 


### PR DESCRIPTION
When calculating volume over capacity for assignment results, the calculation is made on inconsistent indices, which results in wrong voc values for the resuls.

This pull request ensures voc calculation is made with the correct indices.