### PR TITLE
Select link analysis

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,16 +24,15 @@ jupyter-contrib-nbextensions = "*"
 jupyter-nbextensions-configurator = "*"
 matplotlib = "*"
 pytest-xdist="*"
+jupyterlab = "*"
 
 [packages]
 numpy = ">=1.14.0"
 pyaml = "*"
 pyqt5 = "*"
-pyshp = "*"
 cython = "*"
 scipy = "*"
 openmatrix = "*"
-jupyterlab = "*"
 
 [scripts]
 notebook = "jupyter notebook"

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ jupyter = "*"
 jupyter-contrib-nbextensions = "*"
 jupyter-nbextensions-configurator = "*"
 matplotlib = "*"
-pytest-xdist="*
+pytest-xdist="*"
 
 [packages]
 numpy = ">=1.14.0"
@@ -33,6 +33,7 @@ pyshp = "*"
 cython = "*"
 scipy = "*"
 openmatrix = "*"
+jupyterlab = "*"
 
 [scripts]
 notebook = "jupyter notebook"

--- a/aequilibrae/paths/AoN.pyx
+++ b/aequilibrae/paths/AoN.pyx
@@ -81,7 +81,7 @@ def one_to_all(origin, matrix, graph, result, aux_result, curr_thread):
     cdef double [:, :] final_skim_matrices_view = fskm
 
     # views from the result object
-    cdef long long [:] no_path_view = result.no_path[origin_index, :]
+    cdef double [:] not_assigned_view = result.not_assigned[:]
 
     # views from the aux-result object
     cdef long long [:] predecessors_view = aux_result.predecessors[:, curr_thread]
@@ -134,9 +134,9 @@ def one_to_all(origin, matrix, graph, result, aux_result, curr_thread):
                         predecessors_view,
                         conn_view,
                         link_loads_view,
-                        no_path_view,
                         reached_first_view,
                         node_load_view,
+                        not_assigned_view,
                         w)
 
         if skims > 0:

--- a/aequilibrae/paths/all_or_nothing.py
+++ b/aequilibrae/paths/all_or_nothing.py
@@ -76,8 +76,9 @@ class allOrNothing(WorkerThread):
         pool.join()
         # TODO: Multi-thread this sum
         self.results.compact_link_loads = np.sum(self.aux_res.temp_link_loads, axis=2)
-        assign_link_loads(self.results.link_loads, self.results.compact_link_loads,
-                          self.results.crosswalk, self.results.cores)
+        assign_link_loads(
+            self.results.link_loads, self.results.compact_link_loads, self.results.crosswalk, self.results.cores
+        )
         if pyqt:
             self.assignment.emit(["finished_threaded_procedure", None])
 
@@ -88,10 +89,8 @@ class allOrNothing(WorkerThread):
             all_threads[thread_id] = all_threads["count"]
             all_threads["count"] += 1
 
-        x = one_to_all(origin, self.matrix, self.graph, self.results, self.aux_res, th)
+        _ = one_to_all(origin, self.matrix, self.graph, self.results, self.aux_res, th)
         self.cumulative += 1
-        if x != origin:
-            self.report.append(x)
         if pyqt:
             self.assignment.emit(["zones finalized", self.cumulative])
             self.assignment.emit(["text AoN", f"{self.cumulative:,}/{self.matrix.zones:,}"])

--- a/aequilibrae/paths/assignment_paths.py
+++ b/aequilibrae/paths/assignment_paths.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List
+from typing import Dict, List, Tuple
 import numpy as np
 import pandas as pd
 from aequilibrae import logger
@@ -96,7 +96,7 @@ class AssignmentPaths(object):
             )
         return compressed_graph_correspondences
 
