### PR TITLE
avoids division by zero in Cython

### DIFF
--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -21,14 +21,14 @@ from aequilibrae.paths.route_choice_set import RouteChoiceSet
 class RouteChoice:
     all_algorithms = ["bfsle", "lp", "link-penalisation", "link-penalization"]
 
-    default_paramaters = {
-        "generic": {"seed": 0, "max_routes": 0, "max_depth": 0, "max_misses": 100, "penalty": 1.01, "cutoff_prob": 0.0},
+    default_parameters = {
+        "generic": {"seed": 0, "max_routes": 0, "max_depth": 0, "max_misses": 100, "penalty": 1.01, "cutoff_prob": 0.0, "beta": 1.0},
         "link-penalisation": {},
         "bfsle": {"penalty": 1.0},
     }
 
     def __init__(self, graph: Graph, matrix: Optional[AequilibraeMatrix] = None, project=None):
-        self.parameters = self.default_paramaters.copy()
+        self.parameters = self.default_parameters.copy()
         self.procedure_id = None
         self.procedure_date = None
 
@@ -120,7 +120,7 @@ class RouteChoice:
         if algo is None:
             raise AttributeError(f"Assignment algorithm not available. Choose from: {','.join(self.all_algorithms)}")
 
-        defaults = self.default_paramaters["generic"] | self.default_paramaters[algo]
+        defaults = self.default_parameters["generic"] | self.default_parameters[algo]
         for key in kwargs.keys():
             if key not in defaults:
                 raise ValueError(f"Invalid parameter `{key}` provided for algorithm `{algo}`")

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -22,7 +22,15 @@ class RouteChoice:
     all_algorithms = ["bfsle", "lp", "link-penalisation", "link-penalization"]
 
     default_parameters = {
-        "generic": {"seed": 0, "max_routes": 0, "max_depth": 0, "max_misses": 100, "penalty": 1.01, "cutoff_prob": 0.0, "beta": 1.0},
+        "generic": {
+            "seed": 0,
+            "max_routes": 0,
+            "max_depth": 0,
+            "max_misses": 100,
+            "penalty": 1.01,
+            "cutoff_prob": 0.0,
+            "beta": 1.0,
+        },
         "link-penalisation": {},
         "bfsle": {"penalty": 1.0},
     }

--- a/aequilibrae/paths/route_choice_set.pxd
+++ b/aequilibrae/paths/route_choice_set.pxd
@@ -217,7 +217,7 @@ cdef class RouteChoiceSet:
     cdef vector[double] *compute_cost(RouteSet_t *route_sets, double[:] cost_view) noexcept nogil
 
     @staticmethod
-    cdef vector[bool] *compute_mask(double cutoff_prob, vector[double] &total_cost) noexcept nogil
+    cdef vector[bool] *compute_mask(double cutoff_prob, vector[double] &total_cost, long long origin, long long dest) noexcept nogil
 
     @staticmethod
     cdef vector[double] *compute_path_overlap(

--- a/aequilibrae/paths/route_choice_set.pyx
+++ b/aequilibrae/paths/route_choice_set.pyx
@@ -400,11 +400,12 @@ cdef class RouteChoiceSet:
                 mask_set.resize(batch_len)
                 path_overlap_set.resize(batch_len)
                 prob_set.resize(batch_len)
-
             with nogil, parallel(num_threads=c_cores):
-                for i in prange(batch_len, schedule= "dynamic", chunksize=1):
+                for i in prange(batch_len):
                     origin_index = self.nodes_to_indices_view[c_ods[i].first]
                     dest_index = self.nodes_to_indices_view[c_ods[i].second]
+                    if origin_index == dest_index:
+                        continue
 
                     if self.block_flows_through_centroids:
                         blocking_centroid_flows(

--- a/aequilibrae/paths/route_choice_set.pyx
+++ b/aequilibrae/paths/route_choice_set.pyx
@@ -970,10 +970,13 @@ cdef class RouteChoiceSet:
                 # This /should/ never happen.
                 if link_iter == freq_set.first.end():
                     continue
-                path_overlap = path_overlap + cost_view[link] \
-                    / d(freq_set.second)[link_iter - freq_set.first.begin()]
+                if d(freq_set.second)[link_iter - freq_set.first.begin()] > 0:
+                    path_overlap = path_overlap + cost_view[link] / d(freq_set.second)[link_iter - freq_set.first.begin()]
+            if total_cost[i] ==0:
+                d(path_overlap_vec)[i] = 1.0
+            else:
+                d(path_overlap_vec)[i] = path_overlap / total_cost[i]
 
-            d(path_overlap_vec)[i] = path_overlap / total_cost[i]
             inc(i)
 
         return path_overlap_vec

--- a/docs/source/examples/assignment_workflows/plot_route_choice.py
+++ b/docs/source/examples/assignment_workflows/plot_route_choice.py
@@ -150,7 +150,7 @@ rc.set_choice_set_generation("bfsle", max_routes=5)
 
 # %%
 # All parameters are optional, the defaults are:
-print(rc.default_paramaters)
+print(rc.default_parameters)
 
 # %%
 # We can now perform a computation for single OD pair if we'd like. Here we do one between the first and last centroid

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -380,7 +380,15 @@ class TestRouteChoice(TestCase):
         self.rc.set_choice_set_generation("link-penalization", max_routes=20, penalty=1.1)
         self.assertDictEqual(
             self.rc.parameters,
-            {"seed": 0, "max_routes": 20, "max_depth": 0, "max_misses": 100, "penalty": 1.1, "cutoff_prob": 0.0},
+            {
+                "seed": 0,
+                "max_routes": 20,
+                "max_depth": 0,
+                "max_misses": 100,
+                "penalty": 1.1,
+                "cutoff_prob": 0.0,
+                "beta": 1.0,
+            },
         )
 
         self.rc.set_choice_set_generation("bfsle", max_routes=20)
@@ -393,11 +401,9 @@ class TestRouteChoice(TestCase):
                 "max_misses": 100,
                 "penalty": 1.0,
                 "cutoff_prob": 0.0,
+                "beta": 1.0,
             },
         )
-
-        with self.assertRaises(ValueError):
-            self.rc.set_choice_set_generation("link-penalization", max_routes=20, penalty=1.1, beta=1.0)
 
         with self.assertRaises(AttributeError):
             self.rc.set_choice_set_generation("not an algorithm", max_routes=20, penalty=1.1)


### PR DESCRIPTION
@Jake-Moss ,  this one was failing when running assignment, so this fixes it. I am not sure the math is correct, though

Let's also include in this PR:

- [ ] Ability to assign matrices with type float32 in route choice
- [x] Ability to prepare RC assignment with the OD pairs for which there is flow only
- [x] Handling disconnected ODs