### PR TITLE
Add property decorator to LinkTypes

### DIFF
--- a/aequilibrae/project/network/link_types.py
+++ b/aequilibrae/project/network/link_types.py
@@ -110,9 +110,10 @@ class LinkTypes:
             if lt.link_type.lower() == link_type.lower():
                 return lt
 
+    @property
     def fields(self) -> FieldEditor:
         """Returns a FieldEditor class instance to edit the Link_Types table fields and their metadata"""
-        return FieldEditor(self.project.project_base_path, "link_types")
+        return FieldEditor(self.project, "link_types")
 
     def all_types(self) -> dict:
         """Returns a dictionary with all LinkType objects available in the model. link_type_id as key"""


### PR DESCRIPTION
In this PR we add a property decorator to LinkTypes.fields and fix its argument in the FieldEditor function