### PR TITLE
Allow the removal of an existing transit graph from the `public_transport.sqlite` database

### DIFF
--- a/aequilibrae/transit/transit.py
+++ b/aequilibrae/transit/transit.py
@@ -93,17 +93,69 @@ class Transit(WorkerThread):
             initialize_tables(self, "transit")
 
     def create_graph(self, **kwargs) -> TransitGraphBuilder:
+        """
+        Create a transit graph from an existing GTFS import.
+
+        All arguments are forwarded to 'TransitGraphBuilder'.
+
+        A 'period_id' may be specified to select a time period. By default, a whole day is used. See
+        'project.network.Periods' for more details.
+        """
         period_id = kwargs.get("period_id", self.periods.default_period.period_id)
         graph = TransitGraphBuilder(self.pt_con, period_id, **kwargs)
         graph.create_graph()
         self.graphs[period_id] = graph
         return graph
 
-    def save_graphs(self, period_ids: List[int] = None):
+    def save_graphs(self, period_ids: List[int] = None, force: bool = False, suppress_warning: bool = False):
+        """
+        Save the previously build transit graphs to the 'public_transport.sqlite' database. Saving may be filtered
+        by 'period_id'.
+
+        NOTE: Currently only a single transit graph can be saved and reloaded. Multiple graph support is plan for a future release.
+
+        :Arguments:
+            **period_ids** (:obj:`int`): List of periods of to save. Defaults to 'project.network.periods.default_period.period_id'.
+            **force** (:obj:`bool`): Remove the existing graphs before saving the 'period_ids' graphs. Default 'False'.
+            **suppress_warning** (:obj:`bool`): Suppress the warning about single transit graph support. Default 'False'.
+
+        """
         # TODO: Support multiple graph saving
-        warnings.warn(
-            "Currently only a single transit graph can be saved and reloaded. Multiple graph support is plan for a future release."
-        )
+        if not suppress_warning:
+            warnings.warn(
+                "Currently only a single transit graph can be saved and reloaded. Multiple graph support is plan for a future release."
+            )
+
+        if period_ids is None:
+            period_ids = [self.periods.default_period.period_id]
+
+        if len(period_ids) > 1:
+            raise ValueError("Multiple graphs can currently be saved.")
+
+        if force:
+            self.remove_graphs(period_ids, suppress_warning=suppress_warning)
+
+        for period_id in period_ids:
+            self.graphs[period_id].save()
+
+    def remove_graphs(self, period_ids: List[int] = None, suppress_warning: bool = False):
+        """
+        Remove the previously saved transit graphs from the 'public_transport.sqlite' database. Removing may be filtered
+        by 'period_id'.
+
+        NOTE: Currently only a single transit graph can be removed at once. Multiple graph support is plan for a future release.
+
+        :Arguments:
+            **period_ids** (:obj:`int`): List of periods of to save. Defaults to 'project.network.periods.default_period.period_id'.
+            **suppress_warning** (:obj:`bool`): Suppress the warning about single transit graph support. Default 'False'.
+
+        """
+        # TODO: Support multiple graph saving
+        if not suppress_warning:
+            warnings.warn(
+                "Currently only a single transit graph removed at once. Multiple graph support is plan for a future release."
+            )
+
         if period_ids is None:
             period_ids = [self.periods.default_period.period_id]
 
@@ -111,13 +163,25 @@ class Transit(WorkerThread):
             raise ValueError("Multiple graphs can currently be saved.")
 
         for period_id in period_ids:
-            self.graphs[period_id].save()
+            TransitGraphBuilder.remove(self.pt_con, period_id)
 
-    def load(self, period_ids: List[int] = None):
+    def load(self, period_ids: List[int] = None, suppress_warning: bool = False):
+        """
+        Load the previously saved transit graphs from the 'public_transport.sqlite' database. Loading may be filtered
+        by 'period_id'.
+
+        NOTE: Currently only a single transit graph can be saved and reloaded. Multiple graph support is plan for a future release.
+
+        :Arguments:
+            **period_ids** (:obj:`int`): List of periods of to save. Defaults to 'project.network.periods.default_period.period_id'.
+            **suppress_warning** (:obj:`bool`): Suppress the warning about single transit graph support. Default 'False'.
+
+        """
         # TODO: Support multiple graph loading
