### PR TITLE
Modifies links selected for discount in GTFS

### DIFF
--- a/aequilibrae/transit/gtfs_loader.py
+++ b/aequilibrae/transit/gtfs_loader.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 import hashlib
-import logging
 import zipfile
 from copy import deepcopy
 from os.path import splitext, basename
@@ -13,6 +12,7 @@ import pyproj
 from pyproj import Transformer
 from shapely.geometry import LineString
 
+from aequilibrae.context import get_logger
 from aequilibrae.transit.constants import AGENCY_MULTIPLIER
 from aequilibrae.transit.functions.get_srid import get_srid
 from aequilibrae.transit.column_order import column_order
@@ -40,8 +40,6 @@ class GTFSReader(WorkerThread):
 
     signal = SignalImpl(object)
 
-    logger = logging.getLogger("GTFS Reader")
-
     def __init__(self):
         WorkerThread.__init__(self, None)
         self.__capacities__ = {}
@@ -63,6 +61,7 @@ class GTFSReader(WorkerThread):
         self.srid = get_srid()
         self.transformer = Transformer.from_crs("epsg:4326", f"epsg:{self.srid}", always_xy=False)
         self.__mt = ""
+        self.logger = get_logger()
 
     def set_feed_path(self, file_path):
         """Sets GTFS feed source to be used

--- a/aequilibrae/transit/gtfs_loader.py
+++ b/aequilibrae/transit/gtfs_loader.py
@@ -278,7 +278,7 @@ class GTFSReader(WorkerThread):
             self.signal.emit(["update", "secondary", i + 1, msg_txt, self.__mt])
             items = shapes[shapes["shape_id"] == shape_id]
             items = items[np.argsort(items["shape_pt_sequence"])]
-            shape = LineString(list(zip(items["shape_pt_lon"], items["shape_pt_lat"])))
+            shape = LineString(list(zip(items["shape_pt_lat"], items["shape_pt_lon"])))
             self.shapes[shape_id] = shape
 
     def __load_trips_table(self):

--- a/aequilibrae/transit/gtfs_loader.py
+++ b/aequilibrae/transit/gtfs_loader.py
@@ -271,14 +271,14 @@ class GTFSReader(WorkerThread):
         self.signal.emit(["start", "secondary", len(all_shape_ids), msg_txt, self.__mt])
 
         self.data_arrays[shapestxt] = shapes
-        lons, lats = self.transformer.transform(shapes[:]["shape_pt_lat"], shapes[:]["shape_pt_lon"])
+        lats, lons = self.transformer.transform(shapes[:]["shape_pt_lat"], shapes[:]["shape_pt_lon"])
         shapes[:]["shape_pt_lat"][:] = lats[:]
         shapes[:]["shape_pt_lon"][:] = lons[:]
         for i, shape_id in enumerate(all_shape_ids):
             self.signal.emit(["update", "secondary", i + 1, msg_txt, self.__mt])
             items = shapes[shapes["shape_id"] == shape_id]
             items = items[np.argsort(items["shape_pt_sequence"])]
-            shape = LineString(list(zip(items["shape_pt_lat"], items["shape_pt_lon"])))
+            shape = LineString(list(zip(items["shape_pt_lon"], items["shape_pt_lat"])))
             self.shapes[shape_id] = shape
 
     def __load_trips_table(self):

--- a/aequilibrae/transit/gtfs_loader.py
+++ b/aequilibrae/transit/gtfs_loader.py
@@ -114,9 +114,9 @@ class GTFSReader(WorkerThread):
         self.__load_routes_table()
         self.__load_stops_table()
         self.__load_stop_times()
+        self.__load_shapes_table()
         self.__load_trips_table()
         self.__deconflict_stop_times()
-        self.__load_shapes_table()
         self.__load_fare_data()
 
         self.zip_archive.close()
@@ -346,7 +346,7 @@ class GTFSReader(WorkerThread):
                 trip.source_time = list(stop_times.source_time.values)
                 self.logger.debug(f"{trip.trip} has {len(trip.stops)} stops")
                 trip._stop_based_shape = LineString([self.stops[x].geo for x in trip.stops])
-                trip.shape = self.shapes.get(trip.shape)
+                # trip.shape = self.shapes.get(trip.shape)
                 trip.seated_capacity = self.routes[trip.route].seated_capacity
                 trip.total_capacity = self.routes[trip.route].total_capacity
                 self.trips[trip.route] = self.trips.get(trip.route, {})
@@ -454,7 +454,7 @@ class GTFSReader(WorkerThread):
         self.data_arrays[stopstxt] = stops
 
         if np.unique(stops["stop_id"]).shape[0] < stops.shape[0]:
-            self.__fail("There are repeated Stop IDs in stops.txt")
+            self.__fail("There are repeated stop IDs in stops.txt")
 
         lats, lons = self.transformer.transform(stops[:]["stop_lat"], stops[:]["stop_lon"])
         stops[:]["stop_lat"][:] = lats[:]

--- a/aequilibrae/transit/lib_gtfs.py
+++ b/aequilibrae/transit/lib_gtfs.py
@@ -7,8 +7,7 @@ import pyproj
 from pyproj import Transformer
 from shapely.geometry import Point, MultiLineString
 
-from aequilibrae.context import get_active_project
-from aequilibrae.log import logger
+from aequilibrae.context import get_active_project, get_logger
 from aequilibrae.project.database_connection import database_connection
 from aequilibrae.transit.constants import Constants, PATTERN_ID_MULTIPLIER
 from aequilibrae.transit.functions.get_srid import get_srid
@@ -38,7 +37,7 @@ class GTFSRouteSystemBuilder(WorkerThread):
         self.project = get_active_project(False)
         self.archive_dir = None  # type: str
         self.day = day
-        self.logger = logger
+        self.logger = get_logger()
         self.gtfs_data = GTFSReader()
 
         self.srid = get_srid()

--- a/aequilibrae/transit/lib_gtfs.py
+++ b/aequilibrae/transit/lib_gtfs.py
@@ -70,11 +70,6 @@ class GTFSRouteSystemBuilder(WorkerThread):
 
         links = self.project.network.links.data
         self.geo_links = gpd.GeoDataFrame(links, geometry=links.geometry, crs="EPSG:4326")
-        self.reprojected_links = self.geo_links.to_crs(3857)
-        self.reprojected_links["repr_length"] = self.reprojected_links["geometry"].length
-        # Approximately 40 meter buffer
-        # buff_geo = self.geo_links.to_crs(3857).buffer(40).geometry
-        # self.geo_links_buffer = gpd.GeoDataFrame(links, geometry=buff_geo.to_crs(4326), crs="EPSG:4326")
 
     def set_capacities(self, capacities: dict):
         """Sets default capacities for modes/vehicles.

