### PR TITLE
Add `keep_original_ods` to SubAreaAnalysis.post_process

### DIFF
--- a/aequilibrae/paths/sub_area.py
+++ b/aequilibrae/paths/sub_area.py
@@ -122,14 +122,17 @@ class SubAreaAnalysis:
 
                     original_ods = (o, d) if keep_original_ods else ()
                     if not o_inside and not d_inside:
-                        through[(self.graph.all_nodes[link1.a_node], self.graph.all_nodes[link2.b_node]) + original_ods] += load
+                        through[
+                            (self.graph.all_nodes[link1.a_node], self.graph.all_nodes[link2.b_node]) + original_ods
+                        ] += load
 
             sub_area_demand.append(
                 pd.DataFrame(
                     list(entered.values()) + list(exited.values()) + list(through.values()),
                     index=pd.MultiIndex.from_tuples(
                         list(entered.keys()) + list(exited.keys()) + list(through.keys()),
-                        names=["origin id", "destination id"] + (["original origin id", "original destination id"] if keep_original_ods else []),
+                        names=["origin id", "destination id"]
+                        + (["original origin id", "original destination id"] if keep_original_ods else []),
                     ),
                     columns=[col],
                 )
@@ -145,7 +148,9 @@ class SubAreaAnalysis:
         interior = self.rc.demand.df.loc[interior]
         if keep_original_ods:
             # We need to duplicate the interior ODs if we're "keeping the originals"
-            interior.index = pd.MultiIndex.from_tuples((x + x for x in interior.index), names=self.sub_area_demand.index.names)
+            interior.index = pd.MultiIndex.from_tuples(
+                (x + x for x in interior.index), names=self.sub_area_demand.index.names
+            )
 
         self.sub_area_demand = pd.concat([self.sub_area_demand, interior]).sort_index()
         return self.sub_area_demand

--- a/aequilibrae/paths/sub_area.py
+++ b/aequilibrae/paths/sub_area.py
@@ -65,13 +65,16 @@ class SubAreaAnalysis:
         self.rc.add_demand(demand)
         self.rc.set_select_links(self.single_edges | self.edge_pairs, link_loading=False)
 
-    def post_process(self, demand_cols=None):
+    def post_process(self, demand_cols=None, keep_original_ods: bool = False):
         """
         Apply the necessary post processing to the route choice assignment select link results.
 
         :Arguments:
             **demand_cols** (*Optional*: :obj:`[list[str]]`): If provided, only construct the
-            sub-area matrix for these demand matrices.
+              sub-area matrix for these demand matrices.
+
+            **keep_original_ods** (*Optional*: :obj:`bool`): If provided, the original origin and destination IDs for
+              the demand will be kept. This will create a significantly larger demand matrix but is more flexible.
 
         :Returns:
             **sub_area_demand** (:obj:`pd.DataFrame`): A DataFrame representing the sub-area
@@ -100,10 +103,11 @@ class SubAreaAnalysis:
                     o_inside = o in self.interior_nodes.index
                     d_inside = d in self.interior_nodes.index
 
+                    original_ods = (o, d) if keep_original_ods else ()
                     if o_inside and not d_inside:
-                        exited[o, self.graph.all_nodes[link.b_node]] += load
+                        exited[(o, self.graph.all_nodes[link.b_node]) + original_ods] += load
                     elif not o_inside and d_inside:
-                        entered[self.graph.all_nodes[link.a_node], d] += load
+                        entered[(self.graph.all_nodes[link.a_node], d) + original_ods] += load
                     elif not o_inside and not d_inside:
                         pass
 
@@ -116,15 +120,16 @@ class SubAreaAnalysis:
                     o_inside = o in self.interior_nodes.index
                     d_inside = d in self.interior_nodes.index
 
+                    original_ods = (o, d) if keep_original_ods else ()
                     if not o_inside and not d_inside:
-                        through[self.graph.all_nodes[link1.a_node], self.graph.all_nodes[link2.b_node]] += load
+                        through[(self.graph.all_nodes[link1.a_node], self.graph.all_nodes[link2.b_node]) + original_ods] += load
 
             sub_area_demand.append(
                 pd.DataFrame(
                     list(entered.values()) + list(exited.values()) + list(through.values()),
                     index=pd.MultiIndex.from_tuples(
                         list(entered.keys()) + list(exited.keys()) + list(through.keys()),
-                        names=["origin id", "destination id"],
+                        names=["origin id", "destination id"] + (["original origin id", "original destination id"] if keep_original_ods else []),
                     ),
                     columns=[col],
                 )
@@ -136,5 +141,11 @@ class SubAreaAnalysis:
                 interior.append((o, d))
 
         self.sub_area_demand = pd.concat(sub_area_demand, axis=1).fillna(0.0)
-        self.sub_area_demand = pd.concat([self.sub_area_demand, self.rc.demand.df.loc[interior]]).sort_index()
+
+        interior = self.rc.demand.df.loc[interior]
+        if keep_original_ods:
+            # We need to duplicate the interior ODs if we're "keeping the originals"
+            interior.index = pd.MultiIndex.from_tuples((x + x for x in interior.index), names=self.sub_area_demand.index.names)
+
+        self.sub_area_demand = pd.concat([self.sub_area_demand, interior]).sort_index()
         return self.sub_area_demand

--- a/docs/source/examples/route_choice/plot_subarea_analysis.py
+++ b/docs/source/examples/route_choice/plot_subarea_analysis.py
@@ -142,10 +142,12 @@ zones.head()
 # Automated sub-area analysis
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# We first construct out ``SubAreaAnalysis`` object from the graph, zones, and matrix we previously
-# constructed, then configure the route choice assignment and execute it. From there the ``post_process``
-# method is able to use the route choice assignment results to construct the desired demand matrix
-# as a DataFrame.
+# We first construct out ``SubAreaAnalysis`` object from the graph, zones, and matrix we previously constructed, then
+# configure the route choice assignment and execute it. From there the ``post_process`` method is able to use the route
+# choice assignment results to construct the desired demand matrix as a DataFrame. If we were interested in the original
+# origin and destination IDs for each entry we could use `subarea.post_process(keep_original_ods=True)` instead. This
+# will attach the true ODs from the select link OD matrix as part of the index. However, this will create a
+# significantly larger matrix, but more flexible matrix.
 from aequilibrae.paths import SubAreaAnalysis
 
 subarea = SubAreaAnalysis(graph, zones, mat)

--- a/docs/source/examples/route_choice/plot_subarea_analysis.py
+++ b/docs/source/examples/route_choice/plot_subarea_analysis.py
@@ -147,7 +147,7 @@ zones.head()
 # choice assignment results to construct the desired demand matrix as a DataFrame. If we were interested in the original
 # origin and destination IDs for each entry we could use `subarea.post_process(keep_original_ods=True)` instead. This
 # will attach the true ODs from the select link OD matrix as part of the index. However, this will create a
-# significantly larger matrix, but more flexible matrix.
+# significantly larger, but more flexible matrix.
 from aequilibrae.paths import SubAreaAnalysis
 
 subarea = SubAreaAnalysis(graph, zones, mat)


### PR DESCRIPTION
This will attach the original OD matrix entries to the index of the returned matrix. This effectively encodes all the SL OD information in the returned matrix. The matrix will be significantly larger as no entries will be able to be combined.