-        warnings.warn(
-            "Currently only a single transit graph can be saved and reloaded. Multiple graph support is plan for a future release. `period_ids` argument is currently ignored."
-        )
+        if not suppress_warning:
+            warnings.warn(
+                "Currently only a single transit graph can be saved and reloaded. Multiple graph support is plan for a future release. `period_ids` argument is currently ignored."
+            )
 
         if period_ids is None:
             period_ids = [self.periods.default_period.period_id]

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -18,6 +18,8 @@ import pyproj
 import shapely
 import shapely.ops
 import json
+import sqlite3
+
 from aequilibrae.utils.geo_utils import haversine
 from aequilibrae.project.database_connection import database_connection
 from scipy.spatial import KDTree, minkowski_distance
@@ -94,7 +96,7 @@ class TransitGraphBuilder:
 
     def __init__(
         self,
-        public_transport_conn,
+        public_transport_conn: sqlite3.Connection,
         period_id: int = 1,
         time_margin: int = 0,
         projected_crs: str = "EPSG:3857",
@@ -110,11 +112,8 @@ class TransitGraphBuilder:
         connector_method: str = "nearest_neighbour",
         max_connectors_per_zone: int = -1,
     ):
-        self.pt_conn = public_transport_conn  # sqlite connection
-        self.pt_conn.enable_load_extension(True)
-        self.pt_conn.load_extension("mod_spatialite")
-
-        self.project_conn = database_connection("project_database")
+        self.pt_conn = public_transport_conn
+        self.project_conn: sqlite3.Connection = database_connection("project_database")
 
         self.period_id = period_id
         start, end = self.project_conn.execute(
@@ -1320,24 +1319,23 @@ class TransitGraphBuilder:
         # This graph requires some additional tables and fields in order to store all our information.
         # Currently it mimics what we are storing in the df
 
-        self.pt_conn.executemany(
-            """
-            INSERT OR IGNORE INTO link_types (link_type, link_type_id, description) VALUES (?, ?, ?)
-            """,
-            [
-                ("on-board", "o", "From boarding to alighting"),
-                ("boarding", "b", "From stop to boarding"),
-                ("alighting", "a", "From alighting to stop"),
-                ("dwell", "d", "From alighting to boarding"),
-                ("access_connector", "A", ""),
-                ("egress_connector", "e", ""),
-                ("inner_transfer", "t", "Transfer edge within station, from alighting to boarding"),
-                ("outer_transfer", "T", "Transfer edge outside of a station, from alighting to boarding"),
-                ("walking", "w", "Walking, from stop or walking to stop or walking"),
-            ],
-        )
-
-        self.pt_conn.commit()
+        with self.pt_conn as conn:
+            conn.executemany(
+                """
+                INSERT OR IGNORE INTO link_types (link_type, link_type_id, description) VALUES (?, ?, ?)
+                """,
+                [
+                    ("on-board", "o", "From boarding to alighting"),
+                    ("boarding", "b", "From stop to boarding"),
+                    ("alighting", "a", "From alighting to stop"),
+                    ("dwell", "d", "From alighting to boarding"),
+                    ("access_connector", "A", ""),
+                    ("egress_connector", "e", ""),
+                    ("inner_transfer", "t", "Transfer edge within station, from alighting to boarding"),
+                    ("outer_transfer", "T", "Transfer edge outside of a station, from alighting to boarding"),
+                    ("walking", "w", "Walking, from stop or walking to stop or walking"),
+                ],
+            )
 
     def save_vertices(self, robust=True):
         """
@@ -1366,17 +1364,16 @@ class TransitGraphBuilder:
         #     An object to iterate over namedtuples for each row in the DataFrame with the first field possibly being
         #     the index and following fields being the column values.
         # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.itertuples.html
-        self.pt_conn.executemany(
-            f"""\
-            INSERT INTO nodes ({",".join(SF_VERTEX_COLS)},modes)
-            VALUES({",".join("?" * (len(SF_VERTEX_COLS) - 1))},GeomFromWKB(?, {self.__global_crs.to_epsg()}),"t");
-            """,
-            (self.vertices if robust else self.vertices[~duplicated])[SF_VERTEX_COLS].itertuples(
-                index=False, name=None
-            ),
-        )
-
-        self.pt_conn.commit()
+        with self.pt_conn as conn:
+            conn.executemany(
+                f"""\
+                INSERT INTO nodes ({",".join(SF_VERTEX_COLS)},modes)
+                VALUES({",".join("?" * (len(SF_VERTEX_COLS) - 1))},GeomFromWKB(?, {self.__global_crs.to_epsg()}),"t");
+                """,
+                (self.vertices if robust else self.vertices[~duplicated])[SF_VERTEX_COLS].itertuples(
+                    index=False, name=None
+                ),
+            )
 
     def save_edges(self, recreate_line_geometry=False):
         """
@@ -1391,27 +1388,27 @@ class TransitGraphBuilder:
         if "geometry" not in self.edges.columns or recreate_line_geometry:
             self.create_line_geometry()
 
-        # In order to save the line strings from connector project matching we need to disable some smart node creation.
-        # It will be restored to its previous value once we are done here.
-        val = self.pt_conn.execute(
-            "SELECT enabled FROM trigger_settings WHERE name = 'new_link_a_or_b_node'"
-        ).fetchone()[0]
-        self.pt_conn.execute("UPDATE trigger_settings SET enabled = ? WHERE name = 'new_link_a_or_b_node'", (False,))
-        self.pt_conn.executemany(
-            f"""\
-            INSERT INTO links ({",".join(SF_EDGE_COLS)},geometry,modes)
-            VALUES({",".join("?" * len(SF_EDGE_COLS))},GeomFromWKB(?, {self.__global_crs.to_epsg()}),"t");
-            """,
-            self.edges[SF_EDGE_COLS + ["geometry"]].itertuples(index=False, name=None),
-        )
+        with self.pt_conn as conn:
+            # In order to save the line strings from connector project matching we need to disable some smart node creation.
+            # It will be restored to its previous value once we are done here.
+            val = conn.execute(
+                "SELECT enabled FROM trigger_settings WHERE name = 'new_link_a_or_b_node'"
+            ).fetchone()[0]
+            conn.execute("UPDATE trigger_settings SET enabled = ? WHERE name = 'new_link_a_or_b_node'", (False,))
+            conn.executemany(
+                f"""\
+                INSERT INTO links ({",".join(SF_EDGE_COLS)},geometry,modes)
+                VALUES({",".join("?" * len(SF_EDGE_COLS))},GeomFromWKB(?, {self.__global_crs.to_epsg()}),"t");
+                """,
+                self.edges[SF_EDGE_COLS + ["geometry"]].itertuples(index=False, name=None),
+            )
 
-        self.pt_conn.execute("UPDATE trigger_settings SET enabled = ? WHERE name = 'new_link_a_or_b_node'", (val,))
-        self.pt_conn.commit()
+            conn.execute("UPDATE trigger_settings SET enabled = ? WHERE name = 'new_link_a_or_b_node'", (val,))
 
     def save_config(self):
-        sql = "INSERT OR REPLACE INTO transit_graph_configs (period_id,config) VALUES (?,?)"
-        self.project_conn.execute(sql, [self.period_id, json.dumps(self.config)])
-        self.project_conn.commit()
+        with self.project_conn as conn:
+            sql = "INSERT OR REPLACE INTO transit_graph_configs (period_id,config) VALUES (?,?)"
+            conn.execute(sql, [self.period_id, json.dumps(self.config)])
 
     def save(self, robust=True):
         """Save the current graph to the public transport database.

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -1346,23 +1346,20 @@ class TransitGraphBuilder:
         """
         duplicated = self.vertices.geometry.duplicated()
 
-        if not robust and not duplicated.empty:
+        if not robust and duplicated.any():
             warnings.warn(
-                "Duplicated geometry was detected but robust was disabled, verticies that share the same geometry will not be saved.",
+                "Duplicated geometry was detected but robust was disabled, vertices that share the same geometry will not be saved.",
                 warnings.RuntimeWarning,
             )
 
-        if robust and not duplicated.empty:
+        if robust and duplicated.any():
             df = shift_duplicate_geometry(self.vertices[["node_id", "geometry"]][duplicated])
             self.vertices.loc[df.index, "geometry"] = df.geometry
 
-        # The below query is formatted to line the columns up The order of the tuples should be the same
-        # as the order of the columns.
-        #
-        #     An object to iterate over namedtuples for each row in the DataFrame with the first field possibly being
-        #     the index and following fields being the column values.
-        # https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.itertuples.html
         with self.pt_conn as conn:
+            if conn.execute("SELECT node_id FROM nodes LIMIT 1;").fetchall():
+                raise ValueError("cannot save nodes into a database with existing nodes")
+
             conn.executemany(
                 f"""\
                 INSERT INTO nodes ({",".join(SF_VERTEX_COLS)},modes)
@@ -1387,6 +1384,9 @@ class TransitGraphBuilder:
             self.create_line_geometry()
 
         with self.pt_conn as conn:
+            if conn.execute("SELECT link_id FROM links LIMIT 1;").fetchall():
+                raise ValueError("cannot save links into a database with existing links")
+
             # In order to save the line strings from connector project matching we need to disable some smart node creation.
             # It will be restored to its previous value once we are done here.
             val = conn.execute(

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -1402,9 +1402,7 @@ class TransitGraphBuilder:
 
             # In order to save the line strings from connector project matching we need to disable some smart node creation.
             # It will be restored to its previous value once we are done here.
-            val = conn.execute(
-                "SELECT enabled FROM trigger_settings WHERE name = 'new_link_a_or_b_node'"
-            ).fetchone()[0]
+            val = conn.execute("SELECT enabled FROM trigger_settings WHERE name = 'new_link_a_or_b_node'").fetchone()[0]
             conn.execute("UPDATE trigger_settings SET enabled = ? WHERE name = 'new_link_a_or_b_node'", (False,))
             conn.executemany(
                 f"""\

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -596,17 +596,16 @@ class TransitGraphBuilder:
 
         # reset index and copy it to column
         self.vertices.reset_index(drop=True, inplace=True)
-        self.vertices.index.name = "index"
         self.vertices["node_id"] = self.vertices.index + 1
         self.vertices = self.vertices[SF_VERTEX_COLS]
         self.create_od_node_mapping()
 
         # data types
         self.vertices.node_id = self.vertices.node_id.astype(int)
-        self.vertices["node_type"] = self.vertices["node_type"].astype("category")
+        self.vertices["node_type"] = self.vertices["node_type"]
         self.vertices.stop_id = self.vertices.stop_id.fillna("").astype(str)
         self.vertices.line_id = self.vertices.line_id.fillna("").astype(str)
-        self.vertices.line_seg_idx = self.vertices.line_seg_idx.fillna(-1).astype("int32")
+        self.vertices.line_seg_idx = self.vertices.line_seg_idx.fillna(-1).astype("int64")
         self.vertices.taz_id = self.vertices.taz_id.fillna("").astype(str)
 
     def _create_on_board_edges(self):
@@ -1150,7 +1149,6 @@ class TransitGraphBuilder:
 
         # reset index and copy it to column
         self.edges.reset_index(drop=True, inplace=True)
-        self.edges.index.name = "index"
         self.edges["link_id"] = self.edges.index + 1
         for col in SF_EDGE_COLS:
             if col not in self.edges:
@@ -1158,12 +1156,12 @@ class TransitGraphBuilder:
         self.edges = self.edges[SF_EDGE_COLS]
 
         # data types
-        self.edges["link_type"] = self.edges["link_type"].astype("category")
+        self.edges["link_type"] = self.edges["link_type"]
         self.edges.line_id = self.edges.line_id.fillna("").astype(str)
         self.edges.stop_id = self.edges.stop_id.fillna("").astype(str)
-        self.edges.line_seg_idx = self.edges.line_seg_idx.fillna(-1).astype("int32")
-        self.edges.b_node = self.edges.b_node.astype("int32")
-        self.edges.a_node = self.edges.a_node.astype("int32")
+        self.edges.line_seg_idx = self.edges.line_seg_idx.fillna(-1).astype("int64")
+        self.edges.b_node = self.edges.b_node.astype("int64")
+        self.edges.a_node = self.edges.a_node.astype("int64")
         self.edges.trav_time = self.edges.trav_time.astype(float)
         self.edges.freq = self.edges.freq.astype(float)
         self.edges.o_line_id = self.edges.o_line_id.fillna("").astype(str)
@@ -1483,6 +1481,7 @@ class TransitGraphBuilder:
             sql=f"SELECT {','.join(SF_EDGE_COLS)} FROM links;",
             con=public_transport_conn,
         )
+        graph.edges.direction = graph.edges.direction.astype("int8")
 
         return graph
 

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -1370,6 +1370,19 @@ class TransitGraphBuilder:
                 ),
             )
 
