### PR TITLE
Fix some warnings (during tests)

### DIFF
--- a/aequilibrae/distribution/synthetic_gravity_model.py
+++ b/aequilibrae/distribution/synthetic_gravity_model.py
@@ -47,7 +47,7 @@ class SyntheticGravityModel:
             return self.__dict__[key]
 
     def load(self, file_name):
-        """Loads model from disk. Extension is \*.mod"""
+        R"""Loads model from disk. Extension is \*.mod"""
         try:
             with open(file_name, "r") as f:
                 model = yaml.safe_load(f)[self.model_type]
@@ -60,7 +60,7 @@ class SyntheticGravityModel:
             raise ValueError("File provided is not a valid Synthetic Gravity Model - {}".format(err.__str__()))
 
     def save(self, file_name):
-        """Saves model to disk in yaml format. Extension is \*.mod"""
+        R"""Saves model to disk in yaml format. Extension is \*.mod"""
         file_name = str(file_name)
         if file_name[-4:].upper() != ".MOD":
             file_name += ".mod"

--- a/tests/aequilibrae/matrix/test_aequilibraeMatrix.py
+++ b/tests/aequilibrae/matrix/test_aequilibraeMatrix.py
@@ -33,7 +33,7 @@ class TestAequilibraeMatrix(TestCase):
             "file_name": self.name_test,
             "zones": zones,
             "matrix_names": ["mat", "seed", "dist"],
-            "index_names": ["my indices"],
+            "index_names": ["my_indices"],
         }
 
         self.matrix = AequilibraeMatrix()

--- a/tests/aequilibrae/project/test_nodes.py
+++ b/tests/aequilibrae/project/test_nodes.py
@@ -4,7 +4,7 @@ from copy import copy, deepcopy
 from random import randint, random
 from shutil import copytree, rmtree
 from tempfile import gettempdir
-from unittest import TestCase, TestLoader
+from unittest import TestCase, TestLoader as _TestLoader
 
 import shapely.wkb
 from shapely.geometry import Point
@@ -12,7 +12,7 @@ from shapely.geometry import Point
 from aequilibrae.project import Project
 from ...data import siouxfalls_project
 
-TestLoader.sortTestMethodsUsing = None
+_TestLoader.sortTestMethodsUsing = None
 
 
 class TestNodes(TestCase):

--- a/tests/aequilibrae/project/test_zone.py
+++ b/tests/aequilibrae/project/test_zone.py
@@ -88,7 +88,7 @@ class TestZone(TestCase):
         grid = curr.fetchone()[0]
         grid = shapely.wkb.loads(grid)
 
-        grid = [p for p in grid if p.intersects(geo)]
+        grid = [p for p in grid.geoms if p.intersects(geo)]
 
         zoning = self.proj.zoning
         for i, zone_geo in enumerate(grid):


### PR DESCRIPTION
This fixes some/most warnings that popup during tests:

* invalid escape sequence of docstrings -> use raw docstrings. Indicated with a capital R instead of lower case r to differentiate raw strings vs regex strings (especially handy when using magicpython syntax highlighting (https://github.com/MagicStack/MagicPython/issues/114))
* warning about a pandas index name
* warning about test discovery for TestLoader (I renamed this import, but I think we should be able to delete it altogether, perhaps when refactoring that test module)
* shapely deprecation warning about multipart geometries

There's a couple of warnings left with regards to numpy, but they take some more time to investigate.