### PR TITLE
Fix saving path for select link analysis outputs

### DIFF
--- a/aequilibrae/paths/traffic_assignment.py
+++ b/aequilibrae/paths/traffic_assignment.py
@@ -4,7 +4,6 @@ import sqlite3
 from abc import ABC, abstractmethod
 from datetime import datetime
 from os import path
-from pathlib import Path
 from typing import List, Dict, Union
 from uuid import uuid4
 
@@ -810,8 +809,7 @@ class TrafficAssignment(AssignmentBase):
 
     def save_select_link_flows(self, table_name: str, project=None) -> None:
         """
-        Saves the select link link flows for all classes into the results database. Additionally, it exports
-        the OD matrices into OMX format.
+        Saves the select link link flows for all classes into the results database.
 
         :Arguments:
             **table_name** (:obj:`str`): Name of the table being inserted to. Note the traffic class
@@ -850,59 +848,61 @@ class TrafficAssignment(AssignmentBase):
     def save_select_link_matrices(self, matrix_name: str, project=None) -> None:
         """
         Saves the Select Link matrices for each TrafficClass in the current TrafficAssignment class
+        into OMX format.
+
+        :Arguments:
+            **name** (:obj:`str`): name of the matrices
+
+            **project** (:obj:`Project`, *Optional*): Project we want to save the results to.
+            Defaults to the active project
         """
         if not project:
             project = self.project or get_active_project()
 
         mats = project.matrices
 
+        file_name = f"{matrix_name}.omx"
+
+        export_name = path.join(mats.fldr, file_name)
+
+        if path.isfile(export_name):
+            raise FileExistsError(f"{file_name} already exists. Choose a different name or matrix format")
+
+        if mats.check_exists(matrix_name):
+            raise FileExistsError(f"{matrix_name} already exists. Choose a different name")
+
+        names = [f"{key}_{cls._id}" for cls in self.classes for key in cls._selected_links.keys()]
+
+        kwargs = {
+            "file_name": AequilibraeMatrix().random_name(),
+            "zones": self.classes[0].graph.centroids.shape[0],
+            "matrix_names": names,
+            "memory_only": False,
+        }
+
+        # Create the matrix to manipulate
+        out_skims = AequilibraeMatrix()
+        out_skims.create_empty(**kwargs)
+
+        out_skims.index[:] = self.classes[0].graph.centroids[:]
+
         for cls in self.classes:
-            file_name = f"{matrix_name}_{cls._id}.omx"
-
-            export_name = path.join(mats.fldr, file_name)
-
-            if path.isfile(export_name):
-                raise FileExistsError(f"{file_name} already exists. Choose a different name or matrix format")
-
-            if mats.check_exists(matrix_name):
-                raise FileExistsError(f"{matrix_name} already exists. Choose a different name")
-
             if cls._selected_links is None:
                 continue
 
             res = cls.results.select_link_od
-            num_zones = self.classes[0].graph.centroids.shape[0]
-
-            kwargs = {
-                "file_name": AequilibraeMatrix().random_name(),
-                "zones": num_zones,
-                "matrix_names": res.names,
-                "memory_only": False,
-            }
-
-            # Create the matrix to manipulate
-            out_skims = AequilibraeMatrix()
-            out_skims.create_empty(**kwargs)
-
-            out_skims.index[:] = self.classes[0].graph.centroids[:]
-            out_skims.description = f"Select link matrix from procedure ID {self.procedure_id}_sl. Class name {cls._id}"
 
             for mat in res.names:
-                out_skims.matrix[mat][:, :] = res.get_matrix(mat).reshape((num_zones, num_zones))
+                out_skims.matrix[f"{mat}_{cls._id}"][:, :] = res.get_matrix(mat)[:, :, 0]
 
-            out_skims.export(export_name)
+        out_skims.matrices.flush()  # Make sure that all data went to the disk
+        out_skims.description = f"Select link matrix from procedure ID {self.procedure_id}_sl."
+
+        out_skims.export(export_name)
 
     def save_select_link_results(self, name: str) -> None:
         """
         Saves both the Select Link matrices and flow results at the same time, using the same name.
-
-        .. note::
-            Note the Select Link matrices will have _SL_matrices.omx appended to the end for ease of identification.
-            e.g. save_select_link_results("Car") will result in the following names for the flows and matrices:
-            Select Link Flows: inserts the select link flows for each class into the database with the table name:
-            Car
-            Select Link Matrices (only exports to OMX format):
-            Car.omx
 
         :Arguments:
             **name** (:obj:`str`): name of the matrices

--- a/aequilibrae/paths/traffic_assignment.py
+++ b/aequilibrae/paths/traffic_assignment.py
@@ -847,20 +847,50 @@ class TrafficAssignment(AssignmentBase):
         conn.commit()
         conn.close()
 
-    def save_select_link_matrices(self, file_name: str, project=None) -> None:
+    def save_select_link_matrices(self, matrix_name: str, project=None) -> None:
         """
         Saves the Select Link matrices for each TrafficClass in the current TrafficAssignment class
         """
         if not project:
             project = self.project or get_active_project()
 
-        file_path = str(Path(file_name).with_suffix(".omx"))
+        mats = project.matrices
 
         for cls in self.classes:
-            # Save OD_matrices
+            file_name = f"{matrix_name}_{cls._id}.omx"
+
+            export_name = path.join(mats.fldr, file_name)
+
+            if path.isfile(export_name):
+                raise FileExistsError(f"{file_name} already exists. Choose a different name or matrix format")
+
+            if mats.check_exists(matrix_name):
+                raise FileExistsError(f"{matrix_name} already exists. Choose a different name")
+
             if cls._selected_links is None:
                 continue