+    @staticmethod
+    def remove_vertices(pt_conn: sqlite3.Connection, period_id: int = None):
+        """
+        Remove a transit graph's vertices from the public transport database specified by it's 'period_id'.
+
+        :Arguments:
+            **pt_conn** (:obj:`sqlite3.Connection`): Connection to the ``public_transport.sqlite`` database.
+            **period_id** (:obj:`int`): Unused argument. Support for multiple periods is planned.
+
+        """
+        with pt_conn as conn:
+            conn.execute("DELETE FROM nodes")
+
     def save_edges(self, recreate_line_geometry=False):
         """
         Save the contents of self.edges to the public transport database.
@@ -1403,21 +1416,56 @@ class TransitGraphBuilder:
 
             conn.execute("UPDATE trigger_settings SET enabled = ? WHERE name = 'new_link_a_or_b_node'", (val,))
 
+    @staticmethod
+    def remove_edges(pt_conn: sqlite3.Connection, period_id: int = None):
+        """
+        Remove a transit graph's edges from the public transport database specified by it's 'period_id'.
+
+        :Arguments:
+            **pt_conn** (:obj:`sqlite3.Connection`): Connection to the ``public_transport.sqlite`` database.
+            **period_id** (:obj:`int`): Unused argument. Support for multiple periods is planned.
+
+        """
+        with pt_conn as conn:
+            conn.execute("DELETE FROM links")
+
     def save_config(self):
         with self.project_conn as conn:
             sql = "INSERT OR REPLACE INTO transit_graph_configs (period_id,config) VALUES (?,?)"
             conn.execute(sql, [self.period_id, json.dumps(self.config)])
 
+    @staticmethod
+    def remove_config(conn: sqlite3.Connection, period_id: int):
+        """
+        Remove a transit graph configuration from the project database specified by it's 'period_id'.
+
+        :Arguments:
+            **conn** (:obj:`sqlite3.Connection`): Connection to the ``project.sqlite`` database.
+            **period_id** (:obj:`int`): 'period_id' key for the 'transit_graph_configs' table.
+
+        """
+        with conn as conn:
+            sql = "DELETE FROM transit_graph_configs WHERE period_id = ?"
+            conn.execute(sql, [period_id])
+
     def save(self, robust=True):
         """Save the current graph to the public transport database.
 