-    def read_path_file(self, origin: int, iteration: int, traffic_class_id: str) -> (pd.DataFrame, pd.DataFrame):
+    def read_path_file(self, origin: int, iteration: int, traffic_class_id: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
         # TODO: make file ending and read method type dependent, info now stored in assignment results table
         possible_traffic_classes = list(filter(lambda x: x.__id__ == traffic_class_id, self.classes))
         assert (
@@ -112,13 +112,17 @@ class AssignmentPaths(object):
         path_o_index = pd.read_feather(path_o_index_f)
         return path_o, path_o_index
 
-    def get_path_for_destination(self, origin: int, destination: int, iteration: int, traffic_class_id: str):
+    def get_path_for_destination(
+        self, origin: int, destination: int, iteration: int, traffic_class_id: str
+    ) -> np.array:
         """ Return all link ids, i.e. the full path, for a given destination"""
         path_o, path_o_index = self.read_path_file(origin, iteration, traffic_class_id)
         return self.get_path_for_destination_from_files(path_o, path_o_index, destination)
 
     @staticmethod
-    def get_path_for_destination_from_files(path_o: pd.DataFrame, path_o_index: pd.DataFrame, destination: int):
+    def get_path_for_destination_from_files(
+        path_o: pd.DataFrame, path_o_index: pd.DataFrame, destination: int
+    ) -> np.array:
         """ for a given path file and path index file, and a given destination, return the path links in o-d order"""
         if destination == 0:
             lower_incl = 0

--- a/aequilibrae/paths/assignment_paths.py
+++ b/aequilibrae/paths/assignment_paths.py
@@ -20,12 +20,18 @@ from aequilibrae.project.database_connection import database_connection
 
 
 class TrafficClassIdentifier(object):
+    """"Minimal wrapper to replace full traffic class."""
+
     def __init__(self, network_mode: str, identifier: str):
         self.mode = network_mode
         self.__id__ = identifier
 
 
 class AssignmentResultsTable(object):
+    """ Traffic assignment results from project database.
+       table_name (str): Name of assignment result table.
+    """
+
     def __init__(self, table_name: str) -> None:
         self.proj_dir = os.environ.get(ENVIRON_VAR)
         self.table_name = table_name
@@ -86,9 +92,9 @@ class AssignmentPaths(object):
         self.assignment_results = AssignmentResultsTable(table_name)
         self.path_base_dir = os.path.join(self.proj_dir, "path_files", self.assignment_results.procedure_id)
         self.classes = self.assignment_results.get_traffic_class_names_and_id()
-        self.compressed_graph_correspondences = self._read_compressed_graph_correspondence()
+        self.compressed_graph_correspondences = self.__read_compressed_graph_correspondence()
 
-    def _read_compressed_graph_correspondence(self) -> Dict:
+    def __read_compressed_graph_correspondence(self) -> Dict:
         compressed_graph_correspondences = {}
         for c in self.classes:
             compressed_graph_correspondences[c.__id__] = pd.read_feather(

--- a/aequilibrae/paths/assignment_paths.py
+++ b/aequilibrae/paths/assignment_paths.py
@@ -102,7 +102,7 @@ class AssignmentPaths(object):
             )
         return compressed_graph_correspondences
 
-    def read_path_file(self, origin: int, iteration: int, traffic_class_id: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    def get_path_file_names(self, origin: int, iteration: int, traffic_class_id: str) -> (str, str):
         # TODO: make file ending and read method type dependent, info now stored in assignment results table
         possible_traffic_classes = list(filter(lambda x: x.__id__ == traffic_class_id, self.classes))
         assert (
@@ -114,6 +114,11 @@ class AssignmentPaths(object):
         )
         path_o_f = os.path.join(base_dir, f"o{origin}.feather")
         path_o_index_f = os.path.join(base_dir, f"o{origin}_indexdata.feather")
+        return path_o_f, path_o_index_f
+
+    def read_path_file(self, origin: int, iteration: int, traffic_class_id: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        # TODO: make file ending and read method type dependent, info now stored in assignment results table
+        path_o_f, path_o_index_f = self.get_path_file_names(origin, iteration, traffic_class_id)
         path_o = pd.read_feather(path_o_f)
         path_o_index = pd.read_feather(path_o_index_f)
         return path_o, path_o_index

--- a/aequilibrae/paths/assignment_paths.py
+++ b/aequilibrae/paths/assignment_paths.py
@@ -10,12 +10,13 @@ from aequilibrae.project.database_connection import database_connection
 # TODO: let's make it optional to keep path files in memory, although this can get out of control very quickly it should
 # be much quicker when working with a single origin
 
-# TODO: factor out AssignmentResultsTable into different file, also get rid of dirty eval bu changing creation
+# TODO: factor out AssignmentResultsTable into different file, also get rid of dirty eval by changing creation
 
 # FIXME: this is for zone_index and compressed link ids
 # for link ids, look up what we are doing in graph - we might want to keep the order of links for a single compressed
 # link
-# for zones, we need to do the inverse of graph.compact_nodes_to_indices
+# for zones, we need to do the inverse of graph.compact_nodes_to_indices -> implemented now, but let's just use it
+# when retrieving paths for an o and d
 
 
 class TrafficClassIdentifier(object):
@@ -56,6 +57,15 @@ class AssignmentResultsTable(object):
     def get_traffic_class_names_and_id(self) -> List[TrafficClassIdentifier]:
         all_classes = self.procedure_report["setup"]["Classes"]
         return [TrafficClassIdentifier(k, v["network mode"]) for k, v in all_classes.items()]
+
+    def get_number_of_iterations(self):
+        return np.max(self.procedure_report["convergence"]["iteration"])
+
+    def get_assignment_method(self):
+        return self.procedure_report["setup"]["Algorithm"]
+
+    def get_alphas(self):
+        return self.procedure_report["convergence"]["alpha"]
 
 
 class AssignmentPaths(object):

--- a/aequilibrae/paths/assignment_paths.py
+++ b/aequilibrae/paths/assignment_paths.py
@@ -92,7 +92,7 @@ class AssignmentPaths(object):
         compressed_graph_correspondences = {}
         for c in self.classes:
             compressed_graph_correspondences[c.__id__] = pd.read_feather(
-                os.path.join(self.path_base_dir, f"correspondence_c{c.__id__}_{c.mode}.feather")
+                os.path.join(self.path_base_dir, f"correspondence_c{c.mode}_{c.__id__}.feather")
             )
         return compressed_graph_correspondences
 
@@ -104,7 +104,7 @@ class AssignmentPaths(object):
         ), f"traffic class id not unique, please choose one of {list(map(lambda x: x.__id__, self.classes))}"
         traffic_class = possible_traffic_classes[0]
         base_dir = os.path.join(
-            self.path_base_dir, f"iter{iteration}", f"path_c{traffic_class.__id__}_{traffic_class.mode}"
+            self.path_base_dir, f"iter{iteration}", f"path_c{traffic_class.mode}_{traffic_class.__id__}"
         )
         path_o_f = os.path.join(base_dir, f"o{origin}.feather")
         path_o_index_f = os.path.join(base_dir, f"o{origin}_indexdata.feather")

--- a/aequilibrae/paths/basic_path_finding.pyx
+++ b/aequilibrae/paths/basic_path_finding.pyx
@@ -36,9 +36,9 @@ cpdef void network_loading(long classes,
                            long long [:] pred,
                            long long [:] conn,
                            double[:, :] link_loads,
-                           long long [:] no_path,
                            long long [:] reached_first,
                            double [:, :] node_load,
+                           double [:] not_assigned,
                            long found) nogil:
 
     cdef long long i, j, predecessor, connector, node
@@ -66,6 +66,8 @@ cpdef void network_loading(long classes,
         for i in range(zones):
             if not isnan(demand[i, j]):
                 node_load[i, j] = demand[i, j]
+                if pred[i] == -1:
+                    not_assigned[j] += demand[i, j]
 
     #Recursively cascades to the origin
     for i in range(found, 0, -1):

--- a/aequilibrae/paths/results/assignment_results.py
+++ b/aequilibrae/paths/results/assignment_results.py
@@ -29,8 +29,8 @@ class AssignmentResults:
         self.link_loads = np.array([])  # The actual results for assignment
         self.total_link_loads = np.array([])  # The result of the assignment for all user classes summed
         self.crosswalk = np.array([])  # crosswalk between compact graph link IDs and actual link IDs
+        self.not_assigned = np.array([])  # Array of not-assigned demand for all of the user classes
         self.skims = AequilibraeMatrix()  # The array of skims
-        self.no_path = None  # The list os paths
         self.num_skims = 0  # number of skims that will be computed. Depends on the setting of the graph provided
         p = Parameters().parameters["system"]["cpus"]
         if not isinstance(p, int):
@@ -72,12 +72,13 @@ class AssignmentResults:
         self.__integer_type = graph.default_types("int")
 
         if matrix.view_names is None:
-            raise ("Please set the matrix_procedures computational view")
-        else:
-            self.classes["number"] = 1
-            if len(matrix.matrix_view.shape) > 2:
-                self.classes["number"] = matrix.matrix_view.shape[2]
-            self.classes["names"] = matrix.view_names
+            raise Exception("Please set the matrix_procedures computational view")
+
+        self.classes["number"] = 1
+        if len(matrix.matrix_view.shape) > 2:
+            self.classes["number"] = matrix.matrix_view.shape[2]
+        self.classes["names"] = matrix.view_names
+        self.not_assigned = np.zeros(self.classes["number"])
 
         if graph is None:
             raise ("Please provide a graph")
@@ -107,11 +108,11 @@ class AssignmentResults:
         if self.num_skims > 0:
             self.skims.matrices.fill(0)
         if self.link_loads is not None:
-            self.no_path.fill(0)
             self.link_loads.fill(0)
             self.total_link_loads.fill(0)
             self.compact_link_loads.fill(0)
             self.compact_total_link_loads.fill(0)
+            self.not_assigned.fill(0)
         else:
             raise ValueError("Exception: Assignment results object was not yet prepared/initialized")
 
@@ -121,7 +122,6 @@ class AssignmentResults:
 
         self.link_loads = np.zeros((self.links, self.classes["number"]), self.__float_type)
         self.total_link_loads = np.zeros(self.links, self.__float_type)
-        self.no_path = np.zeros((self.zones, self.zones), dtype=self.__integer_type)
 
         if self.num_skims > 0:
             self.skims = AequilibraeMatrix()

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -145,6 +145,9 @@ class SelectLink(object):
                 # logger.info(f" Procesing class {class_id}")
                 comp_link_ids = link_ids_simplified[class_id]
                 for origin in range(self.num_zones):
+                    # skip zero-demand origins
+                    if np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
+                        continue
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
                     # drop disconnected zones (and intrazonal). Depends on index being ordered.
                     path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -149,10 +149,9 @@ class SelectLink(object):
                         logger.info(f" Procesing origin {origin}")
                     # skip zero-demand origins
                     # TODO (Jan 13/6/21): this mess has to be cleaned up at some point, why do we have 2d matrices?
-                    if (len(self.demand_matrices[class_id].matrix_view.shape) == 2) and (
-                        not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :])
-                    ):
-                        continue
+                    if len(self.demand_matrices[class_id].matrix_view.shape) == 2:
+                        if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :]):
+                            continue
                     elif not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
                         continue
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
@@ -171,6 +170,7 @@ class SelectLink(object):
                         )
                         destinations_this_o_and_iter = destinations_this_o_and_iter.astype(int)
 
