### PR TITLE
Add direction to route choice path files

### DIFF
--- a/aequilibrae/paths/cython/graph_building.pyx
+++ b/aequilibrae/paths/cython/graph_building.pyx
@@ -413,13 +413,15 @@ def create_compressed_link_network_mapping(graph):
         )
 
     cdef:
-        long long i, j, a_node, x, b_node, tmp, compressed_id, dup_idx
+        long long i, j, a_node, x, b_node, tmp, compressed_id, non_duplicated_idx
         long long[:] b
         long long[:] values
+        signed char[:] directions
         np.uint32_t[:] idx
-        np.uint32_t[:] data
+        np.int64_t[::] data
         np.int32_t[:] node_mapping
-        np.int64_t[:, :] dups
+        np.int64_t[:, :] non_duplicated
+        signed char direction
 
     # This method requires that graph.graph is sorted on the a_node IDs, since that's done already we don't
     # bother redoing sorting it.
@@ -427,19 +429,19 @@ def create_compressed_link_network_mapping(graph):
     # Some links are completely removed from the network, they are assigned ID `graph.compact_graph.id.max() + 1`,
     # we skip them.
     filtered = graph.graph[graph.graph.__compressed_id__ != graph.compact_graph.id.max() + 1]
-    filtered = filtered[["__compressed_id__", "a_node", "b_node", "link_id"]]
+    filtered = filtered[["__compressed_id__", "a_node", "b_node", "link_id", "direction"]]
     duplicated = filtered.__compressed_id__.duplicated(keep=False)
     gb = filtered[duplicated].groupby(by="__compressed_id__", sort=True)
 
     idx = np.zeros(graph.compact_num_links + 1, dtype=np.uint32)
-    data = np.zeros(len(filtered), dtype=np.uint32)
+    data = np.zeros(len(filtered), dtype=np.int64)
     node_mapping = np.full(graph.num_nodes, -1, dtype=np.int32)
 
     compact_a_nodes = graph.compact_graph["a_node"].to_numpy()
     compact_b_nodes = graph.compact_graph["b_node"].to_numpy()
 
-    dup_idx = 0
-    dups = filtered[~duplicated].sort_values(by="__compressed_id__").to_numpy()
+    non_duplicated_idx = 0
+    non_duplicated = filtered[~duplicated].sort_values(by="__compressed_id__").to_numpy()
 
     i = 0
     # This should be possible to parallelise, each thread gets a segment of the bincount below, they compute their
@@ -449,16 +451,17 @@ def create_compressed_link_network_mapping(graph):
         # We separate the easy un-compressible link path from the compressible link path
         # gb.get_group and those sorted searches are rather slow
         if count == 1:
-            compressed_id, a_node, b_node, link_id = dups[dup_idx]
-            dup_idx += 1
+            compressed_id, a_node, b_node, link_id, direction = non_duplicated[non_duplicated_idx]
+            non_duplicated_idx += 1
             idx[compressed_id] = i
-            data[i] = link_id
+            data[i] = link_id * direction
             node_mapping[a_node] = compact_a_nodes[compressed_id]
             node_mapping[b_node] = compact_b_nodes[compressed_id]
         else:
             df = gb.get_group(compressed_id)
             idx[compressed_id] = i
             values = df.link_id.to_numpy()
+            directions = df.direction.to_numpy()
             a = df.a_node.to_numpy()
             b = df.b_node.to_numpy()
 
@@ -473,7 +476,7 @@ def create_compressed_link_network_mapping(graph):
                 tmp = a.searchsorted(x)
                 if tmp < len(a) and a[tmp] == x:
                     x = b[tmp]
-                    data[i + j] = values[tmp]
+                    data[i + j] = values[tmp] * directions[tmp]
                 else:
                     break
                 j += 1

--- a/aequilibrae/paths/cython/route_choice_set.pxd
+++ b/aequilibrae/paths/cython/route_choice_set.pxd
@@ -6,6 +6,7 @@ from aequilibrae.paths.cython.route_choice_link_loading_results cimport LinkLoad
 from libcpp.vector cimport vector
 
 from aequilibrae.paths.cython.route_choice_types cimport RouteSet_t
+from libc.stdint cimport *
 
 
 cdef class RouteChoiceSet:
@@ -26,7 +27,7 @@ cdef class RouteChoiceSet:
         bint a_star
 
         unsigned int [:] mapping_idx
-        unsigned int [:] mapping_data
+        int64_t [::] mapping_data
 
         readonly RouteChoiceSetResults results
         readonly LinkLoadingResults ll_results

--- a/aequilibrae/paths/cython/route_choice_set_results.pxd
+++ b/aequilibrae/paths/cython/route_choice_set_results.pxd
@@ -3,6 +3,7 @@ from aequilibrae.paths.cython.route_choice_types cimport (
     RouteVec_t,
     RouteSet_t,
     CUInt32Builder,
+    CInt64Builder,
     CDoubleBuilder,
     CBooleanBuilder
 )
