### PR TITLE
Fix multiple classes not being presented in the returned d

### DIFF
--- a/aequilibrae/matrix/aequilibrae_data.py
+++ b/aequilibrae/matrix/aequilibrae_data.py
@@ -106,6 +106,10 @@ class AequilibraeData(object):
             #             raise ValueError('Data types need to be Python or Numpy data types')
 
             for field in self.fields:
+                if not type(field) is str:
+                    raise TypeError(field + " is not a string. You cannot use it as a field name")
+                if not field.isidentifier():
+                    raise Exception(field + " is a not a valid identifier name. You cannot use it as a field name")
                 if field in object.__dict__:
                     raise Exception(field + " is a reserved name. You cannot use it as a field name")
 

--- a/aequilibrae/paths/traffic_assignment.py
+++ b/aequilibrae/paths/traffic_assignment.py
@@ -687,7 +687,7 @@ class TrafficAssignment(object):
         """
         Returns a dataframe of the select link flows for each class
         """
-        sl_flows = None  # stores the df for each class
+        class_flows = []  # stores the df for each class
         for cls in self.classes:
             # Save OD_matrices
             if cls._selected_links is None:
@@ -699,12 +699,8 @@ class TrafficAssignment(object):
             cls_cols = {x: cls.__id__ + "_" + x if (x != "index") else "link_id" for x in df.columns}
             df.rename(columns=cls_cols, inplace=True)
             df.set_index("link_id", inplace=True)
-            if sl_flows is None:
-                sl_flows = df
-            else:
-                sl_flows.join(df)
-        # sl_flows = pd.concat(class_flows, axis=1)
-        return sl_flows
+            class_flows.append(df)
+        return pd.concat(class_flows, axis=1)
 
     def save_select_link_flows(self, table_name: str, project=None) -> None:
         """

--- a/tests/aequilibrae/paths/test_select_link.py
+++ b/tests/aequilibrae/paths/test_select_link.py
@@ -39,6 +39,7 @@ class TestSelectLink(TestCase):
         self.assignment.set_time_field("free_flow_time")
         self.assignment.max_iter = 1
         self.assignment.set_algorithm("msa")
+        self.assignment.set_cores(1)
 
     def tearDown(self) -> None:
         self.matrix.close()

--- a/tests/aequilibrae/paths/test_select_link.py
+++ b/tests/aequilibrae/paths/test_select_link.py
@@ -50,7 +50,7 @@ class TestSelectLink(TestCase):
         Uses two examples: 2 links in one select link, and a single Selected Link
         Checks both the OD Matrix and Link Loading
         """
