### PR TITLE
Fixes deprecation warnings

### DIFF
--- a/aequilibrae/paths/sub_area.py
+++ b/aequilibrae/paths/sub_area.py
@@ -23,12 +23,12 @@ class SubAreaAnalysis:
         Construct a sub-area matrix from a provided sub-area GeoDataFrame using route choice.
 
         This class aims to provide a semi-automated method for constructing the sub-area matrix. The user should provide
-        the Graph object, demand matrix, and a GeoDataFrame whose `unary_union` represents the desired sub-area. Perform
-        a route choice assignment, then call the `post_process` method to obtain a sub-area matrix.
+        the Graph object, demand matrix, and a GeoDataFrame whose geometry union represents the desired sub-area.
+        Perform a route choice assignment, then call the ``post_process`` method to obtain a sub-area matrix.
 
         :Arguments:
             **graph** (:obj:`Graph`): AequilibraE graph object to use
-            **subarea** (:obj:`geopandas.GeoDataFrame`): A GeoPandas GeoDataFrame whose `unary_union` represents the
+            **subarea** (:obj:`gpd.GeoDataFrame`): A GeoPandas GeoDataFrame whose geometry union represents the
               sub-area.
             **demand** (:obj:`Union[pandas.DataFrame, AequilibraeMatrix]`): The demand matrix to provide to the route
               choice assignment.
@@ -63,7 +63,7 @@ class SubAreaAnalysis:
         self.sub_area_demand = None
 
         links = gpd.GeoDataFrame(project.network.links.data)
-        self.interior_links = links[links.crosses(subarea.unary_union.boundary)].sort_index()
+        self.interior_links = links[links.crosses(subarea.union_all().boundary)].sort_index()
 
         nodes = gpd.GeoDataFrame(project.network.nodes.data).set_index("node_id")
         self.interior_nodes = nodes.sjoin(subarea, how="inner").sort_index()

--- a/aequilibrae/project/network/gmns_builder.py
+++ b/aequilibrae/project/network/gmns_builder.py
@@ -225,6 +225,7 @@ class GMNSBuilder:
 
         # For node table
         lons, lats = transformer.transform(self.node_df.loc[:, "x_coord"], self.node_df.loc[:, "y_coord"])
+        self.node_df = self.node_df.astype({"x_coord": np.float64, "y_coord": np.float64})
         self.node_df.loc[:, "x_coord"] = np.around(lons, decimals=10)
         self.node_df.loc[:, "y_coord"] = np.around(lats, decimals=10)
 

--- a/aequilibrae/project/zoning.py
+++ b/aequilibrae/project/zoning.py
@@ -5,7 +5,7 @@ from typing import Union, Dict
 import geopandas as gpd
 import shapely.wkb
 from shapely.geometry import Point, Polygon, LineString, MultiLineString
-from shapely.ops import unary_union
+from shapely import union_all
 
 from aequilibrae.project.basic_table import BasicTable
 from aequilibrae.project.data_loader import DataLoader
@@ -90,7 +90,7 @@ class Zoning(BasicTable):
         with commit_and_close(connect_spatialite(self.project.path_to_file)) as conn:
             dt = conn.execute('Select ST_asBinary("geometry") from zones;').fetchall()
         polygons = [shapely.wkb.loads(x[0]) for x in dt]
-        return unary_union(polygons)
+        return union_all(polygons)
 
     def get(self, zone_id: str) -> Zone:
         """Get a zone from the model by its **zone_id**"""


### PR DESCRIPTION
In this PR we update the code to handle the deprecation changes in third-party libraries, particularly Shapely and Pandas. 

The changes consist in:
1. update of `unary_union` to `union_all`
2. changed data type before filling `NaN` values in GMNS
3. added context manager for graph_building when using `fillna`

Changes in bullets 2 and 3 are based on this [answer on stackoverflow](https://stackoverflow.com/questions/77900971/pandas-futurewarning-downcasting-object-dtype-arrays-on-fillna-ffill-bfill)