+                        # TODO (Jan 13/6/21): this mess has to be cleaned up at some point, why do we have 2d matrices?
                         if destinations_this_o_and_iter.shape[0] > 0:
                             # check shape
                             if len(self.demand_matrices[class_id].matrix_view.shape) == 2:

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -23,7 +23,7 @@ class SelectLink(object):
         name = 'assignment_results_table_name"
         sl = SelectLink(name, matrices)
         link_ids_for_sl = [111]
-        sl.run_select_link_analysis(link_id_for_sl)
+        select_link_matrix = sl.run_select_link_analysis(link_id_for_sl)
     """
 
     def __init__(self, table_name: str, demand_matrices: Dict) -> None:

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -146,7 +146,7 @@ class SelectLink(object):
                 comp_link_ids = link_ids_simplified[class_id]
                 for origin in range(self.num_zones):
                     # skip zero-demand origins
-                    if np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
+                    if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
                         continue
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
                     # drop disconnected zones (and intrazonal). Depends on index being ordered.

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -149,12 +149,12 @@ class SelectLink(object):
                         logger.info(f" Procesing origin {origin}")
                     # skip zero-demand origins
                     # TODO (Jan 13/6/21): this mess has to be cleaned up at some point, why do we have 2d matrices?
-                    if len(self.demand_matrices[class_id].matrix_view.shape) == 2:
-                        if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :]):
-                            continue
-                    else:
-                        if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
-                            continue
+                    if (len(self.demand_matrices[class_id].matrix_view.shape) == 2) and (
+                        not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :])
+                    ):
+                        continue
+                    elif not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
+                        continue
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
                     # drop disconnected zones (and intrazonal). Depends on index being ordered.
                     path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -1,0 +1,148 @@
+import os
+from collections import defaultdict
+from typing import Dict
+import numpy as np
+import pandas as pd
+
+from aequilibrae.paths.assignment_paths import AssignmentPaths, TrafficClassIdentifier
+from aequilibrae import logger
+
+
+class SelectLink(object):
+    """ Class for select link analysis. Depends on traffic assignment results with path files saved to disk.
+    ::
+        from aequilibrae.paths import SelectLink
+        matrices = {class_id: matrix}
+        name = 'assignment_results_table_name"
+        sl = SelectLink(name, matrices)
+        link_ids_for_sl = [111]
+        sl.run_select_link_analysis(link_id_for_sl)
+    """
+
+    def __init__(self, table_name: str, demand_matrices: Dict) -> None:
+        """
+        Instantiates the class
+         Args:
+            table_name (str): Name of the traffic assignment result table used to generate the required path files
+            demand_matrices (dict): Dict with assignment class id and corresponding demand matrix
+        """
+        self.table_name = table_name
+        self.select_link_id = None
+        self.assignment_results = None
+
+        self.paths = AssignmentPaths(self.table_name)
+        self.num_iters = self.paths.assignment_results.get_number_of_iterations()
+
+        # TODO: assert class ids and matrix keys are identical in the following
+        self.classes = self.paths.get_traffic_class_names_and_id()
+        self.demand_matrices = demand_matrices
+
+        self.select_link_matrices = {}
+        self._initialise_matrices()
+
+        # get weight of each iteration to weight corresponding demand.
+        # FIXME (Jan 21/4/21): this is MSA and FW only atm, needs to be implemented for CFW and BFW
+        self.demand_weights = None
+        self._calculate_demand_weights()
+
+    def _initialise_matrices(self) -> None:
+        for c in self.classes:
+            self.select_link_matrices[c.id] = np.zeros_like(self.demand_matrices[c.id].matrix_view)
+
+    def _calculate_demand_weights(self):
+        """Each iteration of traffic assignment contributes a certain fraction to the total solutions. This method
+        figures out how much so we can calculate select link matrices by weighting paths per iteration."""
+
+        assignment_method = self.paths.assignment_results.get_assignment_method()
+
+        if assignment_method == "msa":
+            self.demand_weights = np.repeat(1.0 / self.num_iters, self.num_iters)
+        elif assignment_method in ["fw", "cfw", "bfw", "frank-wolfe"]:
+            self._figure_out_demand_weights_for_linear_approximation()
+        else:
+            raise ValueError(
+                f"Asignment method {assignment_method} cannot be used for select link analysis at the moment."
+            )
+
+        sum_of_contribs = np.sum(self.demand_weights)
+        assert np.allclose(sum_of_contribs, 1.0), f"Contribution of iterations is not one, but {sum_of_contribs}"
+
+    def _figure_out_demand_weights_for_linear_approximation(self):
+        """ Linear approximation contribution for each iteration. """
+
+        # solution^n+1 = alpha^n * sol^n + (1-alpha^n) * direction^n
+        # direction = beta_0 * aon + beta_1 * previous_direction + beta_2 * pre_previous_direction
+        alphas = self.paths.assignment_results.get_alphas()
+        print(alphas)
+        # betas_0 = assignment_report["convergence"]["beta0"]
+        # betas_1 = assignment_report["convergence"]["beta1"]
+        # betas_2 = assignment_report["convergence"]["beta2"]
+
+        self.demand_weights = np.repeat(1.0, self.num_iters)
+
+        # FIXME (Jan 21/4/21): implement CFW and BFW, this is only valid for FW
+        # can we just multiply previous like below?
+        # if assignment_report["setup"]["Algorithm"] in ["fw", "frank-wolfe"]:
+        for i in range(0, self.num_iters):
+            alpha = alphas[i]
+            # beta_0 = betas_0[i]
+            # beta_1 = betas_1[i]
+            # beta_2 = betas_2[i]
+            # demand_weights[i] += alpha * direction + (1.0 - alpha) * current
+            # for FW: direction = AON, so multiply current weight
+            # for CFW: direction = beta_0 * AON + beta_1 * previous_direction
+            # for BFW: direction = beta_0 * AON + beta_1 * previous_direction + beta_2 * pre_previous_direction
+            self.demand_weights[i] *= alpha
+            self.demand_weights[:i] *= 1.0 - alpha
+
+            # if (assignment_report["setup"]["Algorithm"] in ["cfw", "bfw"]) and (i > 1):
+            #     self.demand_weights[i] *= beta_0
+            #     self.demand_weights[:(i - 1)] *= beta_1
+            #
+            # if (assignment_report["setup"]["Algorithm"] == "bfw") and (i > 2):
+            #     self.demand_weights[:(i-2)] *= beta_2
+
+    # FIXME: pass in a list of links
+    def run_select_link_analysis(self, link_id: int) -> None:
+        assert len(self.classes) > 0, "Need at least one traffic class to run select link analysis, use set_classes"
+
+        # FIXME
+        self.select_link_id = link_id
+        # look up compressed id for each class. Should be the same.
+        for c in self.classes:
+            graph = self.compressed_graph_correspondences[c.__id__]
+            self.select_link_id_compressed[c.__id__] = graph.loc[graph["link_id"] == self.select_link_id][
+                "__compressed_id__"
+            ].values[0]
+        # end FIXME
+
+        # now process each iteration.
+        num_centroids = self.classes[0].matrix.zones  # FIXME no TrafficClasses anymore
+
+        for iteration in range(self.num_iters):
+            logger.info(f"Procesing iteration {iteration} for select link analysis")
+            weight = self.demand_weights[iteration]
+            for c in self.classes:
+                comp_link_id = self.select_link_id_compressed[c.id]
+                demand_mat = c.matrix.matrix_view
+
+                for origin in range(num_centroids):
+                    path_o, path_o_index = self._read_path_file(iteration, c, origin)
+
+                    # these are the indeces of the path file where the SL appears, so need to turn these into
+                    # destinations by looking up the values in the path file
+                    idx_to_look_up = path_o.loc[path_o.data == comp_link_id].index.values
+
+                    # drop disconnected zones (and intrazonal). Depends on index being ordered.
+                    path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
+                    destinations_this_o_and_iter = np.array(
+                        [
+                            path_o_index_no_zeros.loc[path_o_index_no_zeros["data"] >= x].index.min()
+                            for x in idx_to_look_up
+                        ]
+                    )
+                    destinations_this_o_and_iter = destinations_this_o_and_iter.astype(int)
+
+                    self.matrices[c.__id__][origin, destinations_this_o_and_iter] += (
+                        weight * demand_mat[origin, destinations_this_o_and_iter]
+                    )

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -26,16 +26,19 @@ class SelectLink(object):
             table_name (str): Name of the traffic assignment result table used to generate the required path files
             demand_matrices (dict): Dict with assignment class id and corresponding demand matrix
         """
