### PR TITLE
Connector project line string matching

### DIFF
--- a/aequilibrae/paths/AoN.pyx
+++ b/aequilibrae/paths/AoN.pyx
@@ -281,6 +281,11 @@ def path_computation(origin, destination, graph, results):
             del all_nodes
             del all_connectors
             del mileposts
+    else:
+        results.path = None
+        results.path_nodes = None
+        results.path_link_directions = None
+        results.milepost = None
 
 
 def update_path_trace(results, destination, graph):
@@ -322,6 +327,12 @@ def update_path_trace(results, destination, graph):
                 results.path_nodes = graph.all_nodes[np.asarray(all_nodes, graph.default_types('int'))][::-1]
                 mileposts.append(0)
                 results.milepost = np.cumsum(mileposts[::-1])
+        else:
+            results.path = None
+            results.path_nodes = None
+            results.path_link_directions = None
+            results.milepost = None
+
 
 def skimming_single_origin(origin, graph, result, aux_result, curr_thread):
     """

--- a/aequilibrae/project/database_specification/transit/tables/link_types.sql
+++ b/aequilibrae/project/database_specification/transit/tables/link_types.sql
@@ -20,7 +20,8 @@ CREATE TABLE  if not exists link_types (link_type     VARCHAR UNIQUE NOT NULL PR
                                         description   VARCHAR,
                                         lanes         NUMERIC,
                                         lane_capacity NUMERIC,
-                                        speed         NUMERIC);
+                                        speed         NUMERIC
+                                        CHECK(LENGTH(link_type_id) == 1));
 
 --#
 INSERT INTO 'link_types' (link_type, link_type_id, description, lanes, lane_capacity) VALUES('centroid_connector', 'z', 'VIRTUAL centroid connectors only', 10, 10000);

--- a/aequilibrae/project/database_specification/transit/tables/links.sql
+++ b/aequilibrae/project/database_specification/transit/tables/links.sql
@@ -37,7 +37,12 @@ CREATE TABLE  if not exists links (ogc_fid         INTEGER PRIMARY KEY,
                                    o_line_id       TEXT,
                                    d_line_id       TEXT,
                                    transfer_id     TEXT
-                                 );
+                                   CHECK(TYPEOF(link_id) == 'integer')
+                                   CHECK(TYPEOF(a_node) == 'integer')
+                                   CHECK(TYPEOF(b_node) == 'integer')
+                                   CHECK(TYPEOF(direction) == 'integer')
+                                   CHECK(LENGTH(modes)>0)
+                                   CHECK(LENGTH(direction)==1));
 
 --#
 select AddGeometryColumn( 'links', 'geometry', 4326, 'LINESTRING', 'XY', 1);

--- a/aequilibrae/project/database_specification/transit/tables/modes.sql
+++ b/aequilibrae/project/database_specification/transit/tables/modes.sql
@@ -22,7 +22,8 @@ CREATE TABLE if not exists modes (mode_name   VARCHAR UNIQUE NOT NULL,
                                   description VARCHAR,
                                   pce         NUMERIC        NOT NULL DEFAULT 1.0,
                                   vot         NUMERIC        NOT NULL DEFAULT 0,
-                                  ppv         NUMERIC        NOT NULL DEFAULT 1.0);
+                                  ppv         NUMERIC        NOT NULL DEFAULT 1.0
+                                  CHECK(LENGTH(mode_id)==1));
 
 --#
 INSERT INTO 'modes' (mode_name, mode_id, description) VALUES('car', 'c', 'All motorized vehicles');

--- a/aequilibrae/project/database_specification/transit/tables/node_types.sql
+++ b/aequilibrae/project/database_specification/transit/tables/node_types.sql
@@ -19,6 +19,10 @@ INSERT INTO 'node_types' (node_type, node_type_id, description) VALUES('default'
 --#
 INSERT INTO 'node_types' (node_type, node_type_id, description) VALUES('od', 'n', 'Origin/Desination node type');
 --#
+INSERT INTO 'node_types' (node_type, node_type_id, description) VALUES('origin', 'o', 'Origin node type');
+--#
+INSERT INTO 'node_types' (node_type, node_type_id, description) VALUES('destination', 'd', 'Desination node type');
+--#
 INSERT INTO 'node_types' (node_type, node_type_id, description) VALUES('stop', 's', 'Stop node type');
 --#
 INSERT INTO 'node_types' (node_type, node_type_id, description) VALUES('alighting', 'a', 'Alighting node type');

--- a/aequilibrae/project/database_specification/transit/tables/nodes.sql
+++ b/aequilibrae/project/database_specification/transit/tables/nodes.sql
@@ -32,7 +32,11 @@ CREATE TABLE if not exists nodes (ogc_fid      INTEGER PRIMARY KEY,
                                   modes        TEXT,
                                   link_types   TEXT,
                                   node_type    TEXT,
-                                  taz_id       TEXT);
+                                  taz_id       TEXT
+                                  CHECK(TYPEOF(node_id) == 'integer')
+                                  CHECK(TYPEOF(is_centroid) == 'integer')
+                                  CHECK(is_centroid>=0)
+                                  CHECK(is_centroid<=1));
 
 --#
 SELECT AddGeometryColumn( 'nodes', 'geometry', 4326, 'POINT', 'XY', 1);

--- a/aequilibrae/project/database_specification/transit/tables/table_list.txt
+++ b/aequilibrae/project/database_specification/transit/tables/table_list.txt
@@ -14,5 +14,6 @@ routes
 stop_connectors
 stops
 results
+trigger_settings
 trips_schedule
 trips

--- a/aequilibrae/project/database_specification/transit/tables/trigger_settings.sql
+++ b/aequilibrae/project/database_specification/transit/tables/trigger_settings.sql
@@ -3,9 +3,8 @@
 
 
 CREATE TABLE if not exists trigger_settings (name TEXT PRIMARY KEY, enabled INTEGER NOT NULL DEFAULT TRUE);
-
+--#
 INSERT INTO trigger_settings (name, enabled) VALUES('new_link_a_or_b_node', TRUE);
-
 --#
 INSERT INTO 'attributes_documentation' (name_table, attribute, description) VALUES('trigger_settings', 'name', 'name for trigger to query against');
 --#

--- a/aequilibrae/project/database_specification/transit/tables/trigger_settings.sql
+++ b/aequilibrae/project/database_specification/transit/tables/trigger_settings.sql
@@ -1,0 +1,12 @@
+--@ This table intends to allow the enabled and disabling of certain triggers
+--@
+
+
+CREATE TABLE if not exists trigger_settings (name TEXT PRIMARY KEY, enabled INTEGER NOT NULL DEFAULT TRUE);
+
+INSERT INTO trigger_settings (name, enabled) VALUES('new_link_a_or_b_node', TRUE);
+
+--#
+INSERT INTO 'attributes_documentation' (name_table, attribute, description) VALUES('trigger_settings', 'name', 'name for trigger to query against');
+--#
+INSERT INTO 'attributes_documentation' (name_table, attribute, description) VALUES('trigger_settings', 'enabled', 'boolean value');

--- a/aequilibrae/project/database_specification/transit/triggers/link_type_table_triggers.sql
+++ b/aequilibrae/project/database_specification/transit/triggers/link_type_table_triggers.sql
@@ -1,24 +1,3 @@
--- Guarantees that the link_type records have a single letter for link_type_id
-
-CREATE TRIGGER link_type_single_letter_update BEFORE UPDATE OF link_type_id ON "link_types"
-WHEN
-    length(new.link_type_id)!= 1
-BEGIN
-    SELECT RAISE(ABORT, 'Link_type_id need to be a single letter');
-END;
-
---#
--- Guarantees that the link_type_id field is exactly 1 character long
-
-CREATE TRIGGER link_type_single_letter_insert BEFORE INSERT ON "link_types"
-WHEN
-    length(new.link_type_id)!= 1
-BEGIN
-    SELECT RAISE(ABORT, 'Link_type_id need to be a single letter');
-END;
-
---#
-
 -- Prevents a link_type record to be changed when it is in use for any link
 
 CREATE TRIGGER link_type_keep_if_in_use_updating BEFORE UPDATE OF link_type ON "link_types"

--- a/aequilibrae/project/database_specification/transit/triggers/network_triggers.sql
+++ b/aequilibrae/project/database_specification/transit/triggers/network_triggers.sql
@@ -33,7 +33,7 @@ create INDEX IF NOT EXISTS nodes_node_id ON nodes (node_id);
 
 --#
 create trigger new_link_a_node before insert on links
-  when
+  when (SELECT enabled FROM trigger_settings where name = 'new_link_a_or_b_node') = TRUE AND
     (SELECT count(*)
     FROM nodes
     WHERE nodes.geometry = StartPoint(new.geometry) AND
@@ -48,7 +48,7 @@ create trigger new_link_a_node before insert on links
   END;
 --#
 create trigger new_link_b_node before insert on links
-  when
+  when (SELECT enabled FROM trigger_settings where name = 'new_link_a_or_b_node') = TRUE AND
     (SELECT count(*)
     FROM nodes
     WHERE nodes.geometry = EndPoint(new.geometry) AND
@@ -65,7 +65,7 @@ create trigger new_link_b_node before insert on links
 -- we use a before ordering here, as it is the only way to guarantee this will run before the nodeid update trigger.
 -- when inserting a link endpoint to empty space, create a new node
 create trigger update_link_a_node before update of geometry on links
-  when
+  when (SELECT enabled FROM trigger_settings where name = 'new_link_a_or_b_node') = TRUE AND
     (SELECT count(*)
     FROM nodes
     WHERE nodes.geometry = StartPoint(new.geometry) AND
@@ -80,7 +80,7 @@ create trigger update_link_a_node before update of geometry on links
   END;
 --#
 create trigger update_link_b_node before update of geometry on links
-  when
+  when (SELECT enabled FROM trigger_settings where name = 'new_link_a_or_b_node') = TRUE AND
     (SELECT count(*)
     FROM nodes
     WHERE nodes.geometry = EndPoint(new.geometry) AND
@@ -95,7 +95,7 @@ create trigger update_link_b_node before update of geometry on links
   END;
 --#
   
-create trigger new_link after insert on links
+create trigger new_link insert on links
   begin
     -- Update a/b_node AFTER creating a link.
     update links

--- a/aequilibrae/project/database_specification/transit/triggers/network_triggers.sql
+++ b/aequilibrae/project/database_specification/transit/triggers/network_triggers.sql
@@ -96,6 +96,7 @@ create trigger update_link_b_node before update of geometry on links
 --#
   
 create trigger new_link insert on links
+  when (SELECT enabled FROM trigger_settings where name = 'new_link_a_or_b_node') = TRUE
   begin
     -- Update a/b_node AFTER creating a link.
     update links

--- a/aequilibrae/transit/parse_csv.py
+++ b/aequilibrae/transit/parse_csv.py
@@ -53,11 +53,10 @@ def parse_csv(file_name: str, column_order=[]):
         new_data_dt = [(f, column_order[f]) for f in col_names]
 
         if int(data.shape.__len__()) > 0:
-            
             # handle the case of int data given as a float string
             for j, (_, dtype) in enumerate(new_data_dt):
                 if dtype == int:
-                    for item in data: 
+                    for item in data:
                         item[j] = item[j].split(".")[0]
 
             return np.array(data, dtype=new_data_dt)

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -9,7 +9,7 @@ import pyproj
 import shapely
 import shapely.ops
 from aequilibrae.utils.geo_utils import haversine
-from scipy.spatial import cKDTree, minkowski_distance
+from scipy.spatial import KDTree, minkowski_distance
 from shapely.geometry import Point
 
 SF_VERTEX_COLS = ["node_id", "node_type", "stop_id", "line_id", "line_seg_idx", "taz_id", "geometry"]
@@ -694,7 +694,7 @@ class SF_graph_builder:
         )
         stop_geometries = np.array(list(stop_geometries.apply(lambda geometry: (geometry.x, geometry.y))))
 
-        kdTree = cKDTree(od_geometries)
+        kdTree = KDTree(od_geometries)
 
         if method == "nearest_neighbour":
             # query the kdTree for the closest (k=1) od for each stop in parallel (workers=-1)
@@ -722,7 +722,7 @@ class SF_graph_builder:
             distance = distance.reshape(-1)
 
             # Construct a kdtree so we can query all the stops within the radius around each OD
-            stop_kdTree = cKDTree(stop_geometries)
+            stop_kdTree = KDTree(stop_geometries)
             results = stop_kdTree.query_ball_point(od_geometries, distance, workers=self.num_threads)
 
             # access connectors


### PR DESCRIPTION
This PR adds project matching for the line strings of the access and egress connectors.

It takes the start and end of the edge, finds the closest nodes within the existing project then computes the shortest path between those nodes and constructs the relevant line string. This can be used to provide more accurate travel time computation and visually appealing results.

TODO:
- [x] Use the more accurate travel time from `line.length / self.walking_speed * self.(access|egress)_time_factor`
- [x] Test on a real network. This code is not tested in its entirety, only on a toy example separate from the rest of the graph building.
- [x] The code currently assumes the project graph has already been initialised correctly and distance is a valid metric. This might end to be improved UX wise.

Note: this does not find the shortest path between the edge ends as visible in the image below.
![connectors](https://github.com/AequilibraE/aequilibrae/assets/49361082/16ae3b94-9b41-4dc1-bbdb-2fd430fdb758)
