### PR TITLE
Revert "Use default wheel repair (#585)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ max-complexity = 20
 
 [tool.cibuildwheel]
 # While we test this facility we we will only build for 3.10
+#build = ["cp310-*"]
 build = ["cp39-*","cp310-*", "cp311-*", "cp312-*"]
 
 # We do not build wheels for Python 3.6 or 3.7, or for 32-bit in either Linux or Windows
@@ -91,10 +92,15 @@ manylinux-pypy_aarch64-image = "manylinux_2_28"
 [tool.cibuildwheel.linux]
 archs = ["auto", "aarch64"]
 build = ["cp310-*", "cp311-*", "cp312-*"]
+repair-wheel-command = [
+  "auditwheel repair -w {dest_dir} {wheel} --exclude libarrow.so.1700 --exclude libarrow_python.so"
+]
 
 [tool.cibuildwheel.macos]
-archs = ["arm64", "x86_64"]
+archs = ["arm64"]
+#archs = ["x86_64"]
 environment = { CC="gcc-12", CXX="g++-12" }
+repair-wheel-command = "delocate-wheel -vv --ignore-missing-dependencies --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 [tool.cython-lint]
 max-line-length = 120


### PR DESCRIPTION
This reverts commit 659b7894825c176021fb517a65049c0b2aa20f13.

I'm unable to make this work. Because we are linking against the library from pyarrow installed as a dependency, once the wheel is build the temporary environment cibuildwheels constructs to build the wheel is destroyed so we cannot access it to properly repair the wheel. From what I can tell ignoring it is the only way.

This was intended as fix for the conda forge build, but it looks like I'll have to find some fix for it on that end