-        self.table_name = table_name
-        self.paths = AssignmentPaths(self.table_name)
+        self.paths = AssignmentPaths(table_name)
         self.num_iters = self.paths.assignment_results.get_number_of_iterations()
-        # TODO: assert class ids and matrix keys are identical in the following
-        self.classes = self.paths.get_traffic_class_names_and_id()
+
+        # TODO:
+        #  assert class ids and matrix keys are identical in the following
+        #  assert sum of demand matrix is equal to result in assignment results for each class
+        self.classes = self.paths.assignment_results.get_traffic_class_names_and_id()
         self.demand_matrices = demand_matrices
-        self.num_zones = demand_matrices.values[0].zones  # TODO: is this the way to go?
+        self.num_zones = list(self.demand_matrices.values())[0].matrix_view.shape[0]  # TODO: is this the way to go?
+
         # get weight of each iteration to weight corresponding demand.
-        # FIXME (Jan 21/4/21): this is MSA and FW only atm, needs to be implemented for CFW and BFW
         self.demand_weights = None
+        # FIXME (Jan 21/4/21): this is MSA and FW only atm, needs to be implemented for CFW and BFW
         self._calculate_demand_weights()
 
     def _calculate_demand_weights(self):

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -95,14 +95,16 @@ class SelectLink(object):
             #     self.demand_weights[:(i-2)] *= beta_2
 
     def __lookup_compressed_links_for_link(self, link_ids: List[int]) -> List[int]:
-        """" look up compressed ids for each class for a given list of network link ids"""
-        select_link_ids_compressed = {}
-        for c in self.classes:
-            graph = self.paths.compressed_graph_correspondences[c.__id__]
-            select_link_ids_compressed[c.__id__] = graph.loc[graph["link_id"].isin(link_ids)][
-                "__compressed_id__"
-            ].to_numpy()
-        return select_link_ids_compressed
+        """" TODO: look up compressed ids for each class for a given list of network link ids"""
+        # FIXME: for now just pass in simplified ids directly
+        # select_link_ids_compressed = {}
+        # for c in self.classes:
+        #     graph = self.paths.compressed_graph_correspondences[c.__id__]
+        #     select_link_ids_compressed[c.__id__] = graph.loc[graph["link_id"].isin(link_ids)][
+        #         "__compressed_id__"
+        #     ].to_numpy()
+        # return select_link_ids_compressed
+        return link_ids
 
     def __initialise_matrices(self, simplified_link_ids: List[int]) -> Dict[str, Dict[int, np.array]]:
         """ For each class and each link, initialise select link demand matrix"""
@@ -122,7 +124,7 @@ class SelectLink(object):
         link_ids_simplified = self.__lookup_compressed_links_for_link(link_ids)
         select_link_matrices = self.__initialise_matrices(link_ids_simplified)
 
-        for iteration in range(self.num_iters):
+        for iteration in range(1, self.num_iters + 1):
             logger.info(f"Procesing iteration {iteration} for select link analysis")
             weight = self.demand_weights[iteration]
             for c in self.classes:

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -140,13 +140,13 @@ class SelectLink(object):
                 comp_link_ids = link_ids_simplified[class_id]
                 for origin in range(self.num_zones):
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
+                    # drop disconnected zones (and intrazonal). Depends on index being ordered.
+                    path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
+
                     for comp_link_id in comp_link_ids:
                         # these are the indexes of the path file where the SLs appear, so need to turn these into
                         # destinations by looking up the values in the path file
                         idx_to_look_up = path_o.loc[path_o.data == comp_link_id].index.to_numpy()
