### PR TITLE
Route choice select link AND sets

### DIFF
--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -392,8 +392,9 @@ class RouteChoice:
 
             or_set = set()
             for link_ids in link_set:
-                # Allow a single int to represent a bidirectional single link AND set
-                if isinstance(link_ids, int):
+                # Allow a single int to represent a bidirectional single link AND set. For compatibility, a tuple of
+                # length 2 is passed, we assume that's a single (link, dir) pair
+                if isinstance(link_ids, int) or (isinstance(link_ids, tuple) and len(link_ids) == 2):
                     link_ids = (link_ids,)
 
                 and_set = set()

--- a/aequilibrae/paths/route_choice_set.pxd
+++ b/aequilibrae/paths/route_choice_set.pxd
@@ -253,13 +253,15 @@ cdef class RouteChoiceSet:
         RouteChoiceSet self,
         COO sparse_mat,
         double[:, :] matrix_view,
-        LinkSet_t &select_link_set
+        vector[unordered_set[long long] *] &select_link_set,
+        vector[size_t] select_link_set_lengths
     ) noexcept nogil
 
     @staticmethod
     cdef bool is_in_select_link(
         vector[long long] &route,
-        LinkSet_t &select_link_set
+        vector[unordered_set[long long] *] &select_link_set,
+        vector[size_t] &select_link_set_lengths
     ) noexcept nogil
 
     cdef shared_ptr[libpa.CTable] make_table_from_results(

--- a/aequilibrae/paths/route_choice_set.pxd
+++ b/aequilibrae/paths/route_choice_set.pxd
@@ -253,7 +253,13 @@ cdef class RouteChoiceSet:
         RouteChoiceSet self,
         COO sparse_mat,
         double[:, :] matrix_view,
-        unordered_set[long] &select_link_set
+        LinkSet_t &select_link_set
+    ) noexcept nogil
+
+    @staticmethod
+    cdef bool is_in_select_link(
+        vector[long long] &route,
+        LinkSet_t &select_link_set
     ) noexcept nogil
 
     cdef shared_ptr[libpa.CTable] make_table_from_results(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''docs/*'''
 


### PR DESCRIPTION
This PR implements AND sets for the route choice select link. Previously we've only had OR sets available to us.
TODO:
- [ ] Update docs
- [ ] Update tests, there was change to the link, loading interface here
- [ ] Add new tests
- [ ] Fix the """smart""" input parsing. If no direction is supplied it currently assumes both directions were meant, however in the AND sets this means there will never be any flow as it will never use both directions of the same link.
- [X] Implementation