### PR TITLE
Early exit Dijsktra's with path reuse

### DIFF
--- a/aequilibrae/paths/AoN.pyx
+++ b/aequilibrae/paths/AoN.pyx
@@ -314,7 +314,7 @@ def update_path_trace(results, destination, graph, early_exit = False):
 
         # If the predecessor is -1 and early exit was enabled we cannot differentiate between
         # an unreachable node and one we just didn't see yet. We need to recompute the tree with the new destination
-        if results.predecessors[dest_index] == -1 and results.early_exit:
+        if results.predecessors[dest_index] == -1 and results._early_exit:
             results.compute_path(results.origin, destination, early_exit=early_exit)
 
         # By the invariant hypothesis presented at https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Proof_of_correctness

--- a/aequilibrae/paths/results/path_results.py
+++ b/aequilibrae/paths/results/path_results.py
@@ -69,6 +69,7 @@ class PathResults:
         self.__float_type = None
         self.__graph_id__ = None
         self.__graph_sum = None
+        self._early_exit = self.early_exit
 
     def compute_path(self, origin: int, destination: int, early_exit: bool = False) -> None:
         """
@@ -86,7 +87,7 @@ class PathResults:
         if self.graph is None:
             raise Exception("You need to set graph skimming before you compute a path")
 
-        self.early_exit = early_exit
+        self.early_exit = self._early_exit = early_exit
         path_computation(origin, destination, self.graph, self, early_exit)
         if self.graph.skim_fields:
             self.skims.fill(np.inf)
@@ -145,7 +146,7 @@ class PathResults:
         else:
             raise ValueError("Exception: Path results object was not yet prepared/initialized")
 
-    def update_trace(self, destination: int, early_exit: bool = False) -> None:
+    def update_trace(self, destination: int) -> None:
         """
         Updates the path's nodes, links, skims and mileposts
 
@@ -165,4 +166,4 @@ class PathResults:
         if destination >= self.graph.nodes_to_indices.shape[0]:
             raise ValueError("destination out of the range of node numbers in the graph")
 
-        update_path_trace(self, destination, self.graph, early_exit)
+        update_path_trace(self, destination, self.graph, self.early_exit)

--- a/tests/aequilibrae/paths/test_pathResults.py
+++ b/tests/aequilibrae/paths/test_pathResults.py
@@ -189,7 +189,8 @@ class TestBlockingTrianglePathResults(TestCase):
         )
 
         # Updating to 2 should cause the recomputation of the tree
-        self.r.update_trace(2, early_exit=True)
+        self.r.early_exit = True
+        self.r.update_trace(2)
         self.assertEqual(list(self.r.path_nodes), [1, 3, 2])
         self.assertEqual(list(self.r.path), [1, 2])
 
@@ -203,7 +204,8 @@ class TestBlockingTrianglePathResults(TestCase):
         self.r.compute_path(1, 6, early_exit=True)
 
         # Updating to 2 should cause the recomputation of the tree
-        self.r.update_trace(2, early_exit=False)
+        self.r.early_exit = False
+        self.r.update_trace(2)
         self.assertEqual(list(self.r.path_nodes), [1, 3, 2])
         self.assertEqual(list(self.r.path), [1, 2])
 


### PR DESCRIPTION
Add a disabled by default option to exit once a destination is found in `path_finding` to  `compute_path` and `update_trace`.

If a partial shortest path tree is computed, `update_trace` will check if the new destination has already been found within that tree, if it isn't it will recompute the necessary tree. It does this by marking the un-scanned nodes as unreachable upon exit, then if the new destination is unreachable and the tree is partial, the tree must be recomputed. Otherwise we are free to reuse the existing tree.

I've added some tests that check the partial trees of the triangle example against what I worked out by hand.

I've also tested this as a default *on* option and all tests still pass.