### PR TITLE
Small performance improvements

### DIFF
--- a/aequilibrae/paths/cython/AoN.pyx
+++ b/aequilibrae/paths/cython/AoN.pyx
@@ -157,16 +157,14 @@ def one_to_all(origin, matrix, graph, result, aux_result, curr_thread):
             sl_network_loading(link_list, demand_view, predecessors_view, conn_view, link_loads_view, sl_od_matrix_view,
                                sl_link_loading_view, has_flow_mask, classes)
         else:
-            # do ONLY regular loading (via cascade assignment)
-            network_loading(classes,
-                            demand_view,
-                            predecessors_view,
-                            conn_view,
-                            link_loads_view,
-                            no_path_view,
-                            reached_first_view,
-                            node_load_view,
-                            w)
+            # do ONLY regular loading
+            network_loading(
+                classes,
+                demand_view,
+                predecessors_view,
+                conn_view,
+                link_loads_view
+            )
 
     if result.save_path_file:
         save_path_file(origin_index, links, zones, predecessors_view, conn_view, path_file_base, path_index_file_base, write_feather)

--- a/aequilibrae/paths/cython/basic_path_finding.pyx
+++ b/aequilibrae/paths/cython/basic_path_finding.pyx
@@ -32,41 +32,20 @@ cpdef void network_loading(long classes,
     cdef long long i, j, predecessor, connector, node
     cdef long long zones = demand.shape[0]
     cdef long long N = node_load.shape[0]
-# Traditional loading, without cascading
-#    for i in range(zones):
-#        node = i
-#        predecessor = pred[node]
-#        connector = conn[node]
-#        while predecessor >= 0:
-#            for j in range(classes):
-#                link_loads[connector, j] += demand[i, j]
-#
-#            predecessor = pred[predecessor]
-#            connector = conn[predecessor]
+    cdef double value
+    cdef size_t offset, col, core
+    # Traditional loading, without cascading
+    for i in range(zones):
+        node = i
 
-    # Clean the node load array
-    for i in range(N):
-        node_load[i] = 0
-
-    # Loads the demand to the centroids
-    for j in range(classes):
-        for i in range(zones):
-            if not isnan(demand[i, j]):
-                node_load[i, j] = demand[i, j]
-
-    # Recursively cascades to the origin
-    for i in range(found, 0, -1):
-        node = reached_first[i]
-
-        # captures how we got to that node
         predecessor = pred[node]
         connector = conn[node]
+        while predecessor >= 0:
+            for j in range(classes):
+                link_loads[connector, j] += demand[i, j]
 
-        # loads the flow to the links for each class
-        for j in range(classes):
-            link_loads[connector, j] += node_load[node, j]
-            # Cascades the load from the node to their predecessor
-            node_load[predecessor, j] += node_load[node, j]
+            connector = conn[predecessor]
+            predecessor = pred[predecessor]
 
 
 @cython.wraparound(False)

--- a/aequilibrae/paths/cython/basic_path_finding.pyx
+++ b/aequilibrae/paths/cython/basic_path_finding.pyx
@@ -19,21 +19,16 @@ include 'pq_4ary_heap.pyx'
 @cython.wraparound(False)
 @cython.embedsignature(True)
 @cython.boundscheck(False)  # turn off bounds-checking for entire function
-cpdef void network_loading(long classes,
-                           double[:, :] demand,
-                           long long [:] pred,
-                           long long [:] conn,
-                           double[:, :] link_loads,
-                           long long [:] no_path,
-                           long long [:] reached_first,
-                           double [:, :] node_load,
-                           long found) noexcept nogil:
-
+cpdef void network_loading(
+    long classes,
+    double[:, :] demand,
+    long long [:] pred,
+    long long [:] conn,
+    double[:, :] link_loads
+) noexcept nogil:
     cdef long long i, j, predecessor, connector, node
     cdef long long zones = demand.shape[0]
-    cdef long long N = node_load.shape[0]
-    cdef double value
-    cdef size_t offset, col, core
+
     # Traditional loading, without cascading
     for i in range(zones):
         node = i

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,8 @@ requires = ["setuptools", "numpy<1.99", "cython", "pyarrow==17.0.0", "wheel"]
 
 
 [tool.ruff]
-
-select = ["B", "C", "E", "F", "W"]
-ignore = ["E501", "F401", "F403", "B028", "B007", "B017"]
+lint.select = ["B", "C", "E", "F", "W"]
+lint.ignore = ["E501", "F401", "F403", "B028", "B007", "B017"]
 exclude = [
     ".idea",
     "__pycache__",
@@ -50,10 +49,10 @@ exclude = [
     ".venv312",
 ]
 line-length = 120
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 target-version = "py39"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 20
 
 [tool.cibuildwheel]


### PR DESCRIPTION
With the early exit changes, it's now more likely to be fast to load the network normally than with a cascade loading.

For functions which one single dimensional, we found performance improvements by making them single threaded, removing the thread over head and time spent waiting. When Cython 3.1 releases we can revert those changes in favour of using the `use_threads_if` argument to get the best of both.

Also move ruff variables from top level to under the `lint` prefix as per the deprecation notice.