### PR TITLE
Default to zstd compression for route choice results

### DIFF
--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -124,7 +124,8 @@ cdef class RouteChoiceSetResults:
             schema=self.psl_schema if self.perform_assignment else self.schema,
             use_threads=True,
             existing_data_behavior="overwrite_or_ignore",
-            file_visitor=lambda written_file: logger.info(f"Wrote partition dataset at {written_file.path}")
+            file_visitor=lambda written_file: logger.info(f"Wrote partition dataset at {written_file.path}"),
+            compression="zstd",
         )
 
     @classmethod

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -20,6 +20,7 @@ from aequilibrae.context import get_active_project
 from aequilibrae.matrix import AequilibraeMatrix
 from aequilibrae.paths.graph import Graph, _get_graph_to_network_mapping
 from aequilibrae.paths.cython.route_choice_set import RouteChoiceSet
+from aequilibrae.paths.cython.route_choice_set_results import RouteChoiceSetResults
 from aequilibrae.matrix.coo_demand import GeneralisedCOODemand
 
 
@@ -347,7 +348,7 @@ class RouteChoice:
         if self.where is None:
             results = self.__rc.get_results()
         else:
-            results = self.__rc.results.read_dataset(self.where)
+            results = RouteChoiceSetResults.read_dataset(self.where)
 
         return results
 


### PR DESCRIPTION
Also allow reading results just by setting the `where` attribute.