### PR TITLE
fixes agencies table

### DIFF
--- a/aequilibrae/paths/graph.py
+++ b/aequilibrae/paths/graph.py
@@ -287,7 +287,7 @@ class Graph(object):
         if cost_field in self.graph.columns:
             self.cost_field = cost_field
             self.compact_cost = np.zeros(self.compact_graph.id.max() + 2, self.__float_type)
-            df = self.__graph_groupby.sum()[[cost_field]].reset_index()
+            df = self.__graph_groupby.sum(numeric_only=True)[[cost_field]].reset_index()
             self.compact_cost[df.index.values] = df[cost_field].values
             if self.graph[cost_field].dtype == self.__float_type:
                 self.cost = np.array(self.graph[cost_field].values, copy=True)

--- a/aequilibrae/transit/transit_elements/agency.py
+++ b/aequilibrae/transit/transit_elements/agency.py
@@ -37,5 +37,5 @@ class Agency(BasicPTElement):
             max_db = conn.execute(sql).fetchone()[0]
 
         c = Constants()
-        c.agencies["agencies"] = max(c.agencies["agencies"], max_db) + 1
+        c.agencies["agencies"] = max(c.agencies.get("agencies", 0), max_db) + 1
         return c.agencies["agencies"]

--- a/aequilibrae/transit/transit_elements/agency.py
+++ b/aequilibrae/transit/transit_elements/agency.py
@@ -34,8 +34,8 @@ class Agency(BasicPTElement):
     def __get_agency_id(self):
         with closing(database_connection("transit")) as conn:
             sql = "Select coalesce(max(distinct(agency_id)), 0) from agencies;"
-            data = [x[0] for x in conn.execute(sql)]
+            max_db = conn.execute(sql).fetchone()[0]
 
         c = Constants()
-        c.agencies["agencies"] = data[0] + 1
+        c.agencies["agencies"] = max(c.agencies["agencies"], max_db) + 1
         return c.agencies["agencies"]

--- a/aequilibrae/transit/transit_elements/agency.py
+++ b/aequilibrae/transit/transit_elements/agency.py
@@ -2,7 +2,7 @@ from contextlib import closing
 from sqlite3 import Connection
 
 from aequilibrae.project.database_connection import database_connection
-from aequilibrae.transit.constants import Constants, WALK_AGENCY_ID
+from aequilibrae.transit.constants import Constants
 from aequilibrae.transit.transit_elements.basic_element import BasicPTElement
 
 
@@ -33,9 +33,9 @@ class Agency(BasicPTElement):
 
     def __get_agency_id(self):
         with closing(database_connection("transit")) as conn:
-            sql = "Select coalesce(max(distinct(agency_id)), 0) from agencies where agency_id<?;"
-            data = [x[0] for x in conn.execute(sql, [WALK_AGENCY_ID])]
+            sql = "Select coalesce(max(distinct(agency_id)), 0) from agencies;"
+            data = [x[0] for x in conn.execute(sql)]
 
         c = Constants()
-        c.agencies["agencies"] = max(c.agencies.get("agencies", 1), data[0])
+        c.agencies["agencies"] = data[0] + 1
         return c.agencies["agencies"]

--- a/aequilibrae/transit/transit_elements/agency.py
+++ b/aequilibrae/transit/transit_elements/agency.py
@@ -34,7 +34,7 @@ class Agency(BasicPTElement):
     def __get_agency_id(self):
         with closing(database_connection("transit")) as conn:
             sql = "Select coalesce(max(distinct(agency_id)), 0) from agencies;"
-            max_db = conn.execute(sql).fetchone()[0]
+            max_db = int(conn.execute(sql).fetchone()[0])
 
         c = Constants()
         c.agencies["agencies"] = max(c.agencies.get("agencies", 0), max_db) + 1

--- a/tests/aequilibrae/transit/test_gtfs_loader.py
+++ b/tests/aequilibrae/transit/test_gtfs_loader.py
@@ -1,4 +1,6 @@
 from os.path import join, dirname, abspath
+from pathlib import Path
+
 import pytest
 
 import pandas as pd
@@ -26,7 +28,8 @@ def test_set_feed_path(gtfs_loader, gtfs_fldr):
 
 
 def test_load_data(gtfs_loader, gtfs_fldr):
-    cap = pd.read_csv(join(abspath(dirname("tests")), "tests/data/gtfs/transit_max_speeds.txt"))
+    pth = Path(__file__).parent.parent.parent
+    cap = pd.read_csv(pth / "data/gtfs/transit_max_speeds.txt")
 
     df = cap[cap.city == "Coquimbo"]
     df.loc[df.min_distance < 100, "speed"] = 10

--- a/tests/aequilibrae/transit/test_transit.py
+++ b/tests/aequilibrae/transit/test_transit.py
@@ -1,11 +1,16 @@
 from os.path import isfile, join
 
 from aequilibrae.project.database_connection import database_connection
