### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Prepare links for DEV
       if: ${{ (github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true') }}
       run: |
-        python -c "from docs.replace_regex import replace_regex; replace_regex('test')"
+        python -c "from docs.replace_regex import replace_regex; replace_regex(f'test/{${{ github.event.number }}}')"
 
     - name: Prepare links for DEVELOP
       if: ${{ (github.ref == 'refs/heads/develop') && (github.event_name == 'push')}}
@@ -84,8 +84,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'docs/build/html/'      # optional: defaults to entire repository
-        # DEST_DIR: 'dev/${{ github.event.number }}/python/'      # optional: defaults to entire repository
-        DEST_DIR: 'test/python/'      # optional: defaults to entire repository
+        DEST_DIR: 'test/${{ github.event.number }}/python/'      # optional: defaults to entire repository
 
     - name: Upload home page to DEV on S3
       if: ${{ (github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true') }}
@@ -98,8 +97,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'docs/build/html/'
-        # DEST_DIR: 'dev/${{ github.event.number }}/'      # optional: defaults to entire repository
-        DEST_DIR: 'test/'      # optional: defaults to entire repository
+        DEST_DIR: 'test/${{ github.event.number }}/'      # optional: defaults to entire repository
 
     - name: Upload python to DEVELOP on S3
       if: ${{ (github.ref == 'refs/heads/develop') && (github.event_name == 'push') && (env.HAS_SECRETS == 'true') }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -52,6 +52,16 @@ jobs:
         python -m pytest --doctest-glob=*.rst docs/source/modeling_with_aequilibrae/project_pieces
         python -m pytest --doctest-glob=*.rst docs/source/modeling_with_aequilibrae/static_traffic_assignment
 
+    - name: Prepare links for DEV
+      if: ${{ (github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true') }}
+      run: |
+        python -c "from docs.replace_regex import replace_regex; replace_regex('test')"
+
+    - name: Prepare links for DEVELOP
+      if: ${{ (github.ref == 'refs/heads/develop') && (github.event_name == 'push')}}
+      run: |
+        python -c "from ci.replace_regex import replace_regex; replace_regex('develop')"
+
     - name: Build documentation
       run: |
         jupyter nbconvert --to rst docs/source/useful_information/validation_benchmarking/IPF_benchmark.ipynb
@@ -74,7 +84,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'docs/build/html/'      # optional: defaults to entire repository
-        DEST_DIR: 'dev/${{ github.event.number }}/python/'      # optional: defaults to entire repository
+        # DEST_DIR: 'dev/${{ github.event.number }}/python/'      # optional: defaults to entire repository
+        DEST_DIR: 'test/python/'      # optional: defaults to entire repository
 
     - name: Upload home page to DEV on S3
       if: ${{ (github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true') }}
@@ -87,7 +98,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'docs/build/html/'
-        DEST_DIR: 'dev/${{ github.event.number }}/'      # optional: defaults to entire repository
+        # DEST_DIR: 'dev/${{ github.event.number }}/'      # optional: defaults to entire repository
+        DEST_DIR: 'test/'      # optional: defaults to entire repository
 
     - name: Upload python to DEVELOP on S3
       if: ${{ (github.ref == 'refs/heads/develop') && (github.event_name == 'push') && (env.HAS_SECRETS == 'true') }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Prepare links for DEV
       if: ${{ (github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true') }}
       run: |
-        python -c "from docs.replace_regex import replace_regex; replace_regex(f'test/{${{ github.event.number }}}')"
+        python -c "from docs.replace_regex import replace_regex; replace_regex(f'dev/{${{ github.event.number }}}')"
 
     - name: Prepare links for DEVELOP
       if: ${{ (github.ref == 'refs/heads/develop') && (github.event_name == 'push')}}
@@ -84,7 +84,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'docs/build/html/'      # optional: defaults to entire repository
-        DEST_DIR: 'test/${{ github.event.number }}/python/'      # optional: defaults to entire repository
+        DEST_DIR: 'dev/${{ github.event.number }}/python/'      # optional: defaults to entire repository
 
     - name: Upload home page to DEV on S3
       if: ${{ (github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true') }}
@@ -97,7 +97,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_REGION: 'us-east-1'   # optional: defaults to us-east-1
         SOURCE_DIR: 'docs/build/html/'
-        DEST_DIR: 'test/${{ github.event.number }}/'      # optional: defaults to entire repository
+        DEST_DIR: 'dev/${{ github.event.number }}/'      # optional: defaults to entire repository
 
     - name: Upload python to DEVELOP on S3
       if: ${{ (github.ref == 'refs/heads/develop') && (github.event_name == 'push') && (env.HAS_SECRETS == 'true') }}

--- a/docs/replace_regex.py
+++ b/docs/replace_regex.py
@@ -17,12 +17,20 @@ def replace_regex(event):
             if file.endswith((".drawio", ".txt", ".omx")):
                 continue
             full_path = os.path.join(root, file)
-            print(full_path)
             with open(full_path, "rb") as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as s:
                 content = s.read().decode("utf-8")
 
-                # Find and replace regex containing the site
-                modified_content = re.sub(r"www.aequilibrae.com/latest/", rf"www.aequilibrae.com/{event}/", content)
+                # Find and replace regex containing the website
+                modified_content = re.sub(
+                    r"www.aequilibrae.com/latest/python/", rf"www.aequilibrae.com/{event}/python/", content
+                )
+
+                if "/" in event:
+                    modified_content = re.sub(
+                        r"www.aequilibrae.com/latest/qgis/",
+                        rf"www.aequilibrae.com/{event.split('/')[0]}/qgis/",
+                        modified_content,
+                    )
 
                 # Write modified content back to file
                 with open(full_path, "w", encoding="utf-8") as w:

--- a/docs/replace_regex.py
+++ b/docs/replace_regex.py
@@ -1,0 +1,29 @@
+import os
+import re
+import mmap
+import sys
+from pathlib import Path
+
+project_dir = Path(__file__).parent.parent
+if str(project_dir) not in sys.path:
+    sys.path.append(str(project_dir))
+
+
+def replace_regex(event):
+    for root, directories, files in os.walk("docs/source"):
+        dirs = ["_auto_examples", "_generated", "_latex", "_static", "images"]
+        directories[:] = [d for d in directories if d not in dirs]
+        for file in files:
+            if file.endswith((".drawio", ".txt", ".omx")):
+                continue
+            full_path = os.path.join(root, file)
+            print(full_path)
+            with open(full_path, "rb") as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as s:
+                content = s.read().decode("utf-8")
+
+                # Find and replace regex containing the site
+                modified_content = re.sub(r"www.aequilibrae.com/latest/", rf"www.aequilibrae.com/{event}/", content)
+
+                # Write modified content back to file
+                with open(full_path, "w", encoding="utf-8") as w:
+                    w.write(modified_content)

--- a/docs/replace_regex.py
+++ b/docs/replace_regex.py
@@ -20,17 +20,20 @@ def replace_regex(event):
             with open(full_path, "rb") as f, mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as s:
                 content = s.read().decode("utf-8")
 
-                # Find and replace regex containing the website
-                modified_content = re.sub(
-                    r"www.aequilibrae.com/latest/python/", rf"www.aequilibrae.com/{event}/python/", content
+                in_path = r"www.aequilibrae.com/latest/" if file == "conf.py" else r"www.aequilibrae.com/latest/python/"
+                out_path = (
+                    rf"www.aequilibrae.com/{event}/" if file == "conf.py" else rf"www.aequilibrae.com/{event}/python/"
                 )
 
-                if "/" in event:
-                    modified_content = re.sub(
-                        r"www.aequilibrae.com/latest/qgis/",
-                        rf"www.aequilibrae.com/{event.split('/')[0]}/qgis/",
-                        modified_content,
-                    )
+                # Find and replace regex containing the website
+                modified_content = re.sub(in_path, out_path, content)
+
+                events = event.split("/")
+                modified_content = re.sub(
+                    r"www.aequilibrae.com/latest/qgis/",
+                    rf"www.aequilibrae.com/{events[0]}/qgis/",
+                    modified_content,
+                )
 
                 # Write modified content back to file
                 with open(full_path, "w", encoding="utf-8") as w:

--- a/docs/source/useful_information/version_history.rst
+++ b/docs/source/useful_information/version_history.rst
@@ -11,184 +11,184 @@ In the meantime, you can find the documentation for all versions since 0.5.3.
 .. grid::
 
     .. grid-item-card:: 0.5.3
-        :link:  https://aequilibrae.com/docs/python/V.0.5.3/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.5.3/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.6.0
-        :link:  https://aequilibrae.com/docs/python/V.0.6.0/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.6.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.6.1
-        :link:  https://aequilibrae.com/docs/python/V.0.6.1/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.6.1/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.6.2
-        :link:  https://aequilibrae.com/docs/python/V.0.6.2/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.6.2/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.6.3
-        :link:  https://aequilibrae.com/docs/python/V.0.6.3/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.6.3/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.6.4
-        :link:  https://aequilibrae.com/docs/python/V.0.6.4/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.6.4/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.6.5
-        :link:  https://aequilibrae.com/docs/python/V.0.6.5/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.6.5/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.7.0
-        :link:  https://aequilibrae.com/docs/python/V.0.7.0/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.7.1
-        :link:  https://aequilibrae.com/docs/python/V.0.7.1/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.1/
         :link-type: url
         :text-align: center            
 
 .. grid::
 
     .. grid-item-card:: 0.7.2
-        :link:  https://aequilibrae.com/docs/python/V.0.7.2/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.2/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.7.3
-        :link:  https://aequilibrae.com/docs/python/V.0.7.3/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.3/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.7.4
-        :link:  https://aequilibrae.com/docs/python/V.0.7.4/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.4/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.7.5
-        :link:  https://aequilibrae.com/docs/python/V.0.7.5/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.5/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.7.6
-        :link:  https://aequilibrae.com/docs/python/V.0.7.6/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.6/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.7.7
-        :link:  https://aequilibrae.com/docs/python/V.0.7.7/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.7.7/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.8.0
-        :link:  https://aequilibrae.com/docs/python/V.0.8.0/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.8.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.8.1
-        :link:  https://aequilibrae.com/docs/python/V.0.8.1/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.8.1/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.8.2
-        :link:  https://aequilibrae.com/docs/python/V.0.8.2/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.8.2/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.8.3
-        :link:  https://aequilibrae.com/docs/python/V.0.8.3/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.8.3/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.9.0
-        :link:  https://aequilibrae.com/docs/python/V.0.9.0/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.9.0/
         :link-type: url
         :text-align: center
     
     .. grid-item-card:: 0.9.1
-        :link:  https://aequilibrae.com/docs/python/V.0.9.1/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.9.1/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.9.2
-        :link:  https://aequilibrae.com/docs/python/V.0.9.2/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.9.2/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 0.9.3
-        :link:  https://aequilibrae.com/docs/python/V.0.9.3/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.9.3/
         :link-type: url
         :text-align: center
     
     .. grid-item-card:: 0.9.4
-        :link:  https://aequilibrae.com/docs/python/V.0.9.4/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.9.4/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 0.9.5
-        :link:  https://aequilibrae.com/docs/python/V.0.9.5/
+        :link:  https://www.aequilibrae.com/docs/python/V.0.9.5/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.0.0
-        :link:  https://aequilibrae.com/docs/python/V.1.0.0/
+        :link:  https://www.aequilibrae.com/docs/python/V.1.0.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.0.1
-        :link:  https://aequilibrae.com/docs/python/V.1.0.1/
+        :link:  https://www.aequilibrae.com/docs/python/V.1.0.1/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 1.1.0
-        :link:  https://aequilibrae.com/docs/python/V.1.1.0/
+        :link:  https://www.aequilibrae.com/docs/python/V.1.1.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.1.1
-        :link:  https://aequilibrae.com/docs/python/V.1.1.1/
+        :link:  https://www.aequilibrae.com/docs/python/V.1.1.1/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.1.2
-        :link:  https://aequilibrae.com/docs/python/V.1.1.2/
+        :link:  https://www.aequilibrae.com/docs/python/V.1.1.2/
         :link-type: url
         :text-align: center
 
 .. grid::
 
     .. grid-item-card:: 1.1.3
-        :link:  https://aequilibrae.com/docs/python/V.1.1.3/
+        :link:  https://www.aequilibrae.com/docs/python/V.1.1.3/
         :link-type: url
         :text-align: center
 
     .. grid-item::
 
     .. grid-item-card:: Upcoming version
-        :link:  https://aequilibrae.com/latest/python/index.html
+        :link:  https://www.aequilibrae.com/latest/python/index.html
         :link-type: url
         :text-align: center
 


### PR DESCRIPTION
This PR fixes the broken references to aequilibrae page links.

We:
* Added _docs/replace_regex.py_, a file that updates the S3 directory name based on the action's name in GitHub (consider latest as default)
* Updated _documentation.yml_ to run _replace_regex.py_
* Updated the subdomain of certain URLs to match regex replace