### PR TITLE
Speeding up OSM network import

### DIFF
--- a/aequilibrae/parameters.yml
+++ b/aequilibrae/parameters.yml
@@ -199,13 +199,13 @@ network:
           pedestrian: 'no'
         unknown_tags: true
 osm:
-    overpass_endpoint: "http://overpass-api.de/api"
+    overpass_endpoint: "https://overpass.kumi.systems/api/interpreter"
     nominatim_endpoint: "https://nominatim.openstreetmap.org/"
     accept_language: "en"
     max_attempts: 50
     timeout: 540
     max_query_area_size: 2500000000
-    sleeptime: 10
+    sleeptime: 2
 
 system:
   cpus: 0

--- a/aequilibrae/project/network/osm_builder.py
+++ b/aequilibrae/project/network/osm_builder.py
@@ -88,13 +88,16 @@ class OSMBuilder(WorkerThread):
         for i, node in enumerate(n):
             nid = node.pop("id")
             _ = node.pop("type")
-            node['node_id'] = i + self.node_start
+            node["node_id"] = i + self.node_start
             self.nodes[nid] = node
-            self.node_df.append([node['node_id'], nid, node['lon'], node['lat']])
+            self.node_df.append([node["node_id"], nid, node["lon"], node["lat"]])
             self.__emit_all(["Value", i])
         del n
-        self.node_df = pd.DataFrame(self.node_df, columns=['A', 'B', 'C', 'D']).drop_duplicates(
-            subset=['C', 'D']).to_records(index=False)
+        self.node_df = (
+            pd.DataFrame(self.node_df, columns=["A", "B", "C", "D"])
+            .drop_duplicates(subset=["C", "D"])
+            .to_records(index=False)
+        )
 
         logger.info("Setting data structures for links")
         self.__emit_all(["text", "Setting data structures for links"])
@@ -128,7 +131,7 @@ class OSMBuilder(WorkerThread):
 
         logger.info("Adding network nodes")
         self.__emit_all(["text", "Adding network nodes"])
-        sql = 'insert into nodes(node_id, is_centroid, osm_id, geometry) Values(?, 0, ?, MakePoint(?,?, 4326))'
+        sql = "insert into nodes(node_id, is_centroid, osm_id, geometry) Values(?, 0, ?, MakePoint(?,?, 4326))"
         self.conn.executemany(sql, self.node_df)
         self.conn.commit()
         del self.node_df
@@ -194,7 +197,7 @@ class OSMBuilder(WorkerThread):
 
             self.__emit_all(["text", f"{counter:,} of {L:,} super links added"])
             self.links[osm_id] = []
-        sql = self.insert_qry.format(table, field_names, ','.join(['?'] * (len(all_attrs[0]) - 1)))
+        sql = self.insert_qry.format(table, field_names, ",".join(["?"] * (len(all_attrs[0]) - 1)))
         logger.info("Adding network links")
         self.__emit_all(["text", "Adding network links"])
         try:
@@ -294,7 +297,7 @@ class OSMBuilder(WorkerThread):
         return link_type
 
     def __get_link_property(self, d2, val, linktags, v):
-        vald = linktags.get(f"{v['osm_source']}:{d2}", val)
+        vald = linktags.get(f'{v["osm_source"]}:{d2}', val)
         if vald is None:
             return vald
 

--- a/aequilibrae/project/network/osm_builder.py
+++ b/aequilibrae/project/network/osm_builder.py
@@ -266,7 +266,7 @@ class OSMBuilder(WorkerThread):
         split = link_type.split("_")
         for i, piece in enumerate(split[1:]):
             if piece in ["link", "segment", "stretch"]:
-                link_type = "_".join(split[0: i + 1])
+                link_type = "_".join(split[0 : i + 1])
 
         if len(link_type) == 0:
             link_type = "empty"

--- a/aequilibrae/project/network/osm_builder.py
+++ b/aequilibrae/project/network/osm_builder.py
@@ -2,16 +2,15 @@ import gc
 import importlib.util as iutil
 import sqlite3
 import string
-import gc
 from typing import List
-import importlib.util as iutil
+
 import numpy as np
 import pandas as pd
-from aequilibrae.project.network.link_types import LinkTypes
-from aequilibrae.context import get_active_project
-from .haversine import haversine
+
 from aequilibrae import logger
+from aequilibrae.context import get_active_project
 from aequilibrae.parameters import Parameters
+from aequilibrae.project.network.link_types import LinkTypes
 from .haversine import haversine
 from ..spatialite_connection import spatialite_connection
 from ...utils import WorkerThread
@@ -267,7 +266,7 @@ class OSMBuilder(WorkerThread):
         split = link_type.split("_")
         for i, piece in enumerate(split[1:]):
             if piece in ["link", "segment", "stretch"]:
-                link_type = "_".join(split[0 : i + 1])
+                link_type = "_".join(split[0: i + 1])
 
         if len(link_type) == 0:
             link_type = "empty"

--- a/aequilibrae/project/spatialite_connection.py
+++ b/aequilibrae/project/spatialite_connection.py
@@ -1,5 +1,13 @@
 import os
 from sqlite3 import Connection
+import sqlite3
+import numpy as np
+
+sqlite3.register_adapter(np.int64, int)
+sqlite3.register_adapter(np.int32, int)
+sqlite3.register_adapter(np.float32, float)
+sqlite3.register_adapter(np.float64, float)
+sqlite3.register_adapter(np.object0, str)
 
 
 def spatialite_connection(conn: Connection) -> Connection:


### PR DESCRIPTION
1. Local tests importing Andorra (a very small network) showed a performance improvement of 2.6x in the network building process (does not include download).
2. Local tests importing Uzbekistan (a reasonably sized network) showed a performance improvement of 7x in the network building process (does not include download).
3. Local tests importing Australia (a large network) showed a performance improvement of 3.5x in the network building process (does not include download). 9h30min to 2h40min.
4. The new Overpass API endpoint is much less restrictive, so we could reduce the time interval between queries (sleep time)