+from aequilibrae.transit.constants import Constants
 
 
 def test_new_gtfs_builder(create_gtfs_project, create_path):
     conn = database_connection("transit")
     existing = conn.execute("SELECT COALESCE(MAX(DISTINCT(agency_id)), 0) FROM agencies;").fetchone()[0]
+
+    c = Constants()
+    existing = max(c["agencies"], existing)
+
     transit = create_gtfs_project.new_gtfs_builder(
         agency="Agency_1",
         day="2016-04-13",

--- a/tests/aequilibrae/transit/test_transit.py
+++ b/tests/aequilibrae/transit/test_transit.py
@@ -1,8 +1,11 @@
 from os.path import isfile, join
+
 from aequilibrae.project.database_connection import database_connection
 
 
 def test_new_gtfs_builder(create_gtfs_project, create_path):
+    conn = database_connection("transit")
+    existing = conn.execute("SELECT COALESCE(MAX(DISTINCT(agency_id)), 0) FROM agencies;").fetchone()[0]
     transit = create_gtfs_project.new_gtfs_builder(
         agency="Agency_1",
         day="2016-04-13",
@@ -11,21 +14,25 @@ def test_new_gtfs_builder(create_gtfs_project, create_path):
 
     assert str(type(transit)) == "<class 'aequilibrae.transit.lib_gtfs.GTFSRouteSystemBuilder'>"
 
-    transit.save_to_disk()
-
-    transit = create_gtfs_project.new_gtfs_builder(
+    transit2 = create_gtfs_project.new_gtfs_builder(
         agency="Agency_2",
         day="2016-07-19",
         file_path=join(create_path, "gtfs_coquimbo.zip"),
     )
 
-    assert str(type(transit)) == "<class 'aequilibrae.transit.lib_gtfs.GTFSRouteSystemBuilder'>"
-
     transit.save_to_disk()
+    transit2.save_to_disk()
 
-    conn = database_connection("transit")
+    assert conn.execute("SELECT MAX(DISTINCT(agency_id)) FROM agencies;").fetchone()[0] == existing + 2
 
-    assert conn.execute("SELECT MAX(DISTINCT(agency_id)) FROM agencies;").fetchone()[0] == 2
+    transit3 = create_gtfs_project.new_gtfs_builder(
+        agency="Agency_3",
+        day="2016-07-19",
+        file_path=join(create_path, "gtfs_coquimbo.zip"),
+    )
+
+    transit3.save_to_disk()
+    assert conn.execute("SELECT MAX(DISTINCT(agency_id)) FROM agencies;").fetchone()[0] == existing + 3
 
 
 def test___create_transit_database(create_gtfs_project):

--- a/tests/aequilibrae/transit/test_transit.py
+++ b/tests/aequilibrae/transit/test_transit.py
@@ -5,11 +5,11 @@ from aequilibrae.transit.constants import Constants
 
 
 def test_new_gtfs_builder(create_gtfs_project, create_path):
+    c = Constants()
+    c.agencies["agencies"] = 0
+
     conn = database_connection("transit")
     existing = conn.execute("SELECT COALESCE(MAX(DISTINCT(agency_id)), 0) FROM agencies;").fetchone()[0]
-
-    c = Constants()
-    existing = max(c["agencies"], existing)
 
     transit = create_gtfs_project.new_gtfs_builder(
         agency="Agency_1",

--- a/tests/aequilibrae/transit/test_transit.py
+++ b/tests/aequilibrae/transit/test_transit.py
@@ -1,13 +1,31 @@
 from os.path import isfile, join
+from aequilibrae.project.database_connection import database_connection
 
 
 def test_new_gtfs_builder(create_gtfs_project, create_path):
     transit = create_gtfs_project.new_gtfs_builder(
-        agency="LISERCO, LISANCO, LINCOSUR",
+        agency="Agency_1",
+        day="2016-04-13",
         file_path=join(create_path, "gtfs_coquimbo.zip"),
     )
 
     assert str(type(transit)) == "<class 'aequilibrae.transit.lib_gtfs.GTFSRouteSystemBuilder'>"
+
+    transit.save_to_disk()
+
+    transit = create_gtfs_project.new_gtfs_builder(
+        agency="Agency_2",
+        day="2016-07-19",
+        file_path=join(create_path, "gtfs_coquimbo.zip"),
+    )
+
+    assert str(type(transit)) == "<class 'aequilibrae.transit.lib_gtfs.GTFSRouteSystemBuilder'>"
+
+    transit.save_to_disk()
+
+    conn = database_connection("transit")
+
+    assert conn.execute("SELECT MAX(DISTINCT(agency_id)) FROM agencies;").fetchone()[0] == 2
 
 
 def test___create_transit_database(create_gtfs_project):


### PR DESCRIPTION
* Fixes the agencies table to import more than one GTFS feed into the same database (_aequilibrae/transit/transit_elements/agency.py_)
* Changed the test to check if two agencies are now being saved in the agencies table (_tests/aequilibrae/transit/test_transit.py_)