+        Within the database nodes may not exist at the exact same point in space, provide ``robust=True`` to move the nodes slightly.
+
         :Arguments:
-           **recreate_line_geometry** (:obj:`bool`): Whether to recreate the line strings for the edges as direct lines. Defaults to ``False``.
+            **robust** (:obj:`bool`): Whether to move stack nodes slightly before saving. Defaults to ``True``.
         """
         self.create_additional_db_fields()
         self.save_vertices(robust=robust)
         self.save_edges()
         self.save_config()
+
+    @classmethod
+    def remove(cls, pt_conn: sqlite3.Connection, period_id: int):
+        cls.remove_edges(pt_conn, period_id)
+        cls.remove_vertices(pt_conn, period_id)
+        cls.remove_config(database_connection("project_database"), period_id)
 
     def to_transit_graph(self) -> TransitGraph:
         """Create an AequilibraE ``TransitGraph`` object from an SF graph builder."""
@@ -1462,23 +1510,26 @@ class TransitGraphBuilder:
            **public_transport_conn** (:obj:`sqlite3.Connection`): Connection to the 'public_transport.sqlite' database.
         """
         project_conn = database_connection("project_database")
-        config = json.loads(
-            project_conn.execute(
-                "SELECT config FROM transit_graph_configs WHERE period_id = ? LIMIT 1;", [period_id]
-            ).fetchone()[0]
-        )
+        config = project_conn.execute(
+            "SELECT config FROM transit_graph_configs WHERE period_id = ? LIMIT 1;", [period_id]
+        ).fetchone()
+
+        if config is None:
+            raise ValueError(f"no transit graph configuration found for 'period_id={period_id}'")
+
+        config = json.loads(config[0])
         config.update(kwargs)
 
         graph = cls(public_transport_conn, **config)
 
         # FIXME Load specific period_id graph from dynamic table
         graph.vertices = pd.read_sql_query(
-            sql=f"SELECT {','.join(SF_VERTEX_COLS)} FROM nodes;",
+            sql=f"SELECT {','.join(SF_VERTEX_COLS[:-1])}, ST_asBinary(\"geometry\") as geometry FROM nodes;",
             con=public_transport_conn,
         )
 
         graph.edges = pd.read_sql_query(
-            sql=f"SELECT {','.join(SF_EDGE_COLS)} FROM links;",
+            sql=f"SELECT {','.join(SF_EDGE_COLS)}, ST_asBinary(\"geometry\") as geometry FROM links;",
             con=public_transport_conn,
         )
         graph.edges.direction = graph.edges.direction.astype("int8")

