### PR TITLE
Modity return object

### DIFF
--- a/aequilibrae/paths/graph.py
+++ b/aequilibrae/paths/graph.py
@@ -320,7 +320,7 @@ class GraphBase(ABC):  # noqa: B024
             skimmer.set_cores(cores)
         skimmer.execute()
 
-        return skimmer.results
+        return skimmer
 
     def exclude_links(self, links: list) -> None:
         """

--- a/tests/aequilibrae/paths/test_graph.py
+++ b/tests/aequilibrae/paths/test_graph.py
@@ -101,7 +101,7 @@ class TestGraph(TestCase):
         graph.set_blocked_centroid_flows(False)
 
         skm = graph.compute_skims()
-        skims = skm.skims
+        skims = skm.results.skims
         self.assertEqual(skims.cores, 2, "Number of cores is not correct")
         self.assertEqual(skims.names, ["distance", "free_flow_time"], "Matrices names are not correct")
 


### PR DESCRIPTION
In this PR we propose changing the object returned by `graph.compute_skims` to be the result of `NetworkSkimmer` after the code execution, rather than the `SkimResults`, allowing the skim matrices generated to be saved.

We:
* Modified the object to be returned in _aequilibrae/paths/graph.py_
* Updated the test