### PR TITLE
Fixes check when creating links table

### DIFF
--- a/aequilibrae/project/database_specification/network/tables/links.sql
+++ b/aequilibrae/project/database_specification/network/tables/links.sql
@@ -41,7 +41,7 @@ CREATE TABLE  if not exists links (ogc_fid         INTEGER PRIMARY KEY,
                                    CHECK(TYPEOF(b_node) == 'integer')
                                    CHECK(TYPEOF(direction) == 'integer')
                                    CHECK(LENGTH(modes)>0)
-                                   CHECK(LENGTH(direction)==1));
+                                   CHECK(direction IN (-1, 0, 1)));
 
 --#
 select AddGeometryColumn( 'links', 'geometry', 4326, 'LINESTRING', 'XY', 1);


### PR DESCRIPTION
In this PR we modify the direction check when creating "links" table. 

Previously, checking the length raised a `sqlite3.IntegrityError`  when updating/creating a link with direction `-1`.

We also add a test to check if the conditions are met and errors are raised when setting the direction values equal to -2, -1, 0, 1, 2.