--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -601,8 +601,7 @@ class TransitGraphBuilder:
         self.create_od_node_mapping()
 
         # data types
-        self.vertices.node_id = self.vertices.node_id.astype(int)
-        self.vertices["node_type"] = self.vertices["node_type"]
+        self.vertices.node_id = self.vertices.node_id.astype("int64")
         self.vertices.stop_id = self.vertices.stop_id.fillna("").astype(str)
         self.vertices.line_id = self.vertices.line_id.fillna("").astype(str)
         self.vertices.line_seg_idx = self.vertices.line_seg_idx.fillna(-1).astype("int64")
@@ -1156,7 +1155,6 @@ class TransitGraphBuilder:
         self.edges = self.edges[SF_EDGE_COLS]
 
         # data types
-        self.edges["link_type"] = self.edges["link_type"]
         self.edges.line_id = self.edges.line_id.fillna("").astype(str)
         self.edges.stop_id = self.edges.stop_id.fillna("").astype(str)
         self.edges.line_seg_idx = self.edges.line_seg_idx.fillna(-1).astype("int64")
@@ -1525,11 +1523,18 @@ class TransitGraphBuilder:
             sql=f"SELECT {','.join(SF_VERTEX_COLS[:-1])}, ST_asBinary(\"geometry\") as geometry FROM nodes;",
             con=public_transport_conn,
         )