@@ -10,6 +11,8 @@ from aequilibrae.paths.cython.route_choice_types cimport (
 from libcpp.vector cimport vector
 from libcpp.memory cimport shared_ptr
 from libcpp cimport bool
+from libc.stdint cimport *
+
 
 cdef class RouteChoiceSetResults:
     cdef:
@@ -20,7 +23,7 @@ cdef class RouteChoiceSetResults:
         double beta
         double[:] cost_view
         unsigned int [:] mapping_idx
-        unsigned int [:] mapping_data
+        int64_t [::] mapping_data
 
         vector[shared_ptr[RouteVec_t]] __route_vecs
         vector[vector[long long] *] __link_union_set

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -24,7 +24,7 @@ cdef class RouteChoiceSetResults:
     provides method to perform an assignment and link loading.
     """
 
-    route_set_dtype = pa.list_(pa.uint32())
+    route_set_dtype = pa.list_(pa.int64())
 
     schema = pa.schema([
         pa.field("origin id", pa.uint32(), nullable=False),
@@ -50,7 +50,7 @@ cdef class RouteChoiceSetResults:
             num_links: int,
             double[:] cost_view,
             unsigned int [:] mapping_idx,
-            unsigned int [:] mapping_data,
+            int64_t [::] mapping_data,
             store_results: bool = True,
             perform_assignment: bool = True,
     ):
@@ -474,7 +474,7 @@ cdef class RouteChoiceSetResults:
             # Custom imports, these are declared in route_choice.pxd *not* libarrow.  We have to use new here because
             # Cython doesn't support passing arguments to the default constructor as it implicitly constructs them and
             # Pyarrow only exposes the single constructor in Cython.
-            CUInt32Builder *path_builder = new CUInt32Builder(pool)
+            CInt64Builder *path_builder = new CInt64Builder(pool)
             CDoubleBuilder *cost_col = <CDoubleBuilder *>nullptr
             CBooleanBuilder *mask_col = <CBooleanBuilder *>nullptr
             CDoubleBuilder *path_overlap_col = <CDoubleBuilder *>nullptr

--- a/aequilibrae/paths/cython/route_choice_types.pxd
+++ b/aequilibrae/paths/cython/route_choice_types.pxd
@@ -115,6 +115,16 @@ cdef extern from "arrow/builder.h" namespace "arrow" nogil:
         )
         libpa.CStatus AppendValues(const uint32_t *values, int64_t length, const uint8_t *valid_bytes = nullptr)
 
+    cdef cppclass CInt64Builder" arrow::Int64Builder"(libpa.CArrayBuilder):
+        CInt64Builder(libpa.CMemoryPool* pool)
+        libpa.CStatus Append(const int64_t value)
+        libpa.CStatus AppendValues(const vector[int64_t] &values)
+        libpa.CStatus AppendValues(
+            vector[int64_t].const_reverse_iterator values_begin,
+            vector[int64_t].const_reverse_iterator values_end
+        )
+        libpa.CStatus AppendValues(const int64_t *values, int64_t length, const uint8_t *valid_bytes = nullptr)
+
     cdef cppclass CDoubleBuilder" arrow::DoubleBuilder"(libpa.CArrayBuilder):
         CDoubleBuilder(libpa.CMemoryPool* pool)
         libpa.CStatus Append(const double value)

--- a/aequilibrae/paths/graph.py
+++ b/aequilibrae/paths/graph.py
@@ -120,6 +120,7 @@ class GraphBase(ABC):  # noqa: B024
 
         self.compressed_link_network_mapping_idx = None
         self.compressed_link_network_mapping_data = None
+        self.network_compressed_node_mapping = None
 
         # Randomly generate a unique Graph ID randomly
         self._id = uuid.uuid4().hex
@@ -600,6 +601,10 @@ class GraphBase(ABC):  # noqa: B024
         network IDs are then in the range ``idx[id]:idx[id + 1]``.
 
         Links not in the compressed graph are not contained within the 'data' array.
+
+        'node_mapping' provides an easy way to check if a node index is present within the compressed graph. If the
+        value is -1 then the node has been removed, either by compression of dead end link removal. If the value is
+        greater than or equal to 0, then that value is the compressed node index.
 
         .. code-block:: python
 

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -352,10 +352,12 @@ class RouteChoice:
         self.logger.info(self._config)
 
     def get_results(self) -> Union[pa.Table, pa.dataset.Dataset]:
-        """Returns the results of the route choice procedure
+        """
+        Returns the results of the route choice procedure
 
-        Returns a table of OD pairs to lists of link IDs for each OD pair provided (as columns).
-        Represents paths from ``origin`` to ``destination``.
+        Returns a table of OD pairs to lists of link IDs for each OD pair provided (as columns).  Represents paths from
+        ``origin`` to ``destination``. When the link id in the route set is positive it represents the ab direction,
+        while negative represents the ba direction.
 
         If ``save_routes`` was specified then a Pyarrow dataset is returned. The caller is
         responsible for reading this dataset.


### PR DESCRIPTION
Closes #635

This adds direction to the route choice set path files via encoding it in the sign. The change is done on the compressed link network mapping rather than the route choice level, this mapping should have always encoded direction anyway. 

This should be backwards compatible when reading old datasets.