### PR TITLE
Better import from OSM and description of bicycle & bus data in network

### DIFF
--- a/aequilibrae/parameters.yml
+++ b/aequilibrae/parameters.yml
@@ -42,6 +42,30 @@ network:
           description: name
           osm_source: name
           type: text
+      - cycleway:
+          description: cycleway, both way
+          osm_source: cycleway
+          type: text
+      - cycleway_right:
+          description: cycleway, right
+          osm_source: cycleway:right
+          type: text
+      - cycleway_left:
+          description: cycleway, left
+          osm_source: cycleway:left
+          type: text
+      - busway:
+          description: busway
+          osm_source: busway
+          type: text
+      - busway_right:
+          description: busway, right
+          osm_source: busway:right
+          type: text
+      - busway_left:
+          description: busway, left
+          osm_source: busway:left
+          type: text            
       two-way:
       - lanes:
           description: lanes
@@ -128,6 +152,14 @@ network:
     modes:
       bicycle:
         link_types:
+        - primary
+        - primary_link
+        - secondary
+        - secondary_link
+        - tertiary
+        - tertiary_link
+        - living_street
+        - residential
         - cycleway
         - corridor
         - pedestrian
@@ -313,7 +345,7 @@ network:
           required: false
         lanes:
           description: Number of lanes in the direction of travel
-          type: inetger
+          type: integer
           required: false
         bike_facility:
           description: Type of bicycle accommodation


### PR DESCRIPTION
Parameters file is a bit hidden/tricky to use for qaequilibrae users, this should help them for a better default OSM import which keep data for bus and bicycle Have keep the same structure as OSM but this result in 3 fields for each one (3 for bicycle and 3 for bus).

Maybe we can think of a way to achieve only one field for bicycle and one for bus ? Might not so easy because of the number of combinations available in OSM, example : https://wiki.openstreetmap.org/wiki/Key:cycleway