--- a/aequilibrae/transit/lib_gtfs.py
+++ b/aequilibrae/transit/lib_gtfs.py
@@ -70,9 +70,11 @@ class GTFSRouteSystemBuilder(WorkerThread):
 
         links = self.project.network.links.data
         self.geo_links = gpd.GeoDataFrame(links, geometry=links.geometry, crs="EPSG:4326")
+        self.reprojected_links = self.geo_links.to_crs(3857)
+        self.reprojected_links["repr_length"] = self.reprojected_links["geometry"].length
         # Approximately 40 meter buffer
-        buff_geo = self.geo_links.to_crs(3857).buffer(40).geometry
-        self.geo_links_buffer = gpd.GeoDataFrame(links, geometry=buff_geo.to_crs(4326), crs="EPSG:4326")
+        # buff_geo = self.geo_links.to_crs(3857).buffer(40).geometry
+        # self.geo_links_buffer = gpd.GeoDataFrame(links, geometry=buff_geo.to_crs(4326), crs="EPSG:4326")
 
     def set_capacities(self, capacities: dict):
         """Sets default capacities for modes/vehicles.

--- a/aequilibrae/transit/map_matching_graph.py
+++ b/aequilibrae/transit/map_matching_graph.py
@@ -106,7 +106,7 @@ class MMGraph(WorkerThread):
         centroids = np.copy(centroid_corresp.centroid_id.values)
         centroid_corresp.set_index("node_id", inplace=True)
         for stop in self.stops.values():
-            stop.___map_matching_id__[self.mode_id] = centroid_corresp.loc[stop.stop_id, "centroid_id"]
+            stop.__map_matching_id__[self.mode_id] = centroid_corresp.loc[stop.stop_id, "centroid_id"]
         return self.__graph_from_broken_net(centroids, net)
 
     def __build_graph_from_scratch(self):
@@ -128,9 +128,9 @@ class MMGraph(WorkerThread):
         self.df = self.df.assign(direction=1, free_flow_time=np.inf, wrong_side=0, closest=1, to_remove=0)
         self.__all_links = {rec.link_id: rec for _, rec in self.df.iterrows()}
         for counter, (stop_id, stop) in enumerate(self.stops.items()):
-            stop.___map_matching_id__[self.mode_id] = self.max_node_id
+            stop.__map_matching_id__[self.mode_id] = self.max_node_id
             self.node_corresp.append([stop_id, self.max_node_id])
-            centroids.append(stop.___map_matching_id__[self.mode_id])
+            centroids.append(stop.__map_matching_id__[self.mode_id])
             self.max_node_id += 1
             self.connect_node(stop)
         self.df = pd.concat([pd.DataFrame(rec).transpose() for rec in self.__all_links.values()])
@@ -245,7 +245,7 @@ class MMGraph(WorkerThread):
             connector = deepcopy(link)
             connector.link_id = self.max_link_id
             connector.original_id = -1
-            connector.a_node = stop.___map_matching_id__[self.mode_id]
+            connector.a_node = stop.__map_matching_id__[self.mode_id]
             connector.b_node = intersec_node
             connector.wrong_side = wrong_side
             connector.direction = 0

--- a/aequilibrae/transit/transit_elements/pattern.py
+++ b/aequilibrae/transit/transit_elements/pattern.py
@@ -158,7 +158,8 @@ class Pattern(BasicPTElement):
         logger.info(f"Map-matched pattern {self.pattern_id}")
 
     def __graph_discount(self, connected_stops):
-        gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries([stop.geo for stop in connected_stops], crs=self.__geolinks.crs))
+        geom = [stop.geo for stop in connected_stops] if self.raw_shape is None else [self.raw_shape]
+        gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries(geom, crs=self.__geolinks.crs))
         gdf = self.__geolinks_buffer.sjoin(gdf, how="inner", predicate="intersects")
 
         gdf = gdf[gdf.modes.str.contains(mode_correspondence[self.route_type])]

--- a/aequilibrae/transit/transit_elements/pattern.py
+++ b/aequilibrae/transit/transit_elements/pattern.py
@@ -112,7 +112,7 @@ class Pattern(BasicPTElement):
     def best_shape(self) -> LineString:
         """Gets the best version of shape available for this pattern"""
         shp = self._stop_based_shape if self.raw_shape is None else self.raw_shape
-        shp = shp if self.shape is None else self.shape
+        # shp = shp if self.shape is None else self.shape
         return shp
 
     def map_match(self):

--- a/aequilibrae/transit/transit_elements/pattern.py
+++ b/aequilibrae/transit/transit_elements/pattern.py
@@ -109,6 +109,7 @@ class Pattern(BasicPTElement):
         if commit:
             conn.commit()
 
+    # TODO: reuse maybe?
     def best_shape(self) -> LineString:
         """Gets the best version of shape available for this pattern"""
         shp = self._stop_based_shape if self.raw_shape is None else self.raw_shape
@@ -171,7 +172,7 @@ class Pattern(BasicPTElement):
 
         # We search for disconnected stops:
         candidate_stops = list(self.stops)
-        stop_node_idxs = [stop.___map_matching_id__[self.route_type] for stop in candidate_stops]
+        stop_node_idxs = [stop.__map_matching_id__[self.route_type] for stop in candidate_stops]
 
         node0 = graph.network.a_node[~graph.network.a_node.isin(graph.centroids)].min()
         connected_stops = []
@@ -182,7 +183,7 @@ class Pattern(BasicPTElement):
         res1.prepare(graph)
 
         for i, stop in enumerate(candidate_stops):
-            node_o = stop.___map_matching_id__[self.route_type]
+            node_o = stop.__map_matching_id__[self.route_type]
             logger.debug(f"Computing paths between {node_o} and {node0}")
             res.compute_path(node_o, int(node0), early_exit=False)
             # Get skims, as proxy for connectivity, for all stops other than the origin
@@ -208,9 +209,9 @@ class Pattern(BasicPTElement):
             return empty_frame
 
         if len(connected_stops) == 2:
-            nstop = connected_stops[1].___map_matching_id__[self.route_type]
-            logger.debug(f"Computing paths between {fstop.___map_matching_id__[self.route_type]} and {nstop}")
-            res.compute_path(fstop.___map_matching_id__[self.route_type], int(nstop), early_exit=True)
+            nstop = connected_stops[1].__map_matching_id__[self.route_type]
+            logger.debug(f"Computing paths between {fstop.__map_matching_id__[self.route_type]} and {nstop}")
+            res.compute_path(fstop.__map_matching_id__[self.route_type], int(nstop), early_exit=True)
             if res.milepost is None:
                 return empty_frame
             pdist = list(res.milepost[1:-1] - res.milepost[:-2])[1:]
@@ -221,15 +222,15 @@ class Pattern(BasicPTElement):
         path_links = []
         path_directions = []
         path_distances = []
-        start = fstop.___map_matching_id__[self.route_type]
+        start = fstop.__map_matching_id__[self.route_type]
         for idx, tstop in enumerate(connected_stops[1:]):
-            end = tstop.___map_matching_id__[self.route_type]
+            end = tstop.__map_matching_id__[self.route_type]
 
             not_last = idx + 2 <= len(connected_stops) - 1
 
             if not_last:
                 following_stop = connected_stops[idx + 2]
-                n_end = following_stop.___map_matching_id__[self.route_type]
+                n_end = following_stop.__map_matching_id__[self.route_type]
             logger.debug(f"Computing paths between {start} and {end}")
             res.compute_path(start, int(end), early_exit=True)
             connection_candidates = graph.network[graph.network.a_node == end].b_node.values

--- a/aequilibrae/transit/transit_elements/pattern.py
+++ b/aequilibrae/transit/transit_elements/pattern.py
@@ -162,7 +162,7 @@ class Pattern(BasicPTElement):
         gdf = self.__reprojected_links.overlay(gdf, how="intersection")
 
         gdf = gdf[gdf.modes.str.contains(mode_correspondence[self.route_type])]
-        gdf.loc[:, "intersect"] = 1/(gdf["geometry"].length / gdf["repr_length"])
+        gdf.loc[:, "intersect"] = 1 / (gdf["geometry"].length / gdf["repr_length"])
         return gdf
 
     def __map_matching_complete_path_building(self):
@@ -207,7 +207,7 @@ class Pattern(BasicPTElement):
         g = graph.graph[links_in_graph]
         g.loc[:, "abs_id"] = g["original_id"].abs()
         g = g.merge(likely_links[["link_id", "intersect"]], left_on="abs_id", right_on="link_id")
-        graph.cost[links_in_graph] *= (g["intersect"] * 0.1)
+        graph.cost[links_in_graph] *= g["intersect"] * 0.1
 
         fstop = connected_stops[0]
 

--- a/aequilibrae/transit/transit_elements/stop.py
+++ b/aequilibrae/transit/transit_elements/stop.py
@@ -37,7 +37,7 @@ class Stop(BasicPTElement):
         self.srid = -1
         self.geo: Optional[Point] = None
         self.route_type: Optional[int] = None
-        self.___map_matching_id__: Dict[Any, Any] = {}
+        self.__map_matching_id__: Dict[Any, Any] = {}
         self.__moved_map_matching__ = 0
 
         for key, value in zip(headers, record):

--- a/tests/aequilibrae/transit/test_pattern.py
+++ b/tests/aequilibrae/transit/test_pattern.py
@@ -6,9 +6,7 @@ import os
 def pat(create_path, create_gtfs_project):
     gtfs_fldr = os.path.join(create_path, "gtfs_coquimbo.zip")
 
-    transit = create_gtfs_project.new_gtfs_builder(
-        agency="LISERCO, LISANCO, LINCOSUR", file_path=gtfs_fldr, description=""
-    )
+    transit = create_gtfs_project.new_gtfs_builder(agency="Lisanco", file_path=gtfs_fldr, description="")
     transit.load_date("2016-04-13")
 
     patterns = transit.select_patterns
@@ -24,7 +22,9 @@ def test_save_to_database(pat, transit_conn):
 
 def test_best_shape(pat):
     shp = pat.best_shape()
-    assert shp == pat._stop_based_shape, "Returned the wrong shape"
+
+    # shp and pat._stop_based_shape must be different because there is a shape.txt file in the gtfs.
+    assert shp != pat._stop_based_shape, "Returned the wrong shape"
 
 
 def test_get_error(pat):


### PR DESCRIPTION
This PR:

* modifies the link selection for discounts when building GTFS routes. We select links using the route shapes and the link overlay: case the route fully encloses the link, the link has a bigger discount.
* renames the variable \_\_map_matching_id__ to have only two underscores in the name.
* fixes logging information in the Transit module - info, debug, and warnings are now displayed in the project aequilibrae.log file.