### PR TITLE
Include LICENSE.TXT in wheel and source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 global-include *.pyx
 global-include *.pxd
+include README.md
+include LICENSE.TXT

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,8 @@ if __name__ == "__main__":
         author="Pedro Camargo",
         author_email="c@margo.co",
         url="https://github.com/AequilibraE/aequilibrae",
-        license="See license.txt",
+        license="See LICENSE.TXT",
+        license_files=('LICENSE.TXT',),
         classifiers=[
             "Programming Language :: Python",
             "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
         author_email="c@margo.co",
         url="https://github.com/AequilibraE/aequilibrae",
         license="See LICENSE.TXT",
-        license_files=('LICENSE.TXT',),
+        license_files=("LICENSE.TXT",),
         classifiers=[
             "Programming Language :: Python",
             "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
This hopefully fixes the failing CI for Conda forge. Not sure why it didn't fail months ago but is now. Unfortunately this requires a new release to fix