### PR TITLE
Avoid absolute path references

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ link_args = [f"{prefix}openmp"]
 
 ext_mod_aon = Extension(
     "aequilibrae.paths.AoN",
-    [join(dirname(os.path.realpath(__file__)), "aequilibrae/paths", "AoN.pyx")],
+    [join("aequilibrae", "paths", "AoN.pyx")],
     extra_compile_args=compile_args,
     extra_link_args=link_args,
     define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],
@@ -37,7 +37,7 @@ ext_mod_aon = Extension(
 
 ext_mod_ipf = Extension(
     "aequilibrae.distribution.ipf_core",
-    [join(dirname(os.path.realpath(__file__)), "aequilibrae/distribution", "ipf_core.pyx")],
+    [join("aequilibrae", "distribution", "ipf_core.pyx")],
     extra_compile_args=compile_args,
     extra_link_args=link_args,
     define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],


### PR DESCRIPTION
Using absolutely paths taints the `SOURCES.txt` that's generated when installed, the conda-forge windows build seems unable to handle it.