-        self.assignclass.set_select_links({"9 or 6": [(9, 1), (6, 1)], "just 3": [(3, 1)], "5 for fun": [(5, 1)]})
+        self.assignclass.set_select_links({"sl 9 or 6": [(9, 1), (6, 1)], "just 3": [(3, 1)], "sl 5 for fun": [(5, 1)]})
         self.assignment.execute()
         for key in self.assignclass._selected_links.keys():
             od_mask, link_loading = create_od_mask(
@@ -73,7 +73,7 @@ class TestSelectLink(TestCase):
         Tests to make sure the OD matrix works when all links surrounding one origin are selected
         Confirms the Link Loading is done correctly in this case
         """
-        self.assignclass.set_select_links({"1, 4, 3, and 2": [(1, 1), (4, 1), (3, 1), (2, 1)]})
+        self.assignclass.set_select_links({"sl 1, 4, 3, and 2": [(1, 1), (4, 1), (3, 1), (2, 1)]})
 
         self.assignment.execute()
 
@@ -102,7 +102,7 @@ class TestSelectLink(TestCase):
         self.matrix.matrix_view = custom_demand
         self.assignclass.matrix = self.matrix
 
-        self.assignclass.set_select_links({"39, 66, or 73": [(39, 1), (66, 1), (73, 1)]})
+        self.assignclass.set_select_links({"sl 39, 66, or 73": [(39, 1), (66, 1), (73, 1)]})
 
         self.assignment.execute()
         for key in self.assignclass._selected_links.keys():
@@ -127,7 +127,7 @@ class TestSelectLink(TestCase):
         self.assignment.execute()
         non_sl_loads = self.assignclass.results.get_load_results()
         self.setUp()
-        self.assignclass.set_select_links({"39, 66, or 73": [(39, 1), (66, 1), (73, 1)]})
+        self.assignclass.set_select_links({"sl 39, 66, or 73": [(39, 1), (66, 1), (73, 1)]})
         self.assignment.execute()
         sl_loads = self.assignclass.results.get_load_results()
         np.testing.assert_allclose(non_sl_loads.matrix_tot, sl_loads.matrix_tot)

--- a/tests/aequilibrae/project/test_place_getter.py
+++ b/tests/aequilibrae/project/test_place_getter.py
@@ -15,7 +15,7 @@ class Test(TestCase):
             if place is None:
                 self.skipTest("Skipping... either Vatican City doesn't exist anymore or there was a network failure")
             place = [round(x, 1) for x in place]
-            if place != [12.4, 41.9, 12.5, 41.9]:
+            if place != [12.5, 41.9, 12.5, 41.9]:
                 self.fail("Returned the wrong boundingbox for Vatican City")
 
             place, report = placegetter("Just a random place with no bear in reality")

--- a/tests/aequilibrae/project/test_place_getter.py
+++ b/tests/aequilibrae/project/test_place_getter.py
@@ -15,7 +15,7 @@ class Test(TestCase):
             if place is None:
                 self.skipTest("Skipping... either Vatican City doesn't exist anymore or there was a network failure")
             place = [round(x, 1) for x in place]
-            if place != [12.5, 41.9, 12.5, 41.9]:
+            if place != [12.4, 41.9, 12.5, 41.9]:
                 self.fail("Returned the wrong boundingbox for Vatican City")
 
             place, report = placegetter("Just a random place with no bear in reality")

--- a/tests/aequilibrae/project/test_place_getter.py
+++ b/tests/aequilibrae/project/test_place_getter.py
@@ -12,6 +12,8 @@ class Test(TestCase):
 
         if random() < thresh:
             place, report = placegetter("Vatican City")
+            if place is None:
+                self.skipTest("Skipping... either Vatican City doesn't exist anymore or there was a network failure")
             place = [round(x, 1) for x in place]
             if place != [12.4, 41.9, 12.5, 41.9]:
                 self.fail("Returned the wrong boundingbox for Vatican City")
@@ -20,4 +22,4 @@ class Test(TestCase):
             if place is not None:
                 self.fail("Returned a bounding box for a place that does not exist")
         else:
-            print("Skipped check to not load OSM servers")
+            self.skipTest("Skipped check to not load OSM servers")

--- a/tests/aequilibrae/transit/functions/test_get_table.py
+++ b/tests/aequilibrae/transit/functions/test_get_table.py
@@ -7,7 +7,7 @@ from aequilibrae.utils.list_tables_in_db import list_tables_in_db
 def test_get_table(transit_conn):
     tables = get_table("routes", transit_conn)
 
-    assert type(tables) == pd.DataFrame
+    assert type(tables) is pd.DataFrame
 
 
 def test_list_tables_in_db(transit_conn):

--- a/tests/aequilibrae/transit/test_lib_gtfs.py
+++ b/tests/aequilibrae/transit/test_lib_gtfs.py
@@ -23,7 +23,7 @@ def test_set_capacities(system_builder):
 
 def test_dates_available(system_builder):
     dates = system_builder.dates_available()
-    assert type(dates) == list
+    assert type(dates) is list
 
 
 def test_set_allow_map_match(system_builder):


### PR DESCRIPTION
Found an issue with the accepted field names of AequilibraE data objects as well. Previously it allowed numeric field names and such. Accessing them would raise a syntax error. Its best we don't accept them in the first place.