+        graph.vertices.node_id = graph.vertices.node_id.astype("int64")
+        graph.vertices.line_seg_idx = graph.vertices.line_seg_idx.astype("int64")
 
         graph.edges = pd.read_sql_query(
             sql=f"SELECT {','.join(SF_EDGE_COLS)}, ST_asBinary(\"geometry\") as geometry FROM links;",
             con=public_transport_conn,
         )
+        graph.edges.line_id = graph.edges.line_id.fillna("").astype(str)
+        graph.edges.stop_id = graph.edges.stop_id.fillna("").astype(str)
+        graph.edges.line_seg_idx = graph.edges.line_seg_idx.astype("int64")
+        graph.edges.b_node = graph.edges.b_node.astype("int64")
+        graph.edges.a_node = graph.edges.a_node.astype("int64")
         graph.edges.direction = graph.edges.direction.astype("int8")
 
         return graph

--- a/aequilibrae/utils/db_utils.py
+++ b/aequilibrae/utils/db_utils.py
@@ -33,16 +33,21 @@ class commit_and_close:
 
             **missing_ok** (:obj:`bool`): Boolean indicating that the db is not expected to exist yet
         """
-        from aequilibrae.utils.spatialite_utils import connect_spatialite
+        from aequilibrae.utils.spatialite_utils import connect_spatialite, load_spatialite_extension
 
         if spatial:
-            if not isinstance(db, (str, PathLike)):
+            if isinstance(db, Connection):
+                load_spatialite_extension(db)
+                self.conn = db
+            elif not isinstance(db, (str, PathLike)):
                 raise Exception("You must provide a database path to connect to spatialite")
-            self.conn = connect_spatialite(db, missing_ok)
+            else:
+                self.conn = connect_spatialite(db, missing_ok)
         elif isinstance(db, (str, PathLike)):
             self.conn = safe_connect(db, missing_ok)
         else:
             self.conn = db
+
         self.commit = commit
 
     def __enter__(self):

--- a/aequilibrae/utils/spatialite_utils.py
+++ b/aequilibrae/utils/spatialite_utils.py
@@ -44,9 +44,13 @@ def connect_spatialite(path_to_file: os.PathLike, missing_ok: bool = False) -> C
 
 def _connect_spatialite(path_to_file: os.PathLike, missing_ok: bool = False):
     conn = safe_connect(path_to_file, missing_ok)
+    load_spatialite_extension(conn)
+    return conn
+
+
+def load_spatialite_extension(conn: Connection):
     conn.enable_load_extension(True)
     conn.load_extension("mod_spatialite")
-    return conn
 
 
 def is_spatialite(conn):

--- a/docs/source/public_transport/examples/plot_public_transit_assignment.py
+++ b/docs/source/public_transport/examples/plot_public_transit_assignment.py
@@ -98,6 +98,11 @@ data.save_graphs()
 data.load()
 
 # %%
+# We can also remove the previously saved graphs.
+
+# data.remove_graphs()
+
+# %%
 # Links and nodes are stored in a similar manner to the 'project_database.sqlite' database.
 # 
 # Reading back into AequilibraE

--- a/tests/aequilibrae/paths/test_transit_graph_builder.py
+++ b/tests/aequilibrae/paths/test_transit_graph_builder.py
@@ -170,4 +170,3 @@ class TestTransitGraphBuilder(TestCase):
 
             with self.assertRaises(ValueError):
                 self.data.load(suppress_warning=True)
-

--- a/tests/aequilibrae/paths/test_transit_graph_builder.py
+++ b/tests/aequilibrae/paths/test_transit_graph_builder.py
@@ -1,22 +1,23 @@
-from unittest import TestCase
 import os
 import tempfile
-import numpy as np
-from aequilibrae.paths import TransitGraph
 from os.path import join
+from shutil import copytree, rmtree
+from unittest import TestCase
 from uuid import uuid4
-from aequilibrae.project import Project
-from ...data import siouxfalls_project
-from aequilibrae.paths.results import PathResults
-from aequilibrae.utils.create_example import create_example
-from aequilibrae.transit import Transit
 
+import numpy as np
+import pandas as pd
+
+from aequilibrae.paths import TransitGraph
+from aequilibrae.paths.results import PathResults
+from aequilibrae.project import Project
+from aequilibrae.transit import Transit
+from aequilibrae.utils.create_example import create_example
 
 # Adds the folder with the data to the path and collects the paths to the files
 # lib_path = os.path.abspath(os.path.join('..', '../tests'))
 # sys.path.append(lib_path)
-from ...data import path_test, test_graph, test_network
-from shutil import copytree, rmtree
+from ...data import path_test, siouxfalls_project, test_graph, test_network
 
 
 class TestTransitGraphBuilder(TestCase):
@@ -134,3 +135,39 @@ class TestTransitGraphBuilder(TestCase):
             len(graph.edges[graph.edges.link_type == "access_connector"]),
             len(graph.edges[graph.edges.link_type == "egress_connector"]),
         )
+
+    def test_saving_loading_removing(self):
+        connector_method = "nearest_neighbour"
+        graph1 = self.data.create_graph(
+            with_outer_stop_transfers=False,
+            with_walking_edges=False,
+            blocking_centroid_flows=False,
+            connector_method=connector_method,
+        )
+
+        with self.subTest("reloading transit graph"):
+            self.data.save_graphs(suppress_warning=True)
+            self.data.load(suppress_warning=True)
+            graph2 = self.data.graphs[1]
+
+            pd.testing.assert_frame_equal(graph1.edges, graph2.edges)
+            pd.testing.assert_frame_equal(graph1.vertices, graph2.vertices)
+            self.assertDictEqual(graph1.config, graph2.config)
+
+        with self.subTest("cannot override existing graph"):
+            with self.assertRaises(ValueError):
+                self.data.save_graphs(suppress_warning=True)
+
+        with self.subTest("removing transit graph"):
+            self.data.save_graphs(suppress_warning=True, force=True)
+            self.data.remove_graphs()
+
+            links = self.data.pt_con.execute("SELECT link_id FROM links LIMIT 1;")
+            nodes = self.data.pt_con.execute("SELECT node_id FROM nodes LIMIT 1;")
+
+            self.assertListEqual(links.fetchall(), [])
+            self.assertListEqual(nodes.fetchall(), [])
+
+            with self.assertRaises(ValueError):
+                self.data.load(suppress_warning=True)
+


### PR DESCRIPTION
This adds a function to remove the transit graph (links, nodes, and config) from the `public_transport.sqlite` and `project.sqlite` databases. It's accessible from the `TransitGraphBuilder`  and `Transit` objects. It also prevents saving when a link or node already exists.

I've also added some more documentation and tests, and the ability to suppress the "only one transit graph" warning.

It also allows the `commit_and_close` class to accept a `sqlite3.Connection` object as per the type hints.