-
-                        # drop disconnected zones (and intrazonal). Depends on index being ordered.
-                        path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
                         destinations_this_o_and_iter = np.array(
                             [
                                 path_o_index_no_zeros.loc[path_o_index_no_zeros["data"] > x].index.min()

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -8,6 +8,13 @@ from aequilibrae.paths.assignment_paths import AssignmentPaths, TrafficClassIden
 from aequilibrae import logger
 
 
+# TODO:
+#  - implement per-iteration contribution for CFW and BFW
+#  - some assertions as per constructor comments
+#  - demand matrix operations do not take cores into account (i.e. we assume we have a 2d demand matrix per class)
+#  - tests
+
+
 class SelectLink(object):
     """ Class for select link analysis. Depends on traffic assignment results with path files saved to disk.
     ::
@@ -142,14 +149,16 @@ class SelectLink(object):
                         path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
                         destinations_this_o_and_iter = np.array(
                             [
-                                path_o_index_no_zeros.loc[path_o_index_no_zeros["data"] >= x].index.min()
+                                path_o_index_no_zeros.loc[path_o_index_no_zeros["data"] > x].index.min()
                                 for x in idx_to_look_up
                             ]
                         )
                         destinations_this_o_and_iter = destinations_this_o_and_iter.astype(int)
 
-                        select_link_matrices[class_id][comp_link_id][origin, destinations_this_o_and_iter] += (
-                            weight * self.demand_matrices[class_id].matrix_view[origin, destinations_this_o_and_iter]
-                        )
+                        if destinations_this_o_and_iter.shape[0] > 0:
+                            select_link_matrices[class_id][comp_link_id][origin, destinations_this_o_and_iter] += (
+                                weight
+                                * self.demand_matrices[class_id].matrix_view[origin, destinations_this_o_and_iter]
+                            )
 
         return select_link_matrices

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -99,7 +99,7 @@ class SelectLink(object):
         select_link_ids_compressed = {}
         for c in self.classes:
             graph = self.paths.compressed_graph_correspondences[c.__id__]
-            select_link_ids_compressed[c.id] = graph.loc[graph["link_id"].isin(link_ids)][
+            select_link_ids_compressed[c.__id__] = graph.loc[graph["link_id"].isin(link_ids)][
                 "__compressed_id__"
             ].to_numpy()
         return select_link_ids_compressed

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -48,7 +48,7 @@ class SelectLink(object):
         # FIXME (Jan 21/4/21): this is MSA and FW only atm, needs to be implemented for CFW and BFW
         self._calculate_demand_weights()
 
-    def _calculate_demand_weights(self):
+    def _calculate_demand_weights(self) -> None:
         """Each iteration of traffic assignment contributes a certain fraction to the total solutions. This method
         figures out how much so we can calculate select link matrices by weighting paths per iteration."""
 
@@ -66,7 +66,7 @@ class SelectLink(object):
         sum_of_contribs = np.sum(self.demand_weights)
         assert np.allclose(sum_of_contribs, 1.0), f"Contribution of iterations is not one, but {sum_of_contribs}"
 
-    def _figure_out_demand_weights_for_linear_approximation(self):
+    def _figure_out_demand_weights_for_linear_approximation(self) -> None:
         """ Linear approximation contribution for each iteration. """
 
         # solution^n+1 = alpha^n * sol^n + (1-alpha^n) * direction^n
@@ -122,7 +122,7 @@ class SelectLink(object):
         }
         return select_link_matrices
 
-    def run_select_link_analysis(self, link_ids: List[int]) -> None:
+    def run_select_link_analysis(self, link_ids: List[int]) -> Dict[str, Dict[int, np.array]]:
         """" Select link analysis for a provided set of links. Processing is done per iteration, class, and origin.
          Providing a list of links means we only need to read each path file once from disk. Note that link ids refer
          to the network ids, these are then turned into simplified ids; this means a bi-directional link will have two

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -97,21 +97,21 @@ class SelectLink(object):
     def __lookup_compressed_links_for_link(self, link_ids: List[int]) -> List[int]:
         """" TODO: look up compressed ids for each class for a given list of network link ids"""
         # FIXME: for now just pass in simplified ids directly
-        # select_link_ids_compressed = {}
-        # for c in self.classes:
+        select_link_ids_compressed = {}
+        for c in self.classes:
+            select_link_ids_compressed[c.__id__] = link_ids
         #     graph = self.paths.compressed_graph_correspondences[c.__id__]
         #     select_link_ids_compressed[c.__id__] = graph.loc[graph["link_id"].isin(link_ids)][
         #         "__compressed_id__"
         #     ].to_numpy()
-        # return select_link_ids_compressed
-        return link_ids
+        return select_link_ids_compressed
 
     def __initialise_matrices(self, simplified_link_ids: List[int]) -> Dict[str, Dict[int, np.array]]:
         """ For each class and each link, initialise select link demand matrix"""
         select_link_matrices = {
             c.__id__: {link_id: np.zeros_like(self.demand_matrices[c.__id__].matrix_view)}
             for c in self.classes
-            for link_id in simplified_link_ids
+            for link_id in simplified_link_ids[c.__id__]
         }
         return select_link_matrices
 
@@ -126,7 +126,7 @@ class SelectLink(object):
 
         for iteration in range(1, self.num_iters + 1):
             logger.info(f"Procesing iteration {iteration} for select link analysis")
-            weight = self.demand_weights[iteration]
+            weight = self.demand_weights[iteration - 1]  # zero based
             for c in self.classes:
                 class_id = c.__id__
                 logger.info(f"  Procesing class {class_id}")
@@ -149,7 +149,7 @@ class SelectLink(object):
                         destinations_this_o_and_iter = destinations_this_o_and_iter.astype(int)
 
                         select_link_matrices[class_id][comp_link_id][origin, destinations_this_o_and_iter] += (
-                            weight * self.demand_matrices[class_id][origin, destinations_this_o_and_iter]
+                            weight * self.demand_matrices[class_id].matrix_view[origin, destinations_this_o_and_iter]
                         )
 
         return select_link_matrices

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -155,18 +155,16 @@ class SelectLink(object):
                     elif not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
                         continue
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
+
                     # drop disconnected zones (and intrazonal). Depends on index being ordered.
-                    path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
+                    # path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
 
                     for comp_link_id in comp_link_ids:
                         # these are the indexes of the path file where the SLs appear, so need to turn these into
                         # destinations by looking up the values in the path file
                         idx_to_look_up = path_o.loc[path_o.data == comp_link_id].index.to_numpy()
                         destinations_this_o_and_iter = np.array(
-                            [
-                                path_o_index_no_zeros.loc[path_o_index_no_zeros["data"] > x].index.min()
-                                for x in idx_to_look_up
-                            ]
+                            [path_o_index.loc[path_o_index["data"] > x].index.min() for x in idx_to_look_up]
                         )
                         destinations_this_o_and_iter = destinations_this_o_and_iter.astype(int)
 
@@ -187,5 +185,5 @@ class SelectLink(object):
                                         origin, destinations_this_o_and_iter, :
                                     ]
                                 )
-        logger.info(f"Select link analysis for links {link_ids} finished.")
+        # logger.info(f"Select link analysis for links {link_ids} finished.")
         return select_link_matrices

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -101,7 +101,7 @@ class SelectLink(object):
             ].to_numpy()
         return select_link_ids_compressed
 
