### PR TITLE
Fixes documentation version switcher button

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -5,12 +5,6 @@
         "url": "https://aequilibrae.com/python/develop/"
     },
     {
-        "name": "stable",
-        "version": "1.0.1",
-        "url": "https://aequilibrae.com/python/V.1.0.1/",
-        "preferred": true
-    },
-    {
         "name": "1.0.2",
         "version": "1.0.2",
         "url": "https://aequilibrae.com/python/V.1.0.2/"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,7 +132,7 @@ html_theme_options = {
     "navbar_start": ["navbar-logo"],
     "navbar_align": "left",
     "switcher": {
-        "json_url": "https://www.aequilibrae.com/python/latest/_static/switcher.json",
+        "json_url": "_static/switcher.json",
         "version_match": switcher_version,
     },
     # "check_switcher": False,


### PR DESCRIPTION
In this PR we set the path to the switcher button to be a file, rather than a link, as it was working on previous versions of AequilibraE documentation. 