### PR TITLE
Parallelising PuT assignment

### DIFF
--- a/aequilibrae/paths/hyperpath.pyx
+++ b/aequilibrae/paths/hyperpath.pyx
@@ -11,7 +11,8 @@ import numpy as np
 cimport numpy as cnp
 
 from libc.stdlib cimport malloc, free
- 
+from libcpp.vector cimport vector
+
 
 ctypedef cnp.float64_t DATATYPE_t
 DATATYPE_PY = np.float64
@@ -100,7 +101,7 @@ cdef void _coo_tocsc_uint32(
 @cython.wraparound(False)
 @cython.embedsignature(False)
 @cython.initializedcheck(False)
-cdef void argsort(DATATYPE_t[::1] data, cnp.uint32_t[:] order) nogil:
+cdef void argsort(cnp.float64_t[::1] data, cnp.uint32_t[:] order) nogil:
     """
     Wrapper of the C function qsort
     source: https://github.com/jcrudy/cython-argsort/tree/master/cyargsort
@@ -179,17 +180,17 @@ cpdef convert_graph_to_csc_uint32(edges, tail, head, data, vertex_count):
 cpdef void compute_SF_in(
     cnp.uint32_t[::1] csc_indptr,
     cnp.uint32_t[::1] csc_edge_idx,
-    DATATYPE_t[::1] c_a_vec,
-    DATATYPE_t[::1] f_a_vec,
+    cnp.float64_t[::1] c_a_vec,
+    cnp.float64_t[::1] f_a_vec,
     cnp.uint32_t[::1] tail_indices,
     cnp.uint32_t[::1] head_indices,
-    cnp.uint32_t[::1] demand_indices,
-    DATATYPE_t[::1] demand_values,
-    DATATYPE_t[::1] v_a_vec,
-    DATATYPE_t[::1] u_i_vec,
-    DATATYPE_t[::1] f_i_vec,
-    DATATYPE_t[::1] u_j_c_a_vec,
-    DATATYPE_t[::1] v_i_vec,
+    vector[cnp.uint32_t] demand_indices,
+    vector[cnp.float64_t] demand_values,
+    cnp.float64_t[::1] v_a_vec,
+    cnp.float64_t[::1] u_i_vec,
+    cnp.float64_t[::1] f_i_vec,
+    cnp.float64_t[::1] u_j_c_a_vec,
+    cnp.float64_t[::1] v_i_vec,
     cnp.uint8_t[::1] h_a_vec,
     cnp.uint32_t[::1] edge_indices,
     int vertex_count,
@@ -201,7 +202,7 @@ cpdef void compute_SF_in(
         DATATYPE_t u_r, v_a_new, v_i, u_i
         size_t i, h_a_count
         cnp.uint32_t vert_idx 
-        int demand_size = demand_indices.shape[0]
+        int demand_size = demand_indices.size()
 
     # initialization
     for i in range(<size_t>vertex_count):
@@ -288,12 +289,12 @@ cpdef void compute_SF_in(
 cdef void _SF_in_first_pass_full(
     cnp.uint32_t[::1] csc_indptr, 
     cnp.uint32_t[::1] csc_edge_idx,
-    DATATYPE_t[::1] c_a_vec,
-    DATATYPE_t[::1] f_a_vec,
+    cnp.float64_t[::1] c_a_vec,
+    cnp.float64_t[::1] f_a_vec,
     cnp.uint32_t[::1] tail_indices,
-    DATATYPE_t[::1] u_i_vec,
-    DATATYPE_t[::1] f_i_vec,
-    DATATYPE_t[::1] u_j_c_a_vec,
+    cnp.float64_t[::1] u_i_vec,
+    cnp.float64_t[::1] f_i_vec,
+    cnp.float64_t[::1] u_j_c_a_vec,
     cnp.uint8_t[::1] h_a_vec,
     int dest_vert_index,
 ) nogil:
@@ -388,10 +389,10 @@ cdef void _SF_in_second_pass(
     cnp.uint32_t[::1] edge_indices,
     cnp.uint32_t[::1] tail_indices,
     cnp.uint32_t[::1] head_indices,
-    DATATYPE_t[::1] v_i_vec,
-    DATATYPE_t[::1] v_a_vec,
-    DATATYPE_t[::1] f_i_vec,
-    DATATYPE_t[::1] f_a_vec,
+    cnp.float64_t[::1] v_i_vec,
+    cnp.float64_t[::1] v_a_vec,
+    cnp.float64_t[::1] f_i_vec,
+    cnp.float64_t[::1] f_a_vec,
     size_t h_a_count
 ) nogil:
 

--- a/aequilibrae/paths/hyperpath.pyx
+++ b/aequilibrae/paths/hyperpath.pyx
@@ -198,7 +198,6 @@ cdef cnp.float64_t *compute_SF_in_parallel(
     int num_threads,
 ) nogil:
     # Thread local variables are prefixed by "thread", anything else should be considered shared and thus read only
-    # except ouput_travel_time when it is non-null
     if ouput_travel_time:
         with gil:
             assert d_vert_ids_view.shape[0] == 1, "To output travel time there must only be one destination"
@@ -219,7 +218,7 @@ cdef cnp.float64_t *compute_SF_in_parallel(
         # When writing all threads must increment!
         cnp.float64_t *edge_volume = <cnp.float64_t *> calloc(num_threads, sizeof(cnp.float64_t) * edge_count)
 
-        # We malloc this memory here, then use it as the 0th threads thread_u_i_vec to allow us to return it
+        # We malloc this memory here, then use it as the 0th thread's thread_u_i_vec to allow us to return it
         cnp.float64_t *u_i_vec_out = <cnp.float64_t *> malloc(sizeof(cnp.float64_t) * vertex_count)
 
         size_t i, j, destination_vertex_index

--- a/aequilibrae/paths/hyperpath.pyx
+++ b/aequilibrae/paths/hyperpath.pyx
@@ -221,7 +221,8 @@ cdef cnp.float64_t *compute_SF_in_parallel(
         # We malloc this memory here, then use it as the 0th thread's thread_u_i_vec to allow us to return it
         cnp.float64_t *u_i_vec_out = <cnp.float64_t *> malloc(sizeof(cnp.float64_t) * vertex_count)
 
-        size_t i, j, destination_vertex_index
+        int i  # openmp on windows requires iterator variable have signed type
+        size_t j, destination_vertex_index
 
     with parallel(num_threads=num_threads):
         thread_demand_origins = <cnp.uint32_t  *> malloc(sizeof(cnp.uint32_t)  * d_vert_ids_view.shape[0])

--- a/aequilibrae/paths/hyperpath.pyx
+++ b/aequilibrae/paths/hyperpath.pyx
@@ -11,8 +11,6 @@ import numpy as np
 cimport numpy as cnp
 
 from libc.stdlib cimport malloc, free
-from libcpp.vector cimport vector
-
 
 ctypedef cnp.float64_t DATATYPE_t
 DATATYPE_PY = np.float64
@@ -172,21 +170,21 @@ cpdef convert_graph_to_csc_uint32(edges, tail, head, data, vertex_count):
     return rs_indptr, rs_indices, rs_data
 
 
-
-@cython.boundscheck(False)
+# @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.embedsignature(False)
 @cython.initializedcheck(False)
-cpdef void compute_SF_in(
+cdef void compute_SF_in(
     cnp.uint32_t[::1] csc_indptr,
     cnp.uint32_t[::1] csc_edge_idx,
     cnp.float64_t[::1] c_a_vec,
     cnp.float64_t[::1] f_a_vec,
     cnp.uint32_t[::1] tail_indices,
     cnp.uint32_t[::1] head_indices,
-    vector[cnp.uint32_t] demand_indices,
-    vector[cnp.float64_t] demand_values,
-    cnp.float64_t[::1] v_a_vec,
+    cnp.uint32_t *demand_indices,
+    cnp.float64_t *demand_values,
+    size_t demand_size,
+    cnp.float64_t *v_a_vec,
     cnp.float64_t[::1] u_i_vec,
     cnp.float64_t[::1] f_i_vec,
     cnp.float64_t[::1] u_j_c_a_vec,
@@ -202,7 +200,6 @@ cpdef void compute_SF_in(
         DATATYPE_t u_r, v_a_new, v_i, u_i
         size_t i, h_a_count
         cnp.uint32_t vert_idx 
-        int demand_size = demand_indices.size()
 
     # initialization
     for i in range(<size_t>vertex_count):
@@ -237,7 +234,7 @@ cpdef void compute_SF_in(
     # demand is loaded into all the origin vertices
     # also we compute the min travel time from all the origin vertices
     u_r = DATATYPE_INF
-    for i in range(<size_t>demand_size):
+    for i in range(demand_size):
         vert_idx = demand_indices[i]
         v_i_vec[<size_t>vert_idx] = demand_values[i]
         u_i = u_i_vec[<size_t>vert_idx]
@@ -390,7 +387,7 @@ cdef void _SF_in_second_pass(
     cnp.uint32_t[::1] tail_indices,
     cnp.uint32_t[::1] head_indices,
     cnp.float64_t[::1] v_i_vec,
-    cnp.float64_t[::1] v_a_vec,
+    cnp.float64_t *v_a_vec,
     cnp.float64_t[::1] f_i_vec,
     cnp.float64_t[::1] f_a_vec,
     size_t h_a_count

--- a/aequilibrae/paths/hyperpath.pyx
+++ b/aequilibrae/paths/hyperpath.pyx
@@ -203,13 +203,14 @@ cdef void compute_SF_in(
     for i in range(vertex_count):
         u_i_vec[i] = DATATYPE_INF
         f_i_vec[i] = 0.0
-        u_j_c_a_vec[i] = DATATYPE_INF  # TODO 90% sure this should not be under vertex_count but edge_count
         v_i_vec[i] = 0.0
     u_i_vec[<size_t>dest_vert_index] = 0.0
 
     for i in range(edge_count):
+        v_a_vec[i] = 0.0
+        u_j_c_a_vec[i] = DATATYPE_INF
         h_a_vec[i] = 0
-        v_a_vec[i] = 0.0  # TODO 90% sure this should not be under edge_count but vertex_count
+
 
     # first pass #
     # ---------- #

--- a/aequilibrae/paths/public_transport.pyx
+++ b/aequilibrae/paths/public_transport.pyx
@@ -138,7 +138,7 @@ class HyperpathGenerating:
         destination_column="dest_vert_idx",
         demand_column="demand",
         check_demand=False,
-        threads=1
+        threads=0
     ):
         # check the input demand paramater
         if check_demand:

--- a/tests/test_hyperpath.py
+++ b/tests/test_hyperpath.py
@@ -15,7 +15,7 @@ def test_SF_run_01():
     hp = HyperpathGenerating(edges, check_edges=False)
     hp.run(origin=0, destination=12, volume=1.0)
 
-    assert np.allclose(edges["volume_ref"].values, hp._edges["volume"].values)
+    np.testing.assert_allclose(edges["volume_ref"].values, hp._edges["volume"].values, rtol=1e-05, atol=1e-08)
 
     u_i_vec_ref = np.array(
         [
@@ -37,7 +37,7 @@ def test_SF_run_01():
             0.00000000e00,
         ]
     )
-    assert np.allclose(u_i_vec_ref, hp.u_i_vec, rtol=1e-08, atol=1e-08)
+    np.testing.assert_allclose(u_i_vec_ref, hp.u_i_vec, rtol=1e-08, atol=1e-08)
 
 
 def test_SF_assign_01():
@@ -55,7 +55,7 @@ def test_SF_assign_01():
         check_demand=True,
     )
 
-    assert np.allclose(edges["volume_ref"].values, hp._edges["volume"].values)
+    np.testing.assert_allclose(edges["volume_ref"].values, hp._edges["volume"].values, rtol=1e-05, atol=1e-08)
 
 
 def create_SF_network(dwell_time=1.0e-6, board_alight_ratio=0.5):

--- a/tests/test_hyperpath.py
+++ b/tests/test_hyperpath.py
@@ -43,9 +43,7 @@ def test_SF_run_01():
 def test_SF_assign_01():
     edges = create_SF_network(dwell_time=0.0)
     hp = HyperpathGenerating(edges, check_edges=False)
-    od_matrix = pd.DataFrame(
-        data={"origin_vertex_id": [0], "destination_vertex_id": [12], "demand": [1.0]}
-    )
+    od_matrix = pd.DataFrame(data={"origin_vertex_id": [0], "destination_vertex_id": [12], "demand": [1.0]})
 
     hp.assign(
         od_matrix,


### PR DESCRIPTION
An attempt at parallelising the PuT assignment using Cython.

TODO:
- [x] data type mismatches in buffers (should be easy fix)
- [x] Use of `vector` in `compute_SF_in` type signature. ~Need to find a way to construct a memoryview object from a pointer and size without gil~ This has been side stepped by just using pointers the whole time
- [x] Need to accumulate results into single array, currently they are being discarded. Could construct `threads x number of edges` matrix and have `_SF_in_second_pass` optionally accumulate into it, then reduce over that single threaded at the end
- [x] ~Replace initialisation in `compute_SF_in` with `memset`s~ Compiler should be able to optimise the `0.0` sets (look at .cpp output). `memset` isn't applicable to multi-byte values so it cannot be used with `DATATYPE_INF`
- [x] Remove `maybe` prefix (just used to denote old vs new when debugging)