-    def __initialise_matrices(self, simplified_link_ids: List[int]) -> Dict[Dict[np.array]]:
+    def __initialise_matrices(self, simplified_link_ids: List[int]) -> Dict[str, Dict[int, np.array]]:
         """ For each class and each link, initialise select link demand matrix"""
         select_link_matrices = {
             c.id: {link_id: np.zeros_like(self.demand_matrices[c.id].matrix_view)}

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -98,7 +98,7 @@ class SelectLink(object):
         """" look up compressed ids for each class for a given list of network link ids"""
         select_link_ids_compressed = {}
         for c in self.classes:
-            graph = self.paths.assignment_results.compressed_graph_correspondences[c.id]
+            graph = self.paths.compressed_graph_correspondences[c.__id__]
             select_link_ids_compressed[c.id] = graph.loc[graph["link_id"].isin(link_ids)][
                 "__compressed_id__"
             ].to_numpy()
@@ -107,7 +107,7 @@ class SelectLink(object):
     def __initialise_matrices(self, simplified_link_ids: List[int]) -> Dict[str, Dict[int, np.array]]:
         """ For each class and each link, initialise select link demand matrix"""
         select_link_matrices = {
-            c.id: {link_id: np.zeros_like(self.demand_matrices[c.id].matrix_view)}
+            c.__id__: {link_id: np.zeros_like(self.demand_matrices[c.__id__].matrix_view)}
             for c in self.classes
             for link_id in simplified_link_ids
         }
@@ -120,13 +120,13 @@ class SelectLink(object):
          associated simplified link ids"""
         assert len(set(link_ids)) == len(link_ids), "Please provide a unique list of link ids"
         link_ids_simplified = self.__lookup_compressed_links_for_link(link_ids)
-        select_link_matrices = self._initialise_matrices(link_ids_simplified)
+        select_link_matrices = self.__initialise_matrices(link_ids_simplified)
 
         for iteration in range(self.num_iters):
             logger.info(f"Procesing iteration {iteration} for select link analysis")
             weight = self.demand_weights[iteration]
             for c in self.classes:
-                class_id = c.id
+                class_id = c.__id__
                 logger.info(f"  Procesing class {class_id}")
                 comp_link_ids = link_ids_simplified[class_id]
                 for origin in range(self.num_zones):

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -136,7 +136,7 @@ class SelectLink(object):
             weight = self.demand_weights[iteration - 1]  # zero based
             for c in self.classes:
                 class_id = c.__id__
-                logger.info(f"  Procesing class {class_id}")
+                # logger.info(f" Procesing class {class_id}")
                 comp_link_ids = link_ids_simplified[class_id]
                 for origin in range(self.num_zones):
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
@@ -160,5 +160,5 @@ class SelectLink(object):
                                 weight
                                 * self.demand_matrices[class_id].matrix_view[origin, destinations_this_o_and_iter]
                             )
-
+        logger.info(f"Select link analysis for links {link_ids} finished.")
         return select_link_matrices

--- a/aequilibrae/paths/select_link.py
+++ b/aequilibrae/paths/select_link.py
@@ -142,12 +142,19 @@ class SelectLink(object):
             weight = self.demand_weights[iteration - 1]  # zero based
             for c in self.classes:
                 class_id = c.__id__
-                # logger.info(f" Procesing class {class_id}")
+                logger.info(f" Procesing class {class_id}")
                 comp_link_ids = link_ids_simplified[class_id]
                 for origin in range(self.num_zones):
+                    if origin % 100 == 0:
+                        logger.info(f" Procesing origin {origin}")
                     # skip zero-demand origins
-                    if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
-                        continue
+                    # TODO (Jan 13/6/21): this mess has to be cleaned up at some point, why do we have 2d matrices?
+                    if len(self.demand_matrices[class_id].matrix_view.shape) == 2:
+                        if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :]):
+                            continue
+                    else:
+                        if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
+                            continue
                     path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
                     # drop disconnected zones (and intrazonal). Depends on index being ordered.
                     path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")

--- a/aequilibrae/paths/select_link.pyx
+++ b/aequilibrae/paths/select_link.pyx
@@ -1,0 +1,55 @@
+# distutils: language = c++
+
+from libcpp.vector cimport vector
+from cython.operator cimport dereference as deref
+from cython.parallel import prange
+
+import pyarrow as pa
+cimport pyarrow as pa
+
+import pyarrow.parquet as pq
+import pyarrow.feather as feather
+
+import numpy as np
+cimport numpy as np
+np.import_array()
+
+@cython.wraparound(False)
+@cython.embedsignature(True)
+@cython.boundscheck(False) # turn of bounds-checking for entire function
+cpdef void select_link_for_origin_cython(
+                                  long long link_id,
+                                  long long origin_index,
+                                  long long [:] path_links,
+                                  long long path_links_size,
+                                  long long [:] path_index,
+                                  long long path_index_size,
+                                  double [:] demand,
+                                  double weight,
+                                  double [:] select_link,
+                                  ) nogil:
+
+    cdef long long i, min_dest, dest_val, val, j
+    cdef vector[long long] path_index_to_look_up
+    cdef vector[long long] dest_this_o
+
+    for i in range(path_links_size):
+        if path_links[i] == link_id:
+            path_index_to_look_up.push_back(i)
+
+    for i in range(path_index_to_look_up.size()):
+        dest_val = path_index_to_look_up[i]
+        min_dest = -1
+        for j in range(path_index_size):
+            val = path_index[j]
+            if val > dest_val:
+                if min_dest < 0:
+                    min_dest = j
+                else:
+                    if min_dest > val:
+                        min_dest = j
+        if min_dest >= 0:
+            dest_this_o.push_back(min_dest)
+
+    for i in range(dest_this_o.size()):
+        select_link[dest_this_o[i]] += weight * demand[dest_this_o[i]]

--- a/aequilibrae/paths/select_link.pyx
+++ b/aequilibrae/paths/select_link.pyx
@@ -1,18 +1,6 @@
 # distutils: language = c++
 
 from libcpp.vector cimport vector
-from cython.operator cimport dereference as deref
-from cython.parallel import prange
-
-import pyarrow as pa
-cimport pyarrow as pa
-
-import pyarrow.parquet as pq
-import pyarrow.feather as feather
-
-import numpy as np
-cimport numpy as np
-np.import_array()
 
 @cython.wraparound(False)
 @cython.embedsignature(True)

--- a/aequilibrae/paths/select_link_parallel.py
+++ b/aequilibrae/paths/select_link_parallel.py
@@ -78,14 +78,9 @@ class SelectLinkParallel(object):
                     if origin % 100 == 0:
                         logger.info(f" Procesing origin {origin}")
                     # skip zero-demand origins
-                    # TODO (Jan 13/6/21): this mess has to be cleaned up at some point, why do we have 2d matrices?
-                    # if len(self.demand_matrices[class_id].matrix_view.shape) == 2:
                     if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :]):
                         continue
-                    # elif not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
-                    #     continue
                     sl_mat = select_link_matrices[class_id]
-                    # FROM HERE
                     path_o_f, path_o_index_f = self.paths.get_path_file_names(origin, iteration, class_id)
                     select_link_for_origin(
                         link_ids,
@@ -97,18 +92,5 @@ class SelectLinkParallel(object):
                         weight,
                         sl_mat,
                     )
-
-                    # path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
-                    # path_o = path_o.to_numpy().flatten()
-                    # path_o_index = path_o_index.to_numpy().flatten()
-                    # # # TODO JAN: why did I do this? was this from before I fixed the path file saving bug?
-                    # # # drop disconnected zones (and intrazonal). Depends on index being ordered.
-                    # # path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
-                    # dest_this_o_and_iter = np.array([np.argwhere(path_o_index > x).min() for x in np.argwhere(path_o == link_id).flatten()]).astype(int)
-                    # select_link_matrices[class_id][origin, dest_this_o_and_iter] += (
-                    #     weight
-                    #     * self.demand_matrices[class_id].matrix_view[origin, dest_this_o_and_iter]
-                    # )
-
         # logger.info(f"Select link analysis for links {link_id} finished.")
         return select_link_matrices

--- a/aequilibrae/paths/select_link_parallel.py
+++ b/aequilibrae/paths/select_link_parallel.py
@@ -1,0 +1,114 @@
+import multiprocessing as mp
+from typing import List, Dict
+import numpy as np
+
+from aequilibrae.paths.assignment_paths import AssignmentPaths
+from aequilibrae import logger
+
+try:
+    from aequilibrae.paths.AoN import select_link_for_origin
+except ImportError as ie:
+    logger.warning(f"Could not import procedures from the binary. {ie.args}")
+
+
+class SelectLinkParallel(object):
+    def __init__(self, table_name: str, demand_matrices: Dict) -> None:
+        """
+        Instantiates the class
+         Args:
+            table_name (str): Name of the traffic assignment result table used to generate the required path files
+            demand_matrices (dict): Dict with assignment class id and corresponding demand matrix
+        """
+        self.paths = AssignmentPaths(table_name)
+        self.num_iters = self.paths.assignment_results.get_number_of_iterations()
+        self.classes = self.paths.assignment_results.get_traffic_class_names_and_id()
+        self.demand_matrices = demand_matrices
+        self.num_zones = list(self.demand_matrices.values())[0].matrix_view.shape[0]  # TODO: is this the way to go?
+
+        # get weight of each iteration to weight corresponding demand.
+        self.demand_weights = None
+        # FIXME (Jan 21/4/21): this is MSA only atm, needs to be implemented for CFW and BFW
+        self._calculate_demand_weights()
+
+    def _calculate_demand_weights(self) -> None:
+        """Each iteration of traffic assignment contributes a certain fraction to the total solutions. This method
+        figures out how much so we can calculate select link matrices by weighting paths per iteration."""
+
+        assignment_method = self.paths.assignment_results.get_assignment_method()
+
+        if assignment_method == "msa":
+            self.demand_weights = np.repeat(1.0 / self.num_iters, self.num_iters)
+        else:
+            raise ValueError(
+                f"Asignment method {assignment_method} cannot be used for select link analysis at the moment."
+            )
+        sum_of_contribs = np.sum(self.demand_weights)
+        assert np.allclose(sum_of_contribs, 1.0), f"Contribution of iterations is not one, but {sum_of_contribs}"
+
+    def _initialise_matrices(self, num_links: int) -> Dict[str, np.array]:
+        """ For each class initialise a select link demand matrix"""
+        select_link_matrices = {
+            c.__id__: np.zeros_like(self.demand_matrices[c.__id__].matrix_view) for c in self.classes
+        }
+
+        for c in self.classes:
+            select_link_matrices[c.__id__] = np.repeat(
+                select_link_matrices[c.__id__][:, :, np.newaxis], num_links, axis=2
+            )
+
+        return select_link_matrices
+
+    def run_select_link_analysis(self, link_ids: List[int]) -> Dict[str, np.array]:
+        """" Select link analysis for a provided set of links. Processing is done per iteration, class, and origin.
+         Providing a list of links means we only need to read each path file once from disk. Note that link ids refer
+         to the network ids, these are then turned into simplified ids; this means a bi-directional link will have two
+         associated simplified link ids"""
+        assert len(set(link_ids)) == len(link_ids), "Please provide a unique list of link ids"
+        link_ids = np.array(link_ids)
+        num_links = len(link_ids)
+        select_link_matrices = self._initialise_matrices(num_links)
+
+        for iteration in range(1, self.num_iters + 1):
+            logger.info(f"Procesing iteration {iteration} for select link analysis")
+            weight = self.demand_weights[iteration - 1]  # zero based
+            for c in self.classes:
+                class_id = c.__id__
+                logger.info(f" Procesing class {class_id}")
+                for origin in range(self.num_zones):
+                    if origin % 100 == 0:
+                        logger.info(f" Procesing origin {origin}")
+                    # skip zero-demand origins
+                    # TODO (Jan 13/6/21): this mess has to be cleaned up at some point, why do we have 2d matrices?
+                    # if len(self.demand_matrices[class_id].matrix_view.shape) == 2:
+                    if not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :]):
+                        continue
+                    # elif not np.nansum(self.demand_matrices[class_id].matrix_view[origin, :, :]):
+                    #     continue
+                    sl_mat = select_link_matrices[class_id]
+                    # FROM HERE
+                    path_o_f, path_o_index_f = self.paths.get_path_file_names(origin, iteration, class_id)
+                    select_link_for_origin(
+                        link_ids,
+                        num_links,
+                        origin,
+                        path_o_f,
+                        path_o_index_f,
+                        self.demand_matrices[class_id],
+                        weight,
+                        sl_mat,
+                    )
+
+                    # path_o, path_o_index = self.paths.read_path_file(origin, iteration, class_id)
+                    # path_o = path_o.to_numpy().flatten()
+                    # path_o_index = path_o_index.to_numpy().flatten()
+                    # # # TODO JAN: why did I do this? was this from before I fixed the path file saving bug?
+                    # # # drop disconnected zones (and intrazonal). Depends on index being ordered.
+                    # # path_o_index_no_zeros = path_o_index.drop_duplicates(keep="first")
+                    # dest_this_o_and_iter = np.array([np.argwhere(path_o_index > x).min() for x in np.argwhere(path_o == link_id).flatten()]).astype(int)
+                    # select_link_matrices[class_id][origin, dest_this_o_and_iter] += (
+                    #     weight
+                    #     * self.demand_matrices[class_id].matrix_view[origin, dest_this_o_and_iter]
+                    # )
+
+        # logger.info(f"Select link analysis for links {link_id} finished.")
+        return select_link_matrices

--- a/tests/aequilibrae/paths/test_assignment_paths.py
+++ b/tests/aequilibrae/paths/test_assignment_paths.py
@@ -7,10 +7,9 @@ from tempfile import gettempdir
 from aequilibrae import TrafficAssignment, TrafficClass, Graph
 from aequilibrae.paths.assignment_paths import AssignmentPaths, AssignmentResultsTable, TrafficClassIdentifier
 from aequilibrae.utils.create_example import create_example
-from ...data import siouxfalls_project
 
 # TODO (Jan 13/6/21): Do we want to add a result table to the SiouxFalls project in tests/data? Or maybe in the
-#  reference project? This here depends on an assignment run, not ideal.
+#  reference project? This here depends on an assignment run.
 
 
 class TestAssignmentPaths(TestCase):

--- a/tests/aequilibrae/paths/test_assignment_paths.py
+++ b/tests/aequilibrae/paths/test_assignment_paths.py
@@ -1,0 +1,117 @@
+from unittest import TestCase
+import os
+import pathlib
+import sqlite3
+import pandas as pd
+import numpy as np
+import uuid
+import string
+import random
+from random import choice
+from tempfile import gettempdir
+from aequilibrae import TrafficAssignment, TrafficClass, Graph
+from aequilibrae.paths.assignment_paths import AssignmentPaths, AssignmentResultsTable, TrafficClassIdentifier
+from aequilibrae.utils.create_example import create_example
+from ...data import siouxfalls_project
+
+# TODO (Jan 13/6/21): Do we want to add a result table to the SiouxFalls project in tests/data? Or maybe in the
+#  reference project? This here depends on an assignment run, not ideal.
+
+
+class TestAssignmentPaths(TestCase):
+    def setUp(self) -> None:
+        os.environ["PATH"] = os.path.join(gettempdir(), "temp_data") + ";" + os.environ["PATH"]
+
+        proj_path = os.path.join(gettempdir(), "test_assignment_paths_" + uuid.uuid4().hex)
+        self.project = create_example(proj_path)
+        self.project.network.build_graphs()
+        self.network_mode = "c"
+        self.car_graph = self.project.network.graphs[self.network_mode]
+        self.car_graph.set_graph("free_flow_time")
+        self.car_graph.set_blocked_centroid_flows(False)
+        self.matrix = self.project.matrices.get_matrix("demand_omx")
+        self.matrix.computational_view()
+
+        self.assignment = TrafficAssignment()
+        self.traffic_class_name = "car"
+        self.assigclass = TrafficClass(self.traffic_class_name, self.car_graph, self.matrix)
+        self.assignment.add_class(self.assigclass)
+        self.assignment.set_save_path_files(True)
+        self.assignment.set_vdf("BPR")
+        self.assignment.set_vdf_parameters({"alpha": 0.15, "beta": 4.0})
+        self.assignment.set_vdf_parameters({"alpha": "b", "beta": "power"})
+        self.assignment.set_capacity_field("capacity")
+        self.assignment.set_time_field("free_flow_time")
+        self.assignment.max_iter = 1
+        self.assignment.set_algorithm("msa")
+        self.assignment.execute()
+        self.result_name = "ass_path_test"
+        self.assignment.save_results(self.result_name)
+        # pathlib.Path(self.project.project_base_path)
+
+    def tearDown(self) -> None:
+        self.matrix.close()
+        self.project.close()
+
+    def test_assignment_results_table(self):
+        ass_res_table = AssignmentResultsTable(self.result_name)
+
+        self.assertEqual(ass_res_table.table_name, self.result_name)
+        self.assertEqual(ass_res_table.procedure, "traffic assignment")
+        self.assertIsInstance(ass_res_table.assignment_results, pd.DataFrame)
+
+        traffic_class_id_and_name = ass_res_table.get_traffic_class_names_and_id()
+        self.assertEqual(len(traffic_class_id_and_name), 1)
+        self.assertIsInstance(traffic_class_id_and_name[0], TrafficClassIdentifier)
+        self.assertEqual(traffic_class_id_and_name[0].mode, self.network_mode)
+        self.assertEqual(traffic_class_id_and_name[0].__id__, self.traffic_class_name)
+
+        self.assertEqual(ass_res_table.get_number_of_iterations(), 1)
+        self.assertEqual(ass_res_table.get_assignment_method(), "msa")
+        car_class_info = ass_res_table.procedure_report["setup"]["Classes"][self.traffic_class_name]
+        car_class_keys = list(car_class_info.keys())
+        self.assertIn("not_assigned", car_class_keys)
+        self.assertIn("matrix_totals", car_class_keys)
+        self.assertIn("intrazonals", car_class_keys)
+        self.assertEqual(car_class_info["network mode"], self.network_mode)
+        self.assertEqual(car_class_info["Value-of-time"], 1.0)
+        self.assertEqual(car_class_info["PCE"], 1.0)
+        self.assertEqual(car_class_info["save_path_files"], True)
+        self.assertEqual(car_class_info["path_file_feather_format"], True)
+
+        convergence_info = ass_res_table.procedure_report["convergence"]
+        self.assertEqual(ass_res_table.get_alphas(), [1.0])
+        self.assertEqual(convergence_info["iteration"], [1])
+        self.assertEqual(convergence_info["rgap"], [np.inf])
+        self.assertEqual(convergence_info["warnings"], [""])
+
+    #
+    #
+    # def test_read_assignment_results(self):
+    #
+    # reference_path_file_dir = pathlib.Path(siouxfalls_project) / "path_files"
+    #
+    # ref_node_correspondence = pd.read_feather(reference_path_file_dir / f"nodes_to_indeces_{class_id}.feather")
+    # node_correspondence = pd.read_feather(path_file_dir / f"nodes_to_indeces_{class_id}.feather")
+    # self.assertTrue(node_correspondence.equals(ref_node_correspondence))
+    #
+    # ref_correspondence = pd.read_feather(reference_path_file_dir / f"correspondence_{class_id}.feather")
+    # correspondence = pd.read_feather(path_file_dir / f"correspondence_{class_id}.feather")
+    # self.assertTrue(correspondence.equals(ref_correspondence))
+    #
+    # path_class_id = f"path_{class_id}"
+    # for i in range(1, self.assignment.max_iter + 1):
+    #     class_dir = path_file_dir / f"iter{i}" / path_class_id
+    #     ref_class_dir = reference_path_file_dir / f"iter{i}" / path_class_id
+    #     for o in self.assigclass.matrix.index:
+    #         o_ind = self.assigclass.graph.compact_nodes_to_indices[o]
+    #         this_o_path_file = pd.read_feather(class_dir / f"o{o_ind}.feather")
+    #         ref_this_o_path_file = pd.read_feather(ref_class_dir / f"o{o_ind}.feather")
+    #         is_eq = this_o_path_file == ref_this_o_path_file
+    #         self.assertTrue(is_eq.all().all())
+    #
+    #         this_o_index_file = pd.read_feather(class_dir / f"o{o_ind}_indexdata.feather")
+    #         ref_this_o_index_file = pd.read_feather(ref_class_dir / f"o{o_ind}_indexdata.feather")
+    #         is_eq = this_o_index_file == ref_this_o_index_file
+    #         self.assertTrue(is_eq.all().all())
+    #

--- a/tests/aequilibrae/paths/test_assignment_paths.py
+++ b/tests/aequilibrae/paths/test_assignment_paths.py
@@ -1,13 +1,8 @@
 from unittest import TestCase
 import os
-import pathlib
-import sqlite3
 import pandas as pd
 import numpy as np
 import uuid
-import string
-import random
-from random import choice
 from tempfile import gettempdir
 from aequilibrae import TrafficAssignment, TrafficClass, Graph
 from aequilibrae.paths.assignment_paths import AssignmentPaths, AssignmentResultsTable, TrafficClassIdentifier
@@ -120,6 +115,8 @@ class TestAssignmentPaths(TestCase):
         path_5_18 = paths.get_path_for_destination(o, d, iteration, self.traffic_class_name)
         self.assertEqual(list(path_5_18), [15, 21, 48, 52])
 
-
-#        read_path_file
-#        get_path_for_destination_from_files
+        p1, p2 = paths.read_path_file(o, iteration, self.traffic_class_name)
+        self.assertIsInstance(p1, pd.DataFrame)
+        self.assertIsInstance(p2, pd.DataFrame)
+        p_5_18 = paths.get_path_for_destination_from_files(p1, p2, d)
+        self.assertEqual(list(path_5_18), list(p_5_18))

--- a/tests/aequilibrae/paths/test_select_link.py
+++ b/tests/aequilibrae/paths/test_select_link.py
@@ -1,0 +1,79 @@
+from unittest import TestCase
+import os
+import uuid
+from tempfile import gettempdir
+from aequilibrae import TrafficAssignment, TrafficClass
+from aequilibrae.paths.select_link import SelectLink
+from aequilibrae.utils.create_example import create_example
+
+# TODO (Jan 13/6/21): Do we want to add a result table to the SiouxFalls project in tests/data? Or maybe in the
+#  reference project? This here depends on an assignment run.
+
+
+class TestAssignmentPaths(TestCase):
+    def setUp(self) -> None:
+        os.environ["PATH"] = os.path.join(gettempdir(), "temp_data") + ";" + os.environ["PATH"]
+
+        proj_path = os.path.join(gettempdir(), "test_assignment_paths_" + uuid.uuid4().hex)
+        self.project = create_example(proj_path)
+        self.project.network.build_graphs()
+        self.network_mode = "c"
+        self.car_graph = self.project.network.graphs[self.network_mode]
+        self.car_graph.set_graph("free_flow_time")
+        self.car_graph.set_blocked_centroid_flows(False)
+        self.matrix = self.project.matrices.get_matrix("demand_omx")
+        self.matrix.computational_view()
+
+        self.assignment = TrafficAssignment()
+        self.traffic_class_name = "car"
+        self.assigclass = TrafficClass(self.traffic_class_name, self.car_graph, self.matrix)
+        self.assignment.add_class(self.assigclass)
+        self.assignment.set_save_path_files(True)
+        self.assignment.set_vdf("BPR")
+        self.assignment.set_vdf_parameters({"alpha": 0.15, "beta": 4.0})
+        self.assignment.set_vdf_parameters({"alpha": "b", "beta": "power"})
+        self.assignment.set_capacity_field("capacity")
+        self.assignment.set_time_field("free_flow_time")
+        self.assignment.max_iter = 1
+        self.assignment.set_algorithm("msa")
+        self.assignment.execute()
+        self.result_name = "sl_test"
+        self.assignment.save_results(self.result_name)
+
+        self.golden_non_zero_vals = [
+            (0, 1),
+            (0, 5),
+            (0, 6),
+            (0, 7),
+            (0, 15),
+            (0, 16),
+            (0, 17),
+            (0, 18),
+            (0, 19),
+            (2, 1),
+            (11, 1),
+            (12, 1),
+        ]
+        self.golden_sum = 3800.0
+
+    def tearDown(self) -> None:
+        self.matrix.close()
+        self.project.close()
+
+    # TODO Jan (13/6/21): need tests for various methods called during instantiation. Maybe implement default
+    #  constructor just for tests and then go from there. Alternatively, just use the test project.
+
+    def test_run_select_link_analysis(self):
+        demand_mat = {"car": self.matrix}
+        sl = SelectLink(self.result_name, demand_mat)
+        test_link = [0]
+        sl_res = sl.run_select_link_analysis(test_link)
+        res = sl_res[self.traffic_class_name][0]
+        self.assertEqual(len(sl_res), 1)
+        self.assertEqual(len(sl_res[self.traffic_class_name]), 1)
+
+        self.assertEqual(res.sum(), self.golden_sum)
+        self.assertEqual(self.matrix.matrix_view[res.nonzero()].sum(), res.sum())
+
+        non_zero_matrix_vals = list(zip(res.nonzero()[0], res.nonzero()[1]))
+        self.assertEqual(non_zero_matrix_vals, self.golden_non_zero_vals)


### PR DESCRIPTION
Select link analysis via on-disk path files. This is slower than an implementation during assignment, however it has the advantage that it works for any link(s) as long as path files have been stored during assignment.

The main reason to go down this path is that path file saving is now available and therefore this implementation is a lot less work.