### PR TITLE
Fixes inrets tests

### DIFF
--- a/tests/aequilibrae/paths/test_inrets.py
+++ b/tests/aequilibrae/paths/test_inrets.py
@@ -10,15 +10,12 @@ class TestInrets(TestCase):
 
         alpha = np.zeros(11)
         beta = np.zeros(11)
-        fftime = np.zeros(11)
-        capacity = np.zeros(11)
+        fftime = np.ones(11)
+        capacity = np.ones(11)
         congested_times = np.zeros(11)
         delta = np.zeros(11)
 
         alpha.fill(0.95)
-        beta.fill(0)
-        fftime.fill(1)
-        capacity.fill(1)
         link_flows = np.arange(11).astype(float) * 0.2
 
         inrets(congested_times, link_flows, capacity, fftime, alpha, beta, cores)
@@ -44,17 +41,20 @@ class TestInrets(TestCase):
 
         # Let's check the derivative for sections of the curve
         dx = 0.00000001
-        for i in range(1, 11):
-            link_flows.fill(1 * 0.2 * i)
-            link_flows += np.arange(11) * dx
+        for i in range(1, 20):
+            link_flows.fill(1 * 0.1001 * i)
 
+            link_flows += np.arange(11) * dx
+            print(link_flows)
             inrets(congested_times, link_flows, capacity, fftime, alpha, beta, cores)
             delta_inrets(delta, link_flows, capacity, fftime, alpha, beta, cores)
 
             # The derivative needs to be monotonically increasing.
-            self.assertGreater(delta[1], delta[0], "Delta is not increasing as it should")
+            # np.testing.asser
+            self.assertGreater(min(delta[1:] - delta[:-1]), 0, "Delta is not increasing as it should")
 
             # We check if the analytical solution matches the numerical differentiation
-            dydx = (congested_times[1] - congested_times[0]) / dx
-            self.assertAlmostEqual(dydx, delta[1], 6, "Problems with derivative for the inrets vdf")
-            print(dydx, delta[1])
+            for j in range(10):
+                dydx = (congested_times[j + 1] - congested_times[j]) / dx
+                self.assertAlmostEqual(dydx, delta[j + 1], 6, "Problems with derivative for the inrets vdf")
+            print(j)


### PR DESCRIPTION
Fixes the Inrets test. There is a kink in the VDF, so the monotonicity of its derivative is not true around the vdf kink.