### PR TITLE
Fix shortest path calculation with blocking centroids

### DIFF
--- a/aequilibrae/paths/basic_path_finding.pyx
+++ b/aequilibrae/paths/basic_path_finding.pyx
@@ -168,10 +168,10 @@ cdef void blocking_centroid_flows(int action,
     cdef long long i
 
     if action == 1: # We are unblocking
-        for i in range(fs[centroids + 1]):
+        for i in range(fs[centroids]):
             temp_b_nodes[i] = real_b_nodes[i]
     else: # We are blocking:
-        for i in range(fs[centroids + 1]):
+        for i in range(fs[centroids]):
             temp_b_nodes[i] = orig
 
         for i in range(fs[orig], fs[orig + 1]):

--- a/tests/aequilibrae/paths/test_pathResults.py
+++ b/tests/aequilibrae/paths/test_pathResults.py
@@ -174,4 +174,3 @@ class TestBlockingTrianglePathResults(TestCase):
         self.r.update_trace(6)
         self.assertEqual(list(self.r.path_nodes), [4, 1, 3, 6])
         self.assertEqual(list(self.r.path), [4, 1, 6])
-

--- a/tests/aequilibrae/paths/test_pathResults.py
+++ b/tests/aequilibrae/paths/test_pathResults.py
@@ -1,15 +1,17 @@
 import os
+import uuid
+from shutil import copytree
 from tempfile import gettempdir
 from uuid import uuid4
 from os.path import join
 import sys
 from unittest import TestCase
 
+from aequilibrae import Project
 from aequilibrae.paths import path_computation, Graph
 from aequilibrae.paths.results import PathResults
-from aequilibrae.paths import binary_version
 from aequilibrae.utils.create_example import create_example
-from ...data import test_graph
+from ...data import triangle_graph_blocking
 import numpy as np
 
 # Adds the folder with the data to the path and collects the paths to the files
@@ -84,3 +86,92 @@ class TestPathResults(TestCase):
         self.assertEqual(list(self.r.path_link_directions), [1, 1], "Path update failed. Wrong link directions")
         self.assertEqual(list(self.r.path_nodes), [5, 9, 10], "Path update failed. Wrong sequence of path nodes")
         self.assertEqual(list(self.r.milepost), [0, 5, 8], "Path update failed. Wrong milepost results")
+
+
+class TestBlockingTrianglePathResults(TestCase):
+    def setUp(self) -> None:
+        os.environ['PATH'] = os.path.join(gettempdir(), 'temp_data') + ';' + os.environ['PATH']
+        self.proj_dir = os.path.join(gettempdir(), uuid.uuid4().hex)
+        copytree(triangle_graph_blocking, self.proj_dir)
+        self.project = Project()
+        self.project.open(self.proj_dir)
+        self.project.network.build_graphs(modes=["c"])
+        self.g = self.project.network.graphs["c"]  # type: Graph
+        self.g.set_graph("free_flow_time")
+        self.g.set_blocked_centroid_flows(True)
+
+        self.r = PathResults()
+        self.r.prepare(self.g)
+
+    def tearDown(self) -> None:
+        self.project.close()
+        del self.r
+
+    def test_compute_paths(self):
+        self.r.compute_path(1, 2)
+        self.assertEqual(list(self.r.path_nodes), [1, 3, 2])
+        self.assertEqual(list(self.r.path), [1, 2])
+
+        self.r.compute_path(2, 1)
+        self.assertEqual(list(self.r.path_nodes), [2, 1])
+        self.assertEqual(list(self.r.path), [3])
+
+        self.r.compute_path(3, 1)
+        self.assertEqual(list(self.r.path_nodes), [3, 2, 1])
+        self.assertEqual(list(self.r.path), [2, 3])
+
+        self.r.compute_path(3, 2)
+        self.assertEqual(list(self.r.path_nodes), [3, 2])
+        self.assertEqual(list(self.r.path), [2])
+
+        self.r.compute_path(1, 3)
+        self.assertEqual(list(self.r.path_nodes), [1, 3])
+        self.assertEqual(list(self.r.path), [1])
+
+        self.r.compute_path(2, 3)
+        self.assertEqual(list(self.r.path_nodes), [2, 1, 3])
+        self.assertEqual(list(self.r.path), [3, 1])
+
+    def test_compute_blocking_paths(self):
+        self.r.compute_path(4, 5)
+        self.assertEqual(list(self.r.path_nodes), [4, 1, 3, 2, 5])
+        self.assertEqual(list(self.r.path), [4, 1, 2, 5])
+
+        self.r.compute_path(5, 4)
+        self.assertEqual(list(self.r.path_nodes), [5, 2, 1, 4])
+        self.assertEqual(list(self.r.path), [5, 3, 4])
+
+        self.r.compute_path(6, 4)
+        self.assertEqual(list(self.r.path_nodes), [6, 3, 2, 1, 4])
+        self.assertEqual(list(self.r.path), [6, 2, 3, 4])
+
+        self.r.compute_path(6, 5)
+        self.assertEqual(list(self.r.path_nodes), [6, 3, 2, 5])
+        self.assertEqual(list(self.r.path), [6, 2, 5])
+
+        self.r.compute_path(4, 6)
+        self.assertEqual(list(self.r.path_nodes), [4, 1, 3, 6])
+        self.assertEqual(list(self.r.path), [4, 1, 6])
+
+        self.r.compute_path(5, 6)
+        self.assertEqual(list(self.r.path_nodes), [5, 2, 1, 3, 6])
+        self.assertEqual(list(self.r.path), [5, 3, 1, 6])
+
+    def test_update_trace(self):
+        self.r.compute_path(1, 2)
+        self.assertEqual(list(self.r.path_nodes), [1, 3, 2])
+        self.assertEqual(list(self.r.path), [1, 2])
+
+        self.r.update_trace(3)
+        self.assertEqual(list(self.r.path_nodes), [1, 3])
+        self.assertEqual(list(self.r.path), [1])
+
+    def test_update_blocking_trace(self):
+        self.r.compute_path(4, 5)
+        self.assertEqual(list(self.r.path_nodes), [4, 1, 3, 2, 5])
+        self.assertEqual(list(self.r.path), [4, 1, 2, 5])
+
+        self.r.update_trace(6)
+        self.assertEqual(list(self.r.path_nodes), [4, 1, 3, 6])
+        self.assertEqual(list(self.r.path), [4, 1, 6])
+

--- a/tests/data/blocking_triangle_graph_project/parameters.yml
+++ b/tests/data/blocking_triangle_graph_project/parameters.yml
@@ -210,6 +210,6 @@ system:
   cpus: 0
   default_directory: C:\
   logging: true
-  logging_directory: /home/burger/projects/model_engine/movici_simulation_core/tests/ae_wrapper/ae_project/ae_project_dir
+  logging_directory: /temp/
   spatialite_path: C:\mod_spatialite-NG-win-amd64
   temp directory: /temp

--- a/tests/data/blocking_triangle_graph_project/parameters.yml
+++ b/tests/data/blocking_triangle_graph_project/parameters.yml
@@ -1,0 +1,215 @@
+assignment:
+  equilibrium:
+    maximum_iterations: 250
+    rgap: 0.0001
+distribution:
+  gravity:
+    max error: 0.0001
+    max iterations: 100
+    max trip length: -1
+  ipf:
+    balancing tolerance: 0.001
+    convergence level: 0.0001
+    max iterations: 5000
+network:
+  links:
+    fields:
+      one-way:
+      - link_id:
+          description: Link ID. THIS FIELD CANNOT BE CHANGED
+          type: integer
+      - a_node:
+          description: Node of origin of the link. THIS FIELD CANNOT BE CHANGED
+          type: integer
+      - b_node:
+          description: Node of destinaiton of the link. THIS FIELD CANNOT BE CHANGED
+          type: integer
+      - direction:
+          description: Direction of the link. THIS FIELD CANNOT BE CHANGED
+          type: integer
+      - distance:
+          description: Length in meters for the link. THIS FIELD CANNOT BE CHANGED
+          type: numeric
+      - modes:
+          description: Set of modes allowed in this link. THIS FIELD CANNOT BE CHANGED
+          type: text
+      - link_type:
+          description: Classification of link (local, arterial, etc). THIS FIELD CANNOT
+            BE CHANGED
+          osm_source: highway
+          type: varchar
+      - name:
+          description: name
+          osm_source: name
+          type: text
+      two-way:
+      - lanes:
+          description: lanes
+          osm_behaviour: divide
+          osm_source: lanes
+          type: integer
+      - capacity:
+          description: capacity
+          type: numeric
+      - speed:
+          description: speed
+          osm_behaviour: copy
+          osm_source: maxspeed
+          type: numeric
+    link_types:
+    - centroid_connector:
+        description: VIRTUAL centroid connectors only
+        lane_capacity: 10000
+        lanes: 10
+        link_type_id: z
+    - default:
+        description: Default link type. Due to lack of information
+        lane_capacity: 900
+        lanes: 2
+        link_type_id: y
+  modes:
+  - car:
+      description: All motorized vehicles
+      letter: c
+  - transit:
+      description: All links capable of supporting transit-vehicles
+      letter: t
+  - walk:
+      description: Linkes where walking is permitted
+      letter: w
+  - bicycle:
+      description: All Bicycles
+      letter: b
+  nodes:
+    fields:
+    - node_id:
+        description: node_id. THIS FIELD CANNOT BE CHANGED
+        type: integer
+    - is_centroid:
+        description: is_centroid
+        type: integer
+  osm:
+    all_link_types:
+    - secondary_link
+    - escalator
+    - trail
+    - cycleway
+    - path
+    - trunk_link
+    - secondary
+    - escape
+    - track
+    - road
+    - motorway_link
+    - primary
+    - corridor
+    - residential
+    - footway
+    - motorway
+    - primary_link
+    - unclassified
+    - bus_guideway
+    - tertiary_link
+    - living_street
+    - pedestrian
+    - bridleway
+    - elevator
+    - motor
+    - trunk
+    - tertiary
+    - service
+    - steps
+    - proposed
+    - raceway
+    - construction
+    - abandoned
+    - platform
+    - unclassified
+    modes:
+      bicycle:
+        link_types:
+        - cycleway
+        - corridor
+        - pedestrian
+        - path
+        - track
+        - trail
+        - unclassified
+        mode_filter:
+          bicycle: 'no'
+        unknown_tags: true
+      car:
+        link_types:
+        - motor
+        - motorway
+        - trunk
+        - primary
+        - secondary
+        - tertiary
+        - unclassified
+        - residential
+        - motorway_link
+        - trunk_link
+        - primary_link
+        - secondary_link
+        - tertiary_link
+        - living_street
+        - service
+        - escape
+        - road
+        mode_filter:
+          motor_vehicle: 'no'
+        unknown_tags: true
+      transit:
+        link_types:
+        - motor
+        - motorway
+        - trunk
+        - primary
+        - secondary
+        - tertiary
+        - unclassified
+        - residential
+        - motorway_link
+        - trunk_link
+        - primary_link
+        - secondary_link
+        - tertiary_link
+        - living_street
+        - service
+        - escape
+        - road
+        - bus_guideway
+        unknown_tags: true
+      walk:
+        link_types:
+        - cycleway
+        - footway
+        - steps
+        - corridor
+        - pedestrian
+        - elevator
+        - escalator
+        - path
+        - track
+        - trail
+        - bridleway
+        - unclassified
+        mode_filter:
+          pedestrian: 'no'
+        unknown_tags: true
+osm:
+  accept_language: en
+  max_attempts: 50
+  max_query_area_size: 2500000000
+  nominatim_endpoint: https://nominatim.openstreetmap.org/
+  overpass_endpoint: http://overpass-api.de/api
+  sleeptime: 10
+  timeout: 540
+system:
+  cpus: 0
+  default_directory: C:\
+  logging: true
+  logging_directory: /home/burger/projects/model_engine/movici_simulation_core/tests/ae_wrapper/ae_project/ae_project_dir
+  spatialite_path: C:\mod_spatialite-NG-win-amd64
+  temp directory: /temp

--- a/tests/data/reference_files.py
+++ b/tests/data/reference_files.py
@@ -30,4 +30,3 @@ siouxfalls_skims = join(dirname(dirname(abspath(__file__))), "data/SiouxFalls_pr
 
 #
 no_triggers_project = join(dirname(dirname(abspath(__file__))), "data/no_triggers_project")
-

--- a/tests/data/reference_files.py
+++ b/tests/data/reference_files.py
@@ -7,6 +7,7 @@ data_folder = join(dirname(dirname(abspath(__file__))), 'data')
 test_network = join(dirname(dirname(abspath(__file__))), "data", "Final_Network.shp")
 test_graph = join(dirname(dirname(abspath(__file__))), "data", "test_graph.aeg")
 path_test = tempfile.gettempdir()
+triangle_graph_blocking = join(dirname(dirname(abspath(__file__))), "data", "blocking_triangle_graph_project")
 
 gtfs_folder = join(dirname(dirname(abspath(__file__))), "data/gtfs")
 gtfs_zip = join(dirname(dirname(abspath(__file__))), "data/gtfs.zip")
@@ -29,3 +30,4 @@ siouxfalls_skims = join(dirname(dirname(abspath(__file__))), "data/SiouxFalls_pr
 
 #
 no_triggers_project = join(dirname(dirname(abspath(__file__))), "data/no_triggers_project")
+


### PR DESCRIPTION
Shortest path calculation with blocking centroids fails. This is because of blocking_centroid_flows() method in basic_path_finding.pyx

centroids variable contains the number of centroids in the graph. This method as is blocks and unblocks one too many node, which means  if the graph is set to block the centroids, the first non centroid node of the graph is always blocked. If a shortest path would contain this node, then we either get no path or wrong path as a result.