### PR TITLE
Transpose shared matrices to better cache locality

### DIFF
--- a/aequilibrae/paths/AoN.pyx
+++ b/aequilibrae/paths/AoN.pyx
@@ -57,7 +57,7 @@ def one_to_all(origin, matrix, graph, result, aux_result, curr_thread):
 
     if skims > 0:
         gskim = graph.compact_skims
-        tskim = aux_result.temporary_skims[:, :, curr_thread]
+        tskim = aux_result.temporary_skims[curr_thread, :, :]
         fskm = result.skims.matrix_view[origin_index, :, :]
     else:
         gskim = np.zeros((1,1))
@@ -72,12 +72,12 @@ def one_to_all(origin, matrix, graph, result, aux_result, curr_thread):
     cdef long long [:] no_path_view = result.no_path[origin_index, :]
 
     # views from the aux-result object
-    cdef long long [:] predecessors_view = aux_result.predecessors[:, curr_thread]
-    cdef long long [:] reached_first_view = aux_result.reached_first[:, curr_thread]
-    cdef long long [:] conn_view = aux_result.connectors[:, curr_thread]
-    cdef double [:, :] link_loads_view = aux_result.temp_link_loads[:, :, curr_thread]
-    cdef double [:, :] node_load_view = aux_result.temp_node_loads[:, :, curr_thread]
-    cdef long long [:] b_nodes_view = aux_result.temp_b_nodes[:, curr_thread]
+    cdef long long [:] predecessors_view = aux_result.predecessors[curr_thread, :]
+    cdef long long [:] reached_first_view = aux_result.reached_first[curr_thread, :]
+    cdef long long [:] conn_view = aux_result.connectors[curr_thread, :]
+    cdef double [:, :] link_loads_view = aux_result.temp_link_loads[curr_thread, :, :]
+    cdef double [:, :] node_load_view = aux_result.temp_node_loads[curr_thread, :, :]
+    cdef long long [:] b_nodes_view = aux_result.temp_b_nodes[curr_thread, :]
 
     # path saving file paths
     cdef string path_file_base
@@ -356,11 +356,11 @@ def skimming_single_origin(origin, graph, result, aux_result, curr_thread):
     cdef double [:, :] final_skim_matrices_view = result.skims.matrix_view[origin_index, :, :]
 
     # views from the aux-result object
-    cdef long long [:] predecessors_view = aux_result.predecessors[:, curr_thread]
-    cdef long long [:] reached_first_view = aux_result.reached_first[:, curr_thread]
-    cdef long long [:] conn_view = aux_result.connectors[:, curr_thread]
-    cdef long long [:] b_nodes_view = aux_result.temp_b_nodes[:, curr_thread]
-    cdef double [:, :] skim_matrix_view = aux_result.temporary_skims[:, :, curr_thread]
+    cdef long long [:] predecessors_view = aux_result.predecessors[curr_thread, :]
+    cdef long long [:] reached_first_view = aux_result.reached_first[curr_thread, :]
+    cdef long long [:] conn_view = aux_result.connectors[curr_thread, :]
+    cdef long long [:] b_nodes_view = aux_result.temp_b_nodes[curr_thread, :]
+    cdef double [:, :] skim_matrix_view = aux_result.temporary_skims[curr_thread, :, :]
 
     #Now we do all procedures with NO GIL
     with nogil:

--- a/aequilibrae/paths/all_or_nothing.py
+++ b/aequilibrae/paths/all_or_nothing.py
@@ -75,7 +75,7 @@ class allOrNothing(WorkerThread):
         pool.close()
         pool.join()
         # TODO: Multi-thread this sum
-        self.results.compact_link_loads = np.sum(self.aux_res.temp_link_loads, axis=2)
+        self.results.compact_link_loads = np.sum(self.aux_res.temp_link_loads, axis=0)
         assign_link_loads(
             self.results.link_loads, self.results.compact_link_loads, self.results.crosswalk, self.results.cores
         )

