### PR TITLE
numpy 1.22 is still not the default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy >= 1.14.0
+numpy>=1.18.0,<1.22
 scipy
 pyaml
 PyQt5


### PR DESCRIPTION
Too many libraries (such as PySal and QGIS) still use NumPy 1.21, which has different c array sizes.  The idea is to make the next release based on this older version of NumPy and re-evaluate when we prepare the following one