### PR TITLE
Use default wheel repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ max-complexity = 20
 
 [tool.cibuildwheel]
 # While we test this facility we we will only build for 3.10
-#build = ["cp310-*"]
 build = ["cp39-*","cp310-*", "cp311-*", "cp312-*"]
 
 # We do not build wheels for Python 3.6 or 3.7, or for 32-bit in either Linux or Windows
@@ -92,15 +91,10 @@ manylinux-pypy_aarch64-image = "manylinux_2_28"
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 build = ["cp310-*", "cp311-*", "cp312-*"]
-repair-wheel-command = [
-  "auditwheel repair -w {dest_dir} {wheel} --exclude libarrow.so.1700 --exclude libarrow_python.so"
-]
 
 [tool.cibuildwheel.macos]
-archs = ["arm64"]
-#archs = ["x86_64"]
+archs = ["arm64", "x86_64"]
 environment = { CC="gcc-12", CXX="g++-12" }
-repair-wheel-command = "delocate-wheel -vv --ignore-missing-dependencies --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cython-lint]
 max-line-length = 120


### PR DESCRIPTION
I think the build failures in https://github.com/conda-forge/staged-recipes/pull/22437 are caused by the wheel repair we have to ship the pyarrow shared libraries ourselves. This should fix that by including the pyarrow libraries within our wheels, at the cost of our wheel size.