--- a/aequilibrae/paths/multi_threaded_aon.py
+++ b/aequilibrae/paths/multi_threaded_aon.py
@@ -22,15 +22,15 @@ class MultiThreadedAoN:
     def prepare(self, graph, results):
         itype = graph.default_types("int")
         ftype = graph.default_types("float")
-        self.predecessors = np.zeros((results.compact_nodes, results.cores), dtype=itype)
+        self.predecessors = np.zeros((results.cores, results.compact_nodes), dtype=itype)
         if results.num_skims > 0:
-            self.temporary_skims = np.zeros((results.compact_nodes, results.num_skims, results.cores), dtype=ftype)
+            self.temporary_skims = np.zeros((results.cores, results.compact_nodes, results.num_skims), dtype=ftype)
         else:
-            self.temporary_skims = np.zeros((1, 1, results.cores), dtype=ftype)
-        self.reached_first = np.zeros((results.compact_nodes, results.cores), dtype=itype)
-        self.connectors = np.zeros((results.compact_nodes, results.cores), dtype=itype)
-        self.temp_link_loads = np.zeros((results.links + 1, results.classes["number"], results.cores), dtype=ftype)
-        self.temp_node_loads = np.zeros((results.compact_nodes, results.classes["number"], results.cores), dtype=ftype)
-        self.temp_b_nodes = np.zeros((graph.compact_graph.b_node.shape[0], results.cores), dtype=itype)
+            self.temporary_skims = np.zeros((results.cores, 1, 1), dtype=ftype)
+        self.reached_first = np.zeros((results.cores, results.compact_nodes), dtype=itype)
+        self.connectors = np.zeros((results.cores, results.compact_nodes), dtype=itype)
+        self.temp_link_loads = np.zeros((results.cores, results.links + 1, results.classes["number"]), dtype=ftype)
+        self.temp_node_loads = np.zeros((results.cores, results.compact_nodes, results.classes["number"]), dtype=ftype)
+        self.temp_b_nodes = np.zeros((results.cores, graph.compact_graph.b_node.shape[0]), dtype=itype)
         for i in range(results.cores):
-            self.temp_b_nodes[:, i] = graph.compact_graph.b_node.values[:]
+            self.temp_b_nodes[i, :] = graph.compact_graph.b_node.values[:]

--- a/aequilibrae/paths/multi_threaded_skimming.py
+++ b/aequilibrae/paths/multi_threaded_skimming.py
@@ -18,11 +18,11 @@ class MultiThreadedNetworkSkimming:
     def prepare(self, graph, results):
         itype = graph.default_types("int")
         ftype = graph.default_types("float")
-        self.predecessors = np.zeros((results.nodes, results.cores), dtype=itype)
-        self.temporary_skims = np.zeros((results.nodes, results.num_skims, results.cores), dtype=ftype)
-        self.reached_first = np.zeros((results.nodes, results.cores), dtype=itype)
-        self.connectors = np.zeros((results.nodes, results.cores), dtype=itype)
-        self.temp_b_nodes = np.zeros((graph.compact_graph.b_node.values.shape[0], results.cores), dtype=itype)
+        self.predecessors = np.zeros((results.cores, results.nodes), dtype=itype)
+        self.temporary_skims = np.zeros((results.cores, results.nodes, results.num_skims), dtype=ftype)
+        self.reached_first = np.zeros((results.cores, results.nodes), dtype=itype)
+        self.connectors = np.zeros((results.cores, results.nodes), dtype=itype)
+        self.temp_b_nodes = np.zeros((results.cores, graph.compact_graph.b_node.values.shape[0]), dtype=itype)
 
         for i in range(results.cores):
-            self.temp_b_nodes[:, i] = graph.compact_graph.b_node.values[:]
+            self.temp_b_nodes[i, :] = graph.compact_graph.b_node.values[:]


### PR DESCRIPTION
By bringing the thread id to the 0-axis we are able to make the thread local slices continuous in memory. This should improve cache locality for better performance in tight loops.

Benchmarked on the Arkansas state wide network and saw ~10% improvement in overall skimming runtime.