### PR TITLE
Save route choice select link OD matrix as AequilibraE matrix

### DIFF
--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -499,13 +499,15 @@ class TestRouteChoice(TestCase):
                     pd.testing.assert_frame_equal(df2, df)
         conn.close()
 
-        matrices = Sparse.from_disk(
+        matrices = AequilibraeMatrix()
+        matrices.create_from_omx(
             (pathlib.Path(self.project.project_base_path) / "matrices" / "sl").with_suffix(".omx")
         )
+        matrices.computational_view()
 
         for sl_name, v in self.rc.get_select_link_od_matrix_results().items():
             for demand_name, matrix in v.items():
-                np.testing.assert_allclose(matrix.to_scipy().toarray(), matrices[sl_name + "_" + demand_name].toarray())
+                np.testing.assert_allclose(matrix.to_scipy().toarray(), matrices.matrix[sl_name + "_" + demand_name])
 
     def test_round_trip(self):
         self.rc.add_demand(self.mat)

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -500,9 +500,7 @@ class TestRouteChoice(TestCase):
         conn.close()
 
         matrices = AequilibraeMatrix()
-        matrices.create_from_omx(
-            (pathlib.Path(self.project.project_base_path) / "matrices" / "sl").with_suffix(".omx")
-        )
+        matrices.create_from_omx((pathlib.Path(self.project.project_base_path) / "matrices" / "sl").with_suffix(".omx"))
         matrices.computational_view()
 
         for sl_name, v in self.rc.get_select_link_od_matrix_results().items():


### PR DESCRIPTION
When saving route choice select link OD matrices, they were missing an index, and thus not able to be opened as a AequilibraE matrix object. This PR saves the graph centroids as the index.

Closes #622
