### PR TITLE
Replace openmp:llvm with normal openmp, fix signed-ness errors

### DIFF
--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -199,7 +199,7 @@ cdef class RouteChoiceSet:
         """
         cdef:
             long long origin, dest
-            size_t i
+            long int i
 
         if select_links is None:
             select_links = {}
@@ -228,7 +228,7 @@ cdef class RouteChoiceSet:
             unsigned int c_max_depth = max_depth
             unsigned int c_max_misses = max_misses
             unsigned int c_seed = seed
-            unsigned int c_cores = cores if cores > 0 else omp_get_max_threads()
+            long int c_cores = cores if cores > 0 else omp_get_max_threads()
 
             # Scale cutoff prob from [0, 1] -> [0.5, 1]. Values below 0.5 produce negative inverse binary logit values.
             double scaled_cutoff_prob = (1.0 - cutoff_prob) * 0.5 + 0.5
@@ -284,7 +284,7 @@ cdef class RouteChoiceSet:
             with nogil, parallel(num_threads=c_cores):
                 route_set = new RouteSet_t()
                 thread_id = threadid()
-                for i in prange(demand.ods.size(), schedule="guided"):
+                for i in prange(<long int>demand.ods.size(), schedule="guided"):
                     origin_index = self.nodes_to_indices_view[demand.ods[i].first]
                     dest_index = self.nodes_to_indices_view[demand.ods[i].second]
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ is_win = "WINDOWS" in platform.platform().upper()
 is_mac = any(e in platform.platform().upper() for e in ["MACOS", "DARWIN"])
 prefix = "/" if is_win else "-f"
 cpp_std = "/std:c++17" if is_win else "-std=c++17"
-compile_args = [cpp_std, f"{prefix}openmp{':llvm' if is_win else ''}"]
+compile_args = [cpp_std, f"{prefix}openmp"]
 compile_args += ["-Wno-unreachable-code"] if is_mac else []
 link_args = [f"{prefix}openmp"]
 


### PR DESCRIPTION
In my dev VM this removed the linkage against `libomp`. Hopefully this resolves the import issues.

Thanks to @jamiecook for finding the relevant docs
> Starting in Visual Studio 2019 version 16.9, you can use the experimental /openmp:llvm option instead of /openmp to target the LLVM OpenMP runtime. **Support currently isn't available for production code, since the required libomp DLLs aren't redistributable**. The option supports the same OpenMP 2.0 directives as /openmp. And, it supports all the SIMD directives supported by the /openmp:experimental option. **It also supports unsigned integer indices in parallel for loops according to the OpenMP 3.0 standard**. For more information, see [Improved OpenMP Support for C++ in Visual Studio](https://devblogs.microsoft.com/cppblog/improved-openmp-support-for-cpp-in-visual-studio/).
>
> https://learn.microsoft.com/en-us/cpp/build/reference/openmp-enable-openmp-2-0-support?view=msvc-170