-            cls.results.select_link_od.export(path.join(project.project_base_path, "matrices", file_path))
+
+            res = cls.results.select_link_od
+            num_zones = self.classes[0].graph.centroids.shape[0]
+
+            kwargs = {
+                "file_name": AequilibraeMatrix().random_name(),
+                "zones": num_zones,
+                "matrix_names": res.names,
+                "memory_only": False,
+            }
+
+            # Create the matrix to manipulate
+            out_skims = AequilibraeMatrix()
+            out_skims.create_empty(**kwargs)
+
+            out_skims.index[:] = self.classes[0].graph.centroids[:]
+            out_skims.description = f"Select link matrix from procedure ID {self.procedure_id}_sl. Class name {cls._id}"
+
+            for mat in res.names:
+                out_skims.matrix[mat][:, :] = res.get_matrix(mat).reshape((num_zones, num_zones))
+
+            out_skims.export(export_name)
 
     def save_select_link_results(self, name: str) -> None:
         """

--- a/aequilibrae/paths/traffic_assignment.py
+++ b/aequilibrae/paths/traffic_assignment.py
@@ -834,7 +834,7 @@ class TrafficAssignment(AssignmentBase):
         data = [
             table_name,
             "select link",
-            self.procedure_id,
+            f"{self.procedure_id}_sl",
             str(report),
             self.procedure_date,
             self.description,
@@ -847,16 +847,20 @@ class TrafficAssignment(AssignmentBase):
         conn.commit()
         conn.close()
 
-    def save_select_link_matrices(self, file_name: str) -> None:
+    def save_select_link_matrices(self, file_name: str, project=None) -> None:
         """
         Saves the Select Link matrices for each TrafficClass in the current TrafficAssignment class
         """
+        if not project:
+            project = self.project or get_active_project()
+
+        file_path = str(Path(file_name).with_suffix(".omx"))
 
         for cls in self.classes:
             # Save OD_matrices
             if cls._selected_links is None:
                 continue
-            cls.results.select_link_od.export(str(Path(file_name).with_suffix(".omx")))
+            cls.results.select_link_od.export(path.join(project.project_base_path, "matrices", file_path))
 
     def save_select_link_results(self, name: str) -> None:
         """

--- a/tests/aequilibrae/paths/test_select_link.py
+++ b/tests/aequilibrae/paths/test_select_link.py
@@ -73,7 +73,14 @@ class TestSelectLink(TestCase):
 
         matrices = self.project.matrices
         matrices.update_database()
-        assert f"select_link_analysis_{self.assignclass._id}.omx" in matrices.list()["file_name"].tolist()
+        assert "select_link_analysis.omx" in matrices.list()["file_name"].tolist()
+
+        # Test if matrices are with the correct shape and are not empty
+        sla = matrices.get_matrix("select_link_analysis_omx")
+        num_zones = self.assignment.classes[0].graph.num_zones
+        for mat in sla.names:
+            m = sla.get_matrix(mat)
+            assert m.sum() > 0 and m.shape == (num_zones, num_zones)
 
         pth = Path(self.project.project_base_path)
         conn = sqlite3.connect(pth / "results_database.sqlite")

--- a/tests/aequilibrae/paths/test_select_link.py
+++ b/tests/aequilibrae/paths/test_select_link.py
@@ -67,7 +67,7 @@ class TestSelectLink(TestCase):
                 link_loading,
                 err_msg="Link loading SL matrix for: " + str(key) + " does not match",
             )
-        
+
         # Test if files are saved in the right place
         self.assignment.save_select_link_results("select_link_analysis")
 

--- a/tests/aequilibrae/paths/test_select_link.py
+++ b/tests/aequilibrae/paths/test_select_link.py
@@ -2,10 +2,12 @@ import os
 import uuid
 import zipfile
 from os.path import join, dirname
+from pathlib import Path
 from tempfile import gettempdir
 from unittest import TestCase
 import pandas as pd
 import numpy as np
+import sqlite3
 
 from aequilibrae import TrafficAssignment, TrafficClass, Graph, Project, PathResults
 from aequilibrae.matrix import AequilibraeMatrix
@@ -65,6 +67,18 @@ class TestSelectLink(TestCase):
                 link_loading,
                 err_msg="Link loading SL matrix for: " + str(key) + " does not match",
             )
+        
+        # Test if files are saved in the right place
+        self.assignment.save_select_link_results("select_link_analysis")
+
+        matrices = self.project.matrices
+        matrices.update_database()
+        assert f"select_link_analysis_{self.assignclass._id}.omx" in matrices.list()["file_name"].tolist()
+
+        pth = Path(self.project.project_base_path)
+        conn = sqlite3.connect(pth / "results_database.sqlite")
+        results = [x[0] for x in conn.execute("SELECT name FROM sqlite_master WHERE type ='table'").fetchall()]
+        assert "select_link_analysis" in results
 
     def test_equals_demand_one_origin(self):
         """


### PR DESCRIPTION
In this PR we fix two bugs when saving select link analysis outputs.

We:

* Renamed the procedure_id when saving select link results to database;
* Fixed file path and matrix output procedure when saving select link matrices;
* Updated the test to check if matrices were saved in to project/matrices folder, if matrices are not empty and with the correct shape, and if results were also saved in the results table.