### PR TITLE
Fix shortest path calculation when the predecessor of destination node is node index 0

### DIFF
--- a/aequilibrae/paths/AoN.pyx
+++ b/aequilibrae/paths/AoN.pyx
@@ -228,7 +228,7 @@ def path_computation(origin, destination, graph, results):
                                     b_nodes_view,
                                     original_b_nodes_view)
 
-    if predecessors_view[dest_index] > 0:
+    if predecessors_view[dest_index] >= 0:
         all_connectors = []
         link_directions = []
         all_nodes = [dest_index]
@@ -273,7 +273,7 @@ def update_path_trace(results, destination, graph):
 
         results.milepost = None
         results.path_nodes = None
-        if results.predecessors[dest_index] > 0:
+        if results.predecessors[dest_index] >= 0:
             all_connectors = []
             link_directions = []
             all_nodes = [dest_index]


### PR DESCRIPTION
In the shortest path computation, predecessors_view array has the predecessor node indices or -1 for no path. The intention with the if statements in this pull request is to check if there is a path to destination.

Unfortunately in the cases where the predecessor of destination node is node with index 0, path computation thinks there is no path to the destination node.

This pull request fixes this issue by checking for >=0 instead of >0 for the predecessor