### PR TITLE
Add Route choice assignment from path files

### DIFF
--- a/aequilibrae/paths/cython/pq_4ary_heap.pyx
+++ b/aequilibrae/paths/cython/pq_4ary_heap.pyx
@@ -244,6 +244,9 @@ cdef void _min_heapify(PriorityQueue* pqueue, size_t node_idx) noexcept nogil:
         size_t c1, c2, c3, c4, i = node_idx, s
         DTYPE_t val_tmp, val_min
 
+    if pqueue.size == 0:
+        return
+
     while True:
 
         c1 = 4 * i + 1

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -496,6 +496,7 @@ cdef class RouteChoiceSet:
             if queue.size() + route_set.size() >= max_routes:
                 shuffle(queue.begin(), queue.end(), rng)
 
+            next_queue.clear()
             for banned in queue:
                 if lp:
                     # We copy the penalised cost buffer into the thread cost buffer to allow us to apply link
@@ -553,20 +554,23 @@ cdef class RouteChoiceSet:
                         new_banned = new unordered_set[long long](d(banned))
                         new_banned.insert(connector)
                         # If we've already seen this set of removed links before we already know what the path is and
-                        # its in our route set
+                        # its in our route set.
                         if removed_links.find(new_banned) != removed_links.end():
                             del new_banned
                         else:
                             next_queue.push_back(new_banned)
 
-                    # The deduplication of routes occurs here
+                    # The de-duplication of routes occurs here
                     status = route_set.insert(vec)
-                    miss_count = miss_count + (not status.second)
+                    if not status.second:
+                        del vec  # If the insertion failed, free this vector, we already have one that is equal to it
+                        miss_count = miss_count + 1
+
                     if miss_count > max_misses or route_set.size() >= max_routes:
-                        break
+                        break  # This condition will be hit again at the start of the loop, we just don't want to
+                               # iterate over the rest of the things in queue when we know there is not more space.
 
             queue.swap(next_queue)
-            next_queue.clear()
 
             if lp:
                 # Update the penalised_cost vector, since next_penalised_cost is always the one updated we just need to
@@ -577,7 +581,14 @@ cdef class RouteChoiceSet:
         for banned in queue:
             del banned
 
-        # We should also free all the sets in removed_links, we don't be needing them
+        # We should also free all the sets in next_queue, we don't be needing them.  We remove next_queue before
+        # removed_links because we just swapped it with queue, and removed_links contains a subset of those that were
+        # added to queue (pre-swap). It may share elements so we make sure to erase them from the set before freeing
+        # them to avoid a use-after free.
+        for banned in next_queue:
+            removed_links.erase(banned)
+            del banned
+
         for banned in removed_links:
             del banned
 

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -406,7 +406,7 @@ cdef class RouteChoiceSet:
             warnings.warn(
                 f"found unreachable OD pairs, no choice sets generated for: {unreachable_ods}"
             )
-            
+
     def assign_from_df(
         self,
         graph: pd.DataFrame,
@@ -623,6 +623,7 @@ cdef class RouteChoiceSet:
             # Local variables, Cython doesn't allow conditional declarations
             vector[long long] *vec
             pair[RouteSet_t.iterator, bool] status
+            pair[LinkSet_t.iterator, bool] banned_status
             unsigned int miss_count = 0
             long long p, connector
 
@@ -630,6 +631,12 @@ cdef class RouteChoiceSet:
             bint lp = penalty != 1.0
             vector[double] *penalised_cost = <vector[double] *>nullptr
             vector[double] *next_penalised_cost = <vector[double] *>nullptr
+
+            # Because we can have duplicate banned link sets, the insertion may fail, in that case we free the set
+            # immediately. However, by doing so we then can't tell (without a method to track it), which sets have
+            # already been freed in the queue if we happened to early exit from it, so we use another variable to just
+            # free the remaining items in the queue.
+            bool free_remaining = False
 
         max_routes = max_routes if max_routes != 0 else UINT_MAX
         max_depth = max_depth if max_depth != 0 else UINT_MAX
@@ -656,6 +663,10 @@ cdef class RouteChoiceSet:
 
             next_queue.clear()
             for banned in queue:
+                if free_remaining:
+                    del banned
+                    continue
+
                 if lp:
                     # We copy the penalised cost buffer into the thread cost buffer to allow us to apply link
                     # penalisation,
@@ -680,7 +691,11 @@ cdef class RouteChoiceSet:
                 )
 
                 # Mark this set of banned links as seen
-                removed_links.insert(banned)
+                banned_status = removed_links.insert(banned)
+                if not banned_status.second:
+                    # If we failed to insert this banned set then an equal set already exists within the removed links
+                    del banned
+                    banned = d(banned_status.first)
 
                 # If the destination is reachable we must build the path and readd
                 if thread_predecessors[dest_index] >= 0:
@@ -725,8 +740,9 @@ cdef class RouteChoiceSet:
                         miss_count = miss_count + 1
 
                     if miss_count > max_misses or route_set.size() >= max_routes:
-                        break  # This condition will be hit again at the start of the loop, we just don't want to
-                               # iterate over the rest of the things in queue when we know there is not more space.
+                        free_remaining = True
+                        continue  # This condition will be hit again at the start of the loop, we just don't want to
+                                  # iterate over the rest of the things in queue when we know there is not more space.
                 else:
                     pass
 
@@ -745,9 +761,6 @@ cdef class RouteChoiceSet:
         # removed_links because we just swapped it with queue, and removed_links contains a subset of those that were
         # added to queue (pre-swap). It may share elements so we make sure to erase them from the set before freeing
         # them to avoid a use-after free.
-        for banned in next_queue:
-            removed_links.erase(banned)
-            del banned
 
         for banned in removed_links:
             del banned
@@ -823,7 +836,10 @@ cdef class RouteChoiceSet:
 
                 # To prevent runaway algorithms if we find N duplicate routes we should stop
                 status = route_set.insert(vec)
-                miss_count = miss_count + (not status.second)
+                if not status.second:
+                    del vec  # If the insertion failed, free this vector, we already have one that is equal to it
+                    miss_count = miss_count + 1
+
                 if miss_count > max_misses:
                     break
             else:

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -145,7 +145,7 @@ cdef class RouteChoiceSet:
         self.batched(demand_coo, {}, *args, **kwargs)
         where = kwargs.get("where", None)
         if where is not None:
-            schema = self.psl_schema if kwargs.get("path_size_logit", False) else self.schema
+            schema = RouteChoiceSetResults.psl_schema if kwargs.get("path_size_logit", False) else RouteChoiceSetResults.schema
             results = pa.dataset.dataset(
                 where, format="parquet", partitioning=pa.dataset.HivePartitioning(schema)
             ).to_table()

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -853,3 +853,15 @@ cdef class RouteChoiceSet:
             raise RuntimeError("Link loading results not computed yet")
 
         return self.ll_results.sl_od_matrices_structs_to_objects()
+
+    def write_path_files(RouteChoiceSet self, where):
+        """
+        Write the path-files to the directory specified
+
+        :Arguments:
+            **where** (:obj:`pathlib.Path`): Directory to save the dataset to.
+        """
+        if self.results is None:
+            raise RuntimeError("Route Choice results not computed yet")
+
+        self.results.write(where)

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -402,24 +402,21 @@ cdef class RouteChoiceSet:
             # Scale cutoff prob from [0, 1] -> [0.5, 1]. Values below 0.5 produce negative inverse binary logit values.
             double scaled_cutoff_prob = (1.0 - cutoff_prob) * 0.5 + 0.5
 
-        # We need to know the indices of the demand matrix that our OD pairs correspond to
-        try:
-            od_indices = (
-                demand.df.assign(index=np.arange(len(demand.df)))
-            ).loc[
-                df[["origin id", "destination id"]].drop_duplicates().itertuples(name=None, index=False),
-                "index"
-            ].reset_index()
-        except KeyError:
-            raise KeyError("not all origin and destinations IDs from the path files are present within the demand matrix")
-
         for _, route_list in df["route set"].items():
             if not isinstance(route_list, (list, np.ndarray)):
                 raise TypeError(f"route sets must be a list or Numpy array, found {type(route_list)}")
 
+        # We want to enforce that if the demand matrix cell is non-cell for an OD pair, then at least one route exists to assign to it
+        demand_df = demand.df.assign(idx=np.arange(len(demand.df)))
+        demand_df = demand_df[demand_df.index.get_level_values(0) != demand_df.index.get_level_values(1)]
+
+        df = df.set_index(demand_df.index.names)
+        if not demand_df.index.drop_duplicates().isin(df.index).all():
+            raise KeyError("not all origin and destinations IDs from the demand matrix are present within the path files")
+
         # We also store those indices along side the route sets themselves so it's easier to keep track
-        df = df.merge(od_indices, on=["origin id", "destination id"])
-        gb = df.groupby(by="index")
+        df = demand_df[["idx"]].merge(df, how="left", left_index=True, right_index=True).reset_index()
+        gb = df.groupby(by="idx")
 
         # In order to map the network link IDs to compressed links we'll use the graph
         graph_to_compressed = graph[["link_id", "direction"]].prod(axis=1).reset_index().set_index(0)
@@ -704,6 +701,8 @@ cdef class RouteChoiceSet:
                     if miss_count > max_misses or route_set.size() >= max_routes:
                         break  # This condition will be hit again at the start of the loop, we just don't want to
                                # iterate over the rest of the things in queue when we know there is not more space.
+                else:
+                    pass
 
             queue.swap(next_queue)
 

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -342,8 +342,6 @@ cdef class RouteChoiceSet:
                     # routes. This is done to simplify memory management later on.
                     route_vec = self.results.get_route_vec(i)
                     RouteChoiceSetResults.route_set_to_route_vec(d(route_vec), d(route_set))
-                    # We now drop all references to those raw pointers. The unique pointers now own those vectors.
-                    route_set.clear()
 
                     if path_size_logit:
                         prob_vec = self.results.compute_result(i, d(route_vec), thread_id)

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -18,6 +18,7 @@ from openmp cimport omp_get_max_threads
 from libcpp.memory cimport shared_ptr
 
 from typing import Tuple
+import itertools
 
 import numpy as np
 import pyarrow as pa
@@ -381,6 +382,137 @@ cdef class RouteChoiceSet:
             self.get_link_loading(cores=c_cores)
             self.get_sl_link_loading(cores=c_cores)
             self.get_sl_od_matrices()
+
+    def assign_from_df(
+        self,
+        graph: pd.DataFrame,
+        df: pd.DataFrame,
+        demand: GeneralisedCOODemand,
+        select_links: Dict[str, FrozenSet[FrozenSet[int]]] = None,
+        recompute_psl: bool = False,
+        sl_link_loading: bool = True,
+        store_results: bool = True,
+        beta: float = 1.0,
+        cutoff_prob: float = 0.0,
+    ):
+        cdef:
+            long int c_cores = 1  # Single threaded only due to high python interop, this shoud be fast anyway
+            int thread_id = 0
+
+            # Scale cutoff prob from [0, 1] -> [0.5, 1]. Values below 0.5 produce negative inverse binary logit values.
+            double scaled_cutoff_prob = (1.0 - cutoff_prob) * 0.5 + 0.5
+
+        # We need to know the indices of the demand matrix that our OD pairs correspond to
+        try:
+            od_indices = (
+                demand.df.assign(index=np.arange(len(demand.df)))
+            ).loc[
+                df[["origin id", "destination id"]].drop_duplicates().itertuples(name=None, index=False),
+                "index"
+            ].reset_index()
+        except KeyError:
+            raise KeyError("not all origin and destinations IDs from the path files are present within the demand matrix")
+
+        # We also store those indices along side the route sets themselves so it's easier to keep track
+        df = df.merge(od_indices, on=["origin id", "destination id"])
+        gb = df.groupby(by="index")
+
+        # In order to map the network link IDs to compressed links we'll use the graph
+        graph_to_compressed = graph[["link_id", "direction"]].prod(axis=1).reset_index().set_index(0)
+
+        # Now we initialise the demand matrix and prepare to insert the route sets
+        demand._initalise_col_names()
+        demand._initalise_c_data(None)
+
+        self.results = RouteChoiceSetResults(
+            demand,
+            scaled_cutoff_prob,
+            beta,
+            self.num_links,
+            self.cost_view,
+            self.mapping_idx,
+            self.mapping_data,
+            store_results=store_results,
+            perform_assignment=True,
+        )
+
+        self.ll_results = LinkLoadingResults(demand, select_links, self.num_links, sl_link_loading, c_cores)
+
+        cdef vector[long long] *route
+
+        # We iterate over the OD pairs in the path files
+        for od_idx, df in gb:
+            # We obtain a reference to the route vector, we then need to insert the right *compressed* link IDs
+            route_vec = self.results.get_route_vec(od_idx)
+
+            # If we are reusing the probabilities then we need to a similar thing for this
+            if not recompute_psl:
+                prob_vec = self.results.get_prob_vec(od_idx)
+
+            d(route_vec).reserve(len(df))
+            for _, row in df.iterrows():
+                # We find the indices for the compressed id that corresponds to the direction link id pair (as a
+                # product)
+                compressed_link_indices = graph_to_compressed.loc[row["route set"]]["index"].to_numpy()
+
+                route = new vector[long long]()
+                # Then use itertools.groupby to de-duplicate them without modifying the order. The order is not required
+                # for assignment but it is if we wish to output this route set again.
+                for compressed_link_id, _ in itertools.groupby(graph.__compressed_id__.iloc[compressed_link_indices]):
+                    route.push_back(compressed_link_id)
+                    # d(d(route_vec)[i]).push_back(compressed_link_id)
+
+                d(route_vec).emplace_back(route)
+                if not recompute_psl:
+                    d(prob_vec).push_back(row["probability"])
+
+            # If we are recomputing the probabilities then we do so here. This also has the side effect of recompute the
+            # cost, masking, and path overlap with new parameters
+            if recompute_psl:
+                prob_vec = self.results.compute_result(od_idx, d(route_vec), thread_id)
+
+            # We have now have both the route and probability vectors restored so we can do LL and SLL.
+            self.ll_results.link_load_single_route_set(od_idx, d(route_vec), d(prob_vec), thread_id)
+
+            origin_index = self.nodes_to_indices_view[demand.ods[od_idx].first]
+            dest_index = self.nodes_to_indices_view[demand.ods[od_idx].second]
+            self.ll_results.sl_link_load_single_route_set(
+                od_idx,
+                d(route_vec),
+                d(prob_vec),
+                origin_index,
+                dest_index,
+                thread_id
+            )
+
+        # Clean up and reduce any results from the threaded storage
+        self.ll_results.reduce_link_loading()
+        self.ll_results.reduce_sl_link_loading()
+        self.ll_results.reduce_sl_od_matrix()
+
+        self.get_link_loading(cores=c_cores)
+        self.get_sl_link_loading(cores=c_cores)
+        self.get_sl_od_matrices()
+
+        if not recompute_psl:
+            # Force the table to be constructed
+            table = self.get_results()
+
+            size = len(table)
+            schema = table.schema
+
+            # Because we're not recomputing the psl, the internal cost, mask, and path overlap vectors are empty. As a
+            # side effect of this those table columns are shorter than the others. This *seems* fine but would be
+            # unexpected for down stream users. Additionally the default values of these columns when converted to
+            # pandas are as if the columns were filled with zeros. This makes the mask column False for all routes. If a
+            # user was filtering the routes based on this mask then suddenly they'd have no routes so we fill it with
+            # True instead.
+            columns = dict(zip(table.column_names, table.columns))
+            columns["cost"] = pa.array(np.zeros(size), type=schema.field("cost").type)
+            columns["mask"] = pa.array(np.ones(size, dtype="bool"), type=schema.field("mask").type)
+            columns["path overlap"] = pa.array(np.zeros(size), type=schema.field("path overlap").type)
+
+            self.results.table = pa.Table.from_pydict(columns, schema=schema)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -19,6 +19,7 @@ from libcpp.memory cimport shared_ptr
 
 from typing import Tuple
 import itertools
+import warnings
 
 import numpy as np
 import pyarrow as pa
@@ -265,9 +266,14 @@ cdef class RouteChoiceSet:
             RouteSet_t *route_set
             shared_ptr[vector[double]] prob_vec
             int thread_id
+            bint found_zero_cost
 
         demand._initalise_col_names()
         self.ll_results = LinkLoadingResults(demand, select_links, self.num_links, sl_link_loading, c_cores)
+
+        # These are accessed with the gil and used for error reporting
+        zero_cost_ods: list[tuple[int]] = []
+        unreachable_ods: list[tuple[int]] = []
 
         for _, grouped_demand_df in (demand.batches() if where is not None else ((None, None),)):
             demand._initalise_c_data(grouped_demand_df)
@@ -287,6 +293,7 @@ cdef class RouteChoiceSet:
             with nogil, parallel(num_threads=c_cores):
                 route_set = new RouteSet_t()
                 thread_id = threadid()
+                found_zero_cost = False  # Make the variable thread local
                 for i in prange(<long int>demand.ods.size(), schedule="guided"):
                     origin_index = self.nodes_to_indices_view[demand.ods[i].first]
                     dest_index = self.nodes_to_indices_view[demand.ods[i].second]
@@ -347,7 +354,7 @@ cdef class RouteChoiceSet:
                     RouteChoiceSetResults.route_set_to_route_vec(d(route_vec), d(route_set))
 
                     if path_size_logit:
-                        prob_vec = self.results.compute_result(i, d(route_vec), thread_id)
+                        prob_vec = self.results.compute_result(i, d(route_vec), &found_zero_cost, thread_id)
                         self.ll_results.link_load_single_route_set(i, d(route_vec), d(prob_vec), thread_id)
                         self.ll_results.sl_link_load_single_route_set(
                             i, d(route_vec),
@@ -356,6 +363,14 @@ cdef class RouteChoiceSet:
                             dest_index,
                             thread_id
                         )
+
+
+                    if d(route_vec).size() == 0 or found_zero_cost:
+                        with gil:
+                            if found_zero_cost:
+                                zero_cost_ods.append(tuple(demand.ods[i]))
+                            if d(route_vec).size() == 0:
+                                unreachable_ods.append(tuple(demand.ods[i]))
 
                     if self.block_flows_through_centroids:
                         blocking_centroid_flows(
@@ -383,6 +398,15 @@ cdef class RouteChoiceSet:
             self.get_sl_link_loading(cores=c_cores)
             self.get_sl_od_matrices()
 
+        if zero_cost_ods:
+            warnings.warn(
+                f"found zero cost routes for OD pairs, the entire route set has been masked for: {zero_cost_ods}"
+            )
+        if unreachable_ods:
+            warnings.warn(
+                f"found unreachable OD pairs, no choice sets generated for: {unreachable_ods}"
+            )
+            
     def assign_from_df(
         self,
         graph: pd.DataFrame,
@@ -439,7 +463,9 @@ cdef class RouteChoiceSet:
 
         self.ll_results = LinkLoadingResults(demand, select_links, self.num_links, sl_link_loading, c_cores)
 
-        cdef vector[long long] *route
+        cdef:
+            vector[long long] *route
+            bint found_zero_cost
 
         # We iterate over the OD pairs in the path files
         for od_idx, df in gb:
@@ -469,7 +495,7 @@ cdef class RouteChoiceSet:
             # If we are recomputing the probabilities then we do so here. This also has the side effect of recompute the
             # cost, masking, and path overlap with new parameters
             if recompute_psl:
-                prob_vec = self.results.compute_result(od_idx, d(route_vec), thread_id)
+                prob_vec = self.results.compute_result(od_idx, d(route_vec), &found_zero_cost, thread_id)
 
             # We have now have both the route and probability vectors restored so we can do LL and SLL.
             self.ll_results.link_load_single_route_set(od_idx, d(route_vec), d(prob_vec), thread_id)

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -27,17 +27,19 @@ import pandas as pd
 """This module aims to implemented the BFS-LE algorithm as described in Rieser-Schüssler, Balmer, and Axhausen, 'Route
 Choice Sets for Very High-Resolution Data'.  https://doi.org/10.1080/18128602.2012.671383
 
-A rough overview of the algorithm is as follows.  1. Prepare the initial graph, this is depth 0 with no links removed.
-    2. Find a short path, P. If P is not empty add P to the path set.  3. For all links p in P, remove p from E,
-    compounding with the previously removed links.  4. De-duplicate the sub-graphs, we only care about unique
-    sub-graphs.  5. Go to 2.
+A rough overview of the algorithm is as follows.
+    1. Prepare the initial graph, this is depth 0 with no links removed.
+    2. Find a short path, P. If P is not empty add P to the path set.
+    3. For all links p in P, remove p from E, compounding with the previously removed links.
+    4. De-duplicate the sub-graphs, we only care about unique sub-graphs.
+    5. Go to 2.
 
 Details: The general idea of the algorithm is pretty simple, as is the implementation. The caveats here is that there is
 a lot of cpp interop and memory management. A description of the purpose of variables is in order:
 
 route_set: See route_choice.pxd for full type signature. It's an unordered set (hash set) of pointers to vectors of link
 IDs. It uses a custom hashing function and comparator. The hashing function is defined in a string that in inlined
-directly into the output ccp. This is done allow declaring of the `()` operator, which is required and AFAIK not
+directly into the output cpp. This is done allow declaring of the `()` operator, which is required and AFAIK not
 possible in Cython. The hash is designed to dereference then hash order dependent vectors. One isn't provided by
 stdlib. The comparator simply dereferences the pointer and uses the vector comparator. It's designed to store the
 outputted paths. Heap allocated (needs to be returned).
@@ -157,23 +159,23 @@ cdef class RouteChoiceSet:
     @cython.embedsignature(True)
     @cython.initializedcheck(False)
     def batched(
-            self,
-            demand: GeneralisedCOODemand,
-            select_links: Dict[str, FrozenSet[FrozenSet[int]]] = None,
-            sl_link_loading: bool = True,
-            max_routes: int = 0,
-            max_depth: int = 0,
-            max_misses: int = 100,
-            seed: int = 0,
-            cores: int = 0,
-            a_star: bool = True,
-            bfsle: bool = True,
-            penalty: float = 1.0,
-            where: Optional[str] = None,
-            store_results: bool = True,
-            path_size_logit: bool = False,
-            beta: float = 1.0,
-            cutoff_prob: float = 0.0,
+        self,
+        demand: GeneralisedCOODemand,
+        select_links: Dict[str, FrozenSet[FrozenSet[int]]] = None,
+        sl_link_loading: bool = True,
+        max_routes: int = 0,
+        max_depth: int = 0,
+        max_misses: int = 100,
+        seed: int = 0,
+        cores: int = 0,
+        a_star: bool = True,
+        bfsle: bool = True,
+        penalty: float = 1.0,
+        where: Optional[str] = None,
+        store_results: bool = True,
+        path_size_logit: bool = False,
+        beta: float = 1.0,
+        cutoff_prob: float = 0.0,
     ):
         """Compute the a route set for a list of OD pairs.
 

--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -413,6 +413,10 @@ cdef class RouteChoiceSet:
         except KeyError:
             raise KeyError("not all origin and destinations IDs from the path files are present within the demand matrix")
 
+        for _, route_list in df["route set"].items():
+            if not isinstance(route_list, (list, np.ndarray)):
+                raise TypeError(f"route sets must be a list or Numpy array, found {type(route_list)}")
+
         # We also store those indices along side the route sets themselves so it's easier to keep track
         df = df.merge(od_indices, on=["origin id", "destination id"])
         gb = df.groupby(by="index")
@@ -460,7 +464,6 @@ cdef class RouteChoiceSet:
                 # for assignment but it is if we wish to output this route set again.
                 for compressed_link_id, _ in itertools.groupby(graph.__compressed_id__.iloc[compressed_link_indices]):
                     route.push_back(compressed_link_id)
-                    # d(d(route_vec)[i]).push_back(compressed_link_id)
 
                 d(route_vec).emplace_back(route)
                 if not recompute_psl:

--- a/aequilibrae/paths/cython/route_choice_set_results.pxd
+++ b/aequilibrae/paths/cython/route_choice_set_results.pxd
@@ -41,7 +41,7 @@ cdef class RouteChoiceSetResults:
     cdef shared_ptr[vector[double]] __get_cost_set(RouteChoiceSetResults self, size_t i) noexcept nogil
     cdef shared_ptr[vector[bool]] __get_mask_set(RouteChoiceSetResults self, size_t i) noexcept nogil
     cdef shared_ptr[vector[double]] __get_path_overlap_set(RouteChoiceSetResults self, size_t i) noexcept nogil
-    cdef shared_ptr[vector[double]] __get_prob_set(RouteChoiceSetResults self, size_t i) noexcept nogil
+    cdef shared_ptr[vector[double]] get_prob_vec(RouteChoiceSetResults self, size_t i) noexcept nogil
 
     cdef shared_ptr[vector[double]] compute_result(
         RouteChoiceSetResults self,

--- a/aequilibrae/paths/cython/route_choice_set_results.pxd
+++ b/aequilibrae/paths/cython/route_choice_set_results.pxd
@@ -47,6 +47,7 @@ cdef class RouteChoiceSetResults:
         RouteChoiceSetResults self,
         size_t i,
         RouteVec_t &route_set,
+        bint *found_zero_cost,
         size_t thread_id
     ) noexcept nogil
 
@@ -54,10 +55,11 @@ cdef class RouteChoiceSetResults:
         RouteChoiceSetResults self,
         vector[double] &cost_vec,
         const RouteVec_t &route_set,
-        const double[:] cost_view
+        const double[:] cost_view,
+        bint *found_zero_cost
     ) noexcept nogil
 
-    cdef bool compute_mask(
+    cdef void compute_mask(
         RouteChoiceSetResults self,
         vector[bool] &route_mask,
         const vector[double] &total_cost

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -144,6 +144,9 @@ cdef class RouteChoiceSetResults:
         for route in route_set:
             route_vec.emplace_back(route)
 
+        # We now drop all references to those raw pointers. The unique pointers now own those vectors.
+        route_set.clear()
+
     cdef shared_ptr[RouteVec_t] get_route_vec(RouteChoiceSetResults self, size_t i) noexcept nogil:
         """
         Return either a new empty RouteSet_t, or the RouteSet_t (initially empty) corresponding to a OD pair index.
@@ -346,7 +349,7 @@ cdef class RouteChoiceSetResults:
         while union_iter != link_union.cend():
             count = 0
             link = d(union_iter)
-            while link == d(union_iter) and union_iter != link_union.cend():
+            while union_iter != link_union.cend() and link == d(union_iter):
                 count = count + 1
                 inc(union_iter)
 
@@ -490,17 +493,20 @@ cdef class RouteChoiceSetResults:
 
             int offset = 0
             size_t network_link_begin, network_link_end, link
+            bool have_assignment_results = self.perform_assignment and self.store_results
 
         # Origins, Destination, Route set, [Cost for route, Mask, Path_Overlap for route, Probability for route]
-        columns.resize(len(self.psl_schema) if self.perform_assignment else len(self.schema))
+        columns.resize(len(self.psl_schema) if have_assignment_results else len(self.schema))
 
-        if self.perform_assignment:
+        if have_assignment_results:
             cost_col = new CDoubleBuilder(pool)
             mask_col = new CBooleanBuilder(pool)
             path_overlap_col = new CDoubleBuilder(pool)
             prob_col = new CDoubleBuilder(pool)
 
             for i in range(self.demand.ods.size()):
+                if not d(self.__route_vecs[i]).size():  # If there's no routes to add just skip these.
+                    continue
                 cost_col.AppendValues(d(self.__cost_set[i]))
                 mask_col.AppendValues(d(self.__mask_set[i]))
                 path_overlap_col.AppendValues(d(self.__path_overlap_set[i]))
@@ -546,14 +552,14 @@ cdef class RouteChoiceSetResults:
         d_col.Finish(&columns[1])
         columns[2] = d(route_set_results)
 
-        if self.perform_assignment:
+        if have_assignment_results:
             cost_col.Finish(&columns[3])
             mask_col.Finish(&columns[4])
             path_overlap_col.Finish(&columns[5])
             prob_col.Finish(&columns[6])
 
         cdef shared_ptr[libpa.CSchema] schema = libpa.pyarrow_unwrap_schema(
-            self.psl_schema if self.perform_assignment else self.schema
+            self.psl_schema if have_assignment_results else self.schema
         )
         cdef shared_ptr[libpa.CTable] table = libpa.CTable.MakeFromArrays(schema, columns)
 
@@ -562,7 +568,7 @@ cdef class RouteChoiceSetResults:
         del o_col
         del d_col
 
-        if self.perform_assignment:
+        if have_assignment_results:
             del cost_col
             del mask_col
             del path_overlap_col

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -14,7 +14,6 @@ import logging
 import pyarrow as pa
 import pyarrow.parquet as pq
 import cython
-import warnings
 
 
 @cython.embedsignature(True)
@@ -181,6 +180,7 @@ cdef class RouteChoiceSetResults:
         RouteChoiceSetResults self,
         size_t i,
         RouteVec_t &route_set,
+        bint *found_zero_cost,
         size_t thread_id
     ) noexcept nogil:
         """
@@ -209,13 +209,8 @@ cdef class RouteChoiceSetResults:
         path_overlap_vec = self.__get_path_overlap_set(i)
         prob_vec = self.get_prob_vec(i)
 
-        self.compute_cost(d(cost_vec), route_set, self.cost_view)
-        if self.compute_mask(d(route_mask), d(cost_vec)):
-            with gil:
-                warnings.warn(
-                    f"Zero cost route found for ({self.demand.ods[i].first}, {self.demand.ods[i].second}). "
-                    "Entire route set masked"
-                )
+        self.compute_cost(d(cost_vec), route_set, self.cost_view, found_zero_cost)
+        self.compute_mask(d(route_mask), d(cost_vec))
         self.compute_frequency(keys, counts, route_set, d(route_mask))
         self.compute_path_overlap(
             d(path_overlap_vec),
@@ -239,7 +234,8 @@ cdef class RouteChoiceSetResults:
         vector[double] &cost_vec,
         const RouteVec_t &route_set,
         const double[:]
-        cost_view
+        cost_view,
+        bint *found_zero_cost
     ) noexcept nogil:
         """Compute the cost each route."""
         cdef:
@@ -250,18 +246,21 @@ cdef class RouteChoiceSetResults:
 
         cost_vec.resize(route_set.size())
 
+        found_zero_cost[0] = False
         for i in range(route_set.size()):
             cost = 0.0
             for link in d(route_set[i]):
                 cost = cost + cost_view[link]
 
             cost_vec[i] = cost
+            if cost == 0.0:
+                found_zero_cost[0] = True
 
     @cython.wraparound(False)
     @cython.embedsignature(True)
     @cython.boundscheck(False)
     @cython.initializedcheck(False)
-    cdef bool compute_mask(
+    cdef void compute_mask(
         RouteChoiceSetResults self,
         vector[bool] &route_mask,
         const vector[double] &total_cost
@@ -301,8 +300,6 @@ cdef class RouteChoiceSetResults:
             # Always include the min element. It should already be but I don't trust floating math to do this correctly.
             # But only if there actually was a min element (i.e. empty route set)
             route_mask[min - total_cost.cbegin()] = True
-
-        return found_zero_cost
 
     @cython.wraparound(False)
     @cython.embedsignature(True)

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -130,7 +130,7 @@ cdef class RouteChoiceSetResults:
 
     @classmethod
     def read_dataset(cls, where):
-        return pa.dataset.dataset(where, format="parquet", partitioning=pa.dataset.HivePartitioning(cls.schema))
+        return pa.dataset.dataset(where, format="parquet", partitioning=pa.dataset.HivePartitioning(cls.psl_schema))
 
     @staticmethod
     cdef void route_set_to_route_vec(RouteVec_t &route_vec, RouteSet_t &route_set) noexcept nogil:
@@ -172,7 +172,7 @@ cdef class RouteChoiceSetResults:
     cdef shared_ptr[vector[double]] __get_path_overlap_set(RouteChoiceSetResults self, size_t i) noexcept nogil:
         return self.__path_overlap_set[i] if self.store_results else make_shared[vector[double]]()
 
-    cdef shared_ptr[vector[double]] __get_prob_set(RouteChoiceSetResults self, size_t i) noexcept nogil:
+    cdef shared_ptr[vector[double]] get_prob_vec(RouteChoiceSetResults self, size_t i) noexcept nogil:
         return self.__prob_set[i] if self.store_results else make_shared[vector[double]]()
 
     cdef shared_ptr[vector[double]] compute_result(
@@ -205,7 +205,7 @@ cdef class RouteChoiceSetResults:
         cost_vec = self.__get_cost_set(i)
         route_mask = self.__get_mask_set(i)
         path_overlap_vec = self.__get_path_overlap_set(i)
-        prob_vec = self.__get_prob_set(i)
+        prob_vec = self.get_prob_vec(i)
 
         self.compute_cost(d(cost_vec), route_set, self.cost_view)
         if self.compute_mask(d(route_mask), d(cost_vec)):

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -115,13 +115,15 @@ cdef class RouteChoiceSetResults:
                 self.__prob_set[i] = make_shared[vector[double]]()
 
     def write(self, where):
+        table = self.results.make_table_from_results()
+
         logger = logging.getLogger("aequilibrae")
         pq.write_to_dataset(
-            self.table,
+            table,
             where,
             partitioning_flavor="hive",
             partitioning=["origin id"],
-            schema=self.psl_schema if self.perform_assignment else self.schema,
+            schema=table.schema,
             use_threads=True,
             existing_data_behavior="overwrite_or_ignore",
             file_visitor=lambda written_file: logger.info(f"Wrote partition dataset at {written_file.path}"),

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -115,7 +115,7 @@ cdef class RouteChoiceSetResults:
                 self.__prob_set[i] = make_shared[vector[double]]()
 
     def write(self, where):
-        table = self.results.make_table_from_results()
+        table = self.make_table_from_results()
 
         logger = logging.getLogger("aequilibrae")
         pq.write_to_dataset(

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -47,7 +47,7 @@ class RouteChoice:
     demand_index_names = ["origin id", "destination id"]
 
     def __init__(self, graph: Graph, project=None):
-        self.parameters = self.default_parameters.copy()
+        self.parameters = {}
         self.procedure_id = None
         self.procedure_date = None
 
@@ -81,13 +81,14 @@ class RouteChoice:
         )
         return d
 
-    def set_choice_set_generation(self, /, algorithm: str, **kwargs) -> None:
+    def set_choice_set_generation(self, /, algorithm: str = None, **kwargs) -> None:
         """
         Chooses the assignment algorithm and set its parameters.
 
         Options for algorithm are 'bfsle' for breadth first search with link removal, or
-        'link-penalisation'/'link-penalization'. 'lp' is also accepted as an alternative
-        to 'link-penalisation'
+        'link-penalisation'/'link-penalization'. 'lp' is also accepted as an alternative to
+        'link-penalisation'. If ``algorithm`` is ``None``, none will be set, but the parameters
+        will be updated. This is useful when assigning from path-files.
 
         BFSLE implementation based on "Route choice sets for very high-resolution data" by
         Nadine Rieser-Schüssler, Michael Balmer & Kay W. Axhausen (2013).
@@ -142,21 +143,29 @@ class RouteChoice:
 
             **kwargs** (:obj:`dict`): Dictionary with all parameters for the algorithm
         """
-        algo_dict = {i: i for i in self.all_algorithms}
-        algo_dict["lp"] = "link-penalisation"
-        algo_dict["link-penalization"] = "link-penalisation"
-        algo = algo_dict.get(algorithm.lower())
+        if algorithm is not None:
+            algo_dict = {i: i for i in self.all_algorithms}
+            algo_dict["lp"] = "link-penalisation"
+            algo_dict["link-penalization"] = "link-penalisation"
 
-        if algo is None:
-            raise AttributeError(f"Assignment algorithm not available. Choose from: {','.join(self.all_algorithms)}")
+            sentinel = object()
+            algorithm = algo_dict.get(algorithm.lower(), sentinel)
 
-        defaults = self.default_parameters["generic"] | self.default_parameters[algo]
-        for key in kwargs.keys():
-            if key not in defaults:
-                raise ValueError(f"Invalid parameter `{key}` provided for algorithm `{algo}`")
+            if algorithm is sentinel:
+                raise AttributeError(f"Assignment algorithm not available. Choose from: {','.join(self.all_algorithms)}")
 
-        self.algorithm = algo
-        self._config["Algorithm"] = algo
+            defaults = self.default_parameters["generic"] | self.default_parameters[algorithm]
+            for key in kwargs.keys():
+                if key not in defaults:
+                    raise ValueError(f"Invalid parameter '{key}' provided for algorithm `{algorithm}`")
+        else:
+            defaults = self.default_parameters["generic"]
+            for key in kwargs.keys():
+                if key not in defaults:
+                    raise ValueError(f"Invalid or non-generic parameter '{key}' provided")
+
+        self.algorithm = algorithm
+        self._config["Algorithm"] = algorithm
 
         self.parameters = defaults | kwargs
 
@@ -318,6 +327,76 @@ class RouteChoice:
             **self.parameters,
         )
 
+    def execute_from_path_files(self, path_files: Union[pathlib.Path, str], recompute_psl: bool = False) -> None:
+        """
+        Perform an assignment from an existing set of path-files.
+
+        This method expects the path-files to be written by the ``self.save_path_files()`` method,
+        however any PyArrow hive dataset with the correct structure is accepted. This allows the
+        use of AequilibraE's path-sized logit, link loading, select link analysis, and assignment
+        while using externally generated routes.
+        """
+
+        # Read the dataset schema and make sure it conforms to what we want
+        ds = RouteChoiceSetResults.read_dataset(path_files)
+        required_fields = ["origin id", "destination id", "route set"] + [] if recompute_psl else ["probability"]
+        schema = RouteChoiceSetResults.schema if recompute_psl else RouteChoiceSetResults.psl_schema
+
+        try:
+            for field in required_fields:
+                if schema.field(field) != ds.schema.field(field):
+                    raise TypeError(
+                        f"schema of required field '{field}' does not match. "
+                        f"Expected {schema.field(field)}, "
+                        f"found {ds.schema.field(field)}"
+                    )
+        except KeyError as e:
+            raise KeyError(f"Column '{field}' does not exist in the path-files") from e
+
+        # Once we know it's fine, read in the table and convert it to a pandas object. This is all little easier to work
+        # with.
+        df = ds.to_table().to_pandas()
+        self.execute_from_pandas(df=df, recompute_psl=recompute_psl)
+
+    def execute_from_pandas(self, df: pd.DataFrame, recompute_psl: bool = False) -> None:
+        """
+        Perform an assignment using route sets from a Pandas DataFrame.
+
+        Requires the DataFrame contains the ``origin id``, ``destination id`` and ``route set``
+        columns. The route sets must be a list of links IDs stored as integers with the direction
+        encoded as the sign.  Additionally, when ``recompute_psl`` is ``False``, the
+        ``probability`` column must also be present.
+
+        When ``recompute_psl`` is ``True``, the path-sized logit is recomputed for each route with
+        respect to the graphs current cost field and the ``beta`` and ``cutoff_prob`` parameters.
+
+        All origin and destination IDs within the DataFrame must exist within the demand matrix.
+
+        All link IDs and directions must exist within the graph. Links must also be present within
+        the compressed graph.
+
+        If ``recompute_psl`` is ``False`` the table returned from ``self.get_results()`` will have
+        all zeros for the cost and path overlap fields, and all True for the mask field. If
+        ``recompute_psl`` is ``True`` these fields will be recalculated as required.
+        """
+
+        required_columns = ["origin id", "destination id", "route set"] + [] if recompute_psl else ["probability"]
+        for col in required_columns:
+            if col not in df.columns:
+                raise ValueError(f"provided DataFrame is missing required column '{col}'")
+
+        self.__rc.assign_from_df(
+            self.graph.graph,
+            df,
+            self.demand,
+            select_links=self._selected_links,
+            recompute_psl=recompute_psl,
+            sl_link_loading=self.sl_link_loading,
+            store_results=self.parameters["store_results"],
+            beta=self.parameters["beta"],
+            cutoff_prob=self.parameters["cutoff_prob"],
+        )
+
     def info(self) -> dict:
         """Returns information for the transit assignment procedure
 
@@ -373,6 +452,22 @@ class RouteChoice:
             results = RouteChoiceSetResults.read_dataset(self.where)
 
         return results
+
+    def save_path_files(self, where: Optional[pathlib.Path] = None):
+        """
+        Save path-files to the directory specific.
+
+        Files will be saved as a PyArrow hive dataset partitioned by the origin ID. Existing path-files will not be
+        removed to allow incremental route choice set generation.
+
+        :Arguments:
+            **where** (:obj:`Optional[pathlib.Path]`): Directory to save the dataset to.
+        """
+        where = where if where is not None else self.where
+        if where is None:
+            raise ValueError("either the 'where' argument or 'self.where' property must not None")
+
+        self.__rc.results.write(where)
 
     def get_load_results(self) -> pd.DataFrame:
         """

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -64,7 +64,6 @@ class RouteChoice:
         self.sl_link_loads: Optional[Dict[str, np.array]] = None
 
         self.where: Optional[pathlib.Path] = None
-        self.save_path_files: bool = False
         self.index_name = "route_choice_sl_index"
 
         self._config = {}
@@ -152,7 +151,9 @@ class RouteChoice:
             algorithm = algo_dict.get(algorithm.lower(), sentinel)
 
             if algorithm is sentinel:
-                raise AttributeError(f"Assignment algorithm not available. Choose from: {','.join(self.all_algorithms)}")
+                raise AttributeError(
+                    f"Assignment algorithm not available. Choose from: {','.join(self.all_algorithms)}"
+                )
 
             defaults = self.default_parameters["generic"] | self.default_parameters[algorithm]
             for key in kwargs.keys():
@@ -178,15 +179,6 @@ class RouteChoice:
             **cores** (:obj:`int`): Number of CPU cores to use
         """
         self.cores = cores
-
-    def set_save_path_files(self, save_it: bool) -> None:
-        """turn path saving on or off.
-
-        :Arguments:
-            **save_it** (:obj:`bool`): Boolean to indicate whether paths should be saved
-        """
-        self.save_path_files = save_it
-        raise NotImplementedError()
 
     def set_save_routes(self, where: Optional[str] = None) -> None:
         """

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -459,7 +459,7 @@ class RouteChoice:
         if where is None:
             raise ValueError("either the 'where' argument or 'self.where' property must not None")
 
-        self.__rc.results.write(where)
+        self.__rc.write_path_files(where)
 
     def get_load_results(self) -> pd.DataFrame:
         """

--- a/docs/source/examples/route_choice/plot_route_choice_set.py
+++ b/docs/source/examples/route_choice/plot_route_choice_set.py
@@ -91,6 +91,21 @@ rc.execute(perform_assignment=True)
 choice_set = rc.get_results().to_pandas()
 
 # %%
+# If we were interested in storing the route choice result, we could also write them to disk using the ``save_path_files`` method.
+
+# rc.save_path_files(path)
+
+# %%
+# From those path files we could also preform a full assignment or select link analysis by using the ``execute_from_path_files`` method.
+
+# rc.execute_from_path_files(path)
+
+# %%
+# Or if we had externally computed route choice sets, we can use AequilibraEs assignment procedures by loading them with the ``execute_from_pandas` method.
+
+# rc.execute_from_pandas(path_files_df)
+
+# %%
 # Plotting choice sets
 # --------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import importlib.util as iutil
 import platform
 from os.path import join
+import os
 
 import numpy as np
 from Cython.Distutils import build_ext
@@ -34,6 +35,13 @@ cpp_std = "/std:c++17" if is_win else "-std=c++17"
 compile_args = [cpp_std, f"{prefix}openmp"]
 compile_args += ["-Wno-unreachable-code"] if is_mac else []
 link_args = [f"{prefix}openmp"]
+
+if os.getenv("DEBUG"):
+    compile_args.extend(["-O0", "-g"])
+
+if os.getenv("ASAN"):
+    compile_args.extend(["-fsanitize=address", "-fsanitize=undefined"])
+    link_args.extend(["-fsanitize=address", "-fsanitize=undefined"])
 
 extension_args = {
     "extra_compile_args": compile_args,

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,17 @@ compile_args = [cpp_std, f"{prefix}openmp"]
 compile_args += ["-Wno-unreachable-code"] if is_mac else []
 link_args = [f"{prefix}openmp"]
 
-if os.getenv("DEBUG"):
+if os.getenv("AEQ_DEBUG"):
     compile_args.extend(["-O0", "-g"])
 
-if os.getenv("ASAN"):
-    compile_args.extend(["-fsanitize=address", "-fsanitize=undefined"])
-    link_args.extend(["-fsanitize=address", "-fsanitize=undefined"])
+if os.getenv("AEQ_ASAN"):
+    compile_args.append(f"{prefix}sanitize=address")
+    link_args.append(f"{prefix}sanitize=address")
+
+    if not is_win:
+        compile_args.append(f"{prefix}sanitize=undefined")
+        link_args.append(f"{prefix}sanitize=undefined")
+
 
 extension_args = {
     "extra_compile_args": compile_args,

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -109,7 +109,8 @@ class TestRouteChoiceSet(TestCase):
                 self.graph.set_blocked_centroid_flows(True)
                 rc = RouteChoiceSet(self.graph)
 
-                results = rc.run(a, b, self.shape, max_routes=2, max_depth=2, **kwargs)
+                with self.assertWarns(UserWarning):
+                    results = rc.run(a, b, self.shape, max_routes=2, max_depth=2, **kwargs)
                 self.assertListEqual(results, [], "Blocked centroid flow found a path")
 
     def test_route_choice_batched(self):
@@ -333,7 +334,7 @@ class TestRouteChoiceSet(TestCase):
             ll_res = rc.get_link_loading()["all ones"]
 
             values2 = np.zeros_like(values)
-            values2[:len(df) // 2] = values[:len(df) // 2]
+            values2[: len(df) // 2] = values[: len(df) // 2]
             np.testing.assert_array_equal(
                 ll_res[links.index],
                 values2,
@@ -358,7 +359,7 @@ class TestRouteChoiceSet(TestCase):
             ll_res = rc.get_link_loading()["all ones"]
 
             values2 = np.zeros(len(links.index))
-            values2[:len(df) // 2] = 1.0
+            values2[: len(df) // 2] = 1.0
             np.testing.assert_array_equal(
                 ll_res[links.index],
                 values2,
@@ -369,9 +370,7 @@ class TestRouteChoiceSet(TestCase):
             # route per OD (and Sioux falls has no links with the same A and B nodes) there's no overlap, thus their are
             # all 1.0 for probabilities and path overlap.
             links2 = links.head(len(df) // 2)
-            np.testing.assert_array_equal(
-                results["cost"].to_numpy(), links2["distance"].to_numpy()
-            )
+            np.testing.assert_array_equal(results["cost"].to_numpy(), links2["distance"].to_numpy())
             np.testing.assert_array_equal(results["mask"].to_numpy(), True)
             np.testing.assert_array_equal(results["path overlap"].to_numpy(), 1.0)
             np.testing.assert_array_equal(results["probability"].to_numpy(), 1.0)

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -321,15 +321,22 @@ class TestRouteChoiceSet(TestCase):
                 "route set": [[x] for x in link_ids],
             },
         )
+
+        # For the tests that should not raise errors we reduce our demand matrix to half the route sets
+        args["demand"].df = args["demand"].df.loc[
+            df[["origin id", "destination id"]].head(len(df) // 2).itertuples(name=None, index=False)
+        ]
         with self.subTest("assign random links", recompute_psl=False):
             rc.assign_from_df(df=df, **args)
 
             results = rc.get_results().to_pandas()
             ll_res = rc.get_link_loading()["all ones"]
 
+            values2 = np.zeros_like(values)
+            values2[:len(df) // 2] = values[:len(df) // 2]
             np.testing.assert_array_equal(
                 ll_res[links.index],
-                values,
+                values2,
                 "Link loading results don't match the expected values",
             )
 
@@ -340,7 +347,7 @@ class TestRouteChoiceSet(TestCase):
 
             pd.testing.assert_series_equal(
                 results["probability"],
-                df.sort_values(by=["origin id", "destination id"])["probability"],
+                df.head(len(df) // 2)["probability"],
                 check_index=False,
             )
 
@@ -350,17 +357,20 @@ class TestRouteChoiceSet(TestCase):
             results = rc.get_results().to_pandas()
             ll_res = rc.get_link_loading()["all ones"]
 
+            values2 = np.zeros(len(links.index))
+            values2[:len(df) // 2] = 1.0
             np.testing.assert_array_equal(
                 ll_res[links.index],
-                1.0,
+                values2,
                 "Link loading results don't match the expected values",
             )
 
             # Since we recomputed PSL the cost field should be updated. As we sampled the links and there's only one
             # route per OD (and Sioux falls has no links with the same A and B nodes) there's no overlap, thus their are
             # all 1.0 for probabilities and path overlap.
+            links2 = links.head(len(df) // 2)
             np.testing.assert_array_equal(
-                results["cost"].to_numpy(), links.sort_values(by=["a_node", "b_node"])["distance"].to_numpy()
+                results["cost"].to_numpy(), links2["distance"].to_numpy()
             )
             np.testing.assert_array_equal(results["mask"].to_numpy(), True)
             np.testing.assert_array_equal(results["path overlap"].to_numpy(), 1.0)
@@ -600,7 +610,7 @@ class TestRouteChoice(TestCase):
         tmp_path = pathlib.Path(self.project.project_base_path) / "rc"
         tmp_path.mkdir()
 
-        self.rc.set_choice_set_generation("link-penalization", max_routes=20, penalty=1.1)
+        self.rc.set_choice_set_generation("link-penalization", max_routes=5, penalty=1.1)
         self.rc.add_demand(self.mat)
         self.rc.prepare()
         self.rc.execute(perform_assignment=True)

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -1,20 +1,21 @@
 import os
-import uuid
-import zipfile
-from os.path import join, dirname
 import pathlib
 import sqlite3
+import uuid
+import zipfile
+from os.path import dirname, join
 from tempfile import gettempdir
-from unittest import TestCase, skip
-import pandas as pd
-import numpy as np
-import pyarrow as pa
 from typing import List, Tuple
+from unittest import TestCase, skip
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
 
 from aequilibrae import Project
+from aequilibrae.matrix import AequilibraeMatrix, GeneralisedCOODemand, Sparse
 from aequilibrae.paths.cython.route_choice_set import RouteChoiceSet
 from aequilibrae.paths.route_choice import RouteChoice
-from aequilibrae.matrix import AequilibraeMatrix, Sparse, GeneralisedCOODemand
 
 from ...data import siouxfalls_project
 
@@ -230,22 +231,140 @@ class TestRouteChoiceSet(TestCase):
                 for od, df in gb:
                     self.assertAlmostEqual(1.0, sum(df["probability"].values), msg=", probability not close to 1.0")
 
-    @skip("not implemented")
-    def test_path_file_link_loading(self):
-        np.random.seed(0)
+    def test_assign_from_df(self):
+
+        mat = AequilibraeMatrix()
+        mat.create_empty(
+            memory_only=True,
+            zones=self.graph.num_zones,
+            matrix_names=["all ones"],
+        )
+        mat.index = self.graph.centroids[:]
+        mat.computational_view()
+        mat.matrix_view[:, :] = np.full(self.shape, 1.0)
+        demand = GeneralisedCOODemand(
+            "origin id",
+            "destination id",
+            self.graph.nodes_to_indices,
+            shape=(self.graph.num_zones, self.graph.num_zones),
+        )
+        demand.add_matrix(mat)
+
         rc = RouteChoiceSet(self.graph)
-        nodes = [tuple(x) for x in np.random.choice(self.graph.centroids, size=(10, 2), replace=False)]
-        demand = demand_from_nodes(nodes, self.graph)
-        demand.add_matrix(self.mat)
-        demand.df = demand.df.loc[nodes]
-        rc.batched(demand, max_routes=20, max_depth=10, path_size_logit=True)
 
-        n = self.mat.names[0]
+        args = {
+            "graph": self.graph.graph,
+            "demand": demand,
+            "select_links": {},
+            "recompute_psl": False,
+            "sl_link_loading": False,
+            "store_results": True,
+        }
 
-        ll = rc.get_link_loading()[n]
-        ll2 = rc.get_link_loading(generate_path_files=True)[n]
+        with self.subTest("failed to notice missing OD pairs"), self.assertRaises(KeyError):
+            df = pd.DataFrame(
+                {
+                    "origin id": [self.graph.centroids[0]],
+                    "destination id": [999999999],
+                    "probability": [1.0],
+                },
+            )
 
-        np.testing.assert_array_almost_equal(ll, ll2)
+            rc.assign_from_df(df=df, **args)
+
+        with self.subTest("failed to notice link missing from compressed graph"), self.assertRaises(KeyError):
+            df = pd.DataFrame(
+                {
+                    "origin id": [self.graph.centroids[0]],
+                    "destination id": [self.graph.centroids[1]],
+                    "probability": [1.0],
+                    "route set": [[999999999]],
+                },
+            )
+
+            rc.assign_from_df(df=df, **args)
+
+        with self.subTest("failed to notice with wrong direction"), self.assertRaises(KeyError):
+            df = pd.DataFrame(
+                {
+                    "origin id": [self.graph.centroids[0]],
+                    "destination id": [self.graph.centroids[1]],
+                    "probability": [1.0],
+                    "route set": [[-self.graph.graph.iloc[0].link_id]],
+                },
+            )
+
+            rc.assign_from_df(df=df, **args)
+
+        with self.subTest("route sets should be a list"), self.assertRaises(TypeError):
+            df = pd.DataFrame(
+                {
+                    "origin id": [self.graph.centroids[0]],
+                    "destination id": [self.graph.centroids[1]],
+                    "probability": [1.0],
+                    "route set": [1],
+                },
+            )
+
+            rc.assign_from_df(df=df, **args)
+
+        link_ids = self.graph.network.sample(10).link_id.to_numpy()
+        links = self.graph.network[self.graph.network.link_id.isin(link_ids)]
+        links = links.loc[links.link_id.replace({x: i for i, x in enumerate(link_ids)}).sort_values().index]
+
+        values = np.random.random(len(links))
+        df = pd.DataFrame(
+            {
+                "origin id": links.a_node.to_numpy(),
+                "destination id": links.b_node.to_numpy(),
+                "probability": values,
+                "route set": [[x] for x in link_ids],
+            },
+        )
+        with self.subTest("assign random links", recompute_psl=False):
+            rc.assign_from_df(df=df, **args)
+
+            results = rc.get_results().to_pandas()
+            ll_res = rc.get_link_loading()["all ones"]
+
+            np.testing.assert_array_equal(
+                ll_res[links.index],
+                values,
+                "Link loading results don't match the expected values",
+            )
+
+            # The filled values should be the constant here, we didn't recompute PSL.
+            np.testing.assert_array_equal(results["cost"].to_numpy(), 0.0)
+            np.testing.assert_array_equal(results["mask"].to_numpy(), True)
+            np.testing.assert_array_equal(results["path overlap"].to_numpy(), 0.0)
+
+            pd.testing.assert_series_equal(
+                results["probability"],
+                df.sort_values(by=["origin id", "destination id"])["probability"],
+                check_index=False,
+            )
+
+        with self.subTest("assign random links", recompute_psl=True):
+            rc.assign_from_df(df=df, **(args | {"recompute_psl": True}))
+
+            results = rc.get_results().to_pandas()
+            ll_res = rc.get_link_loading()["all ones"]
+
+            np.testing.assert_array_equal(
+                ll_res[links.index],
+                1.0,
+                "Link loading results don't match the expected values",
+            )
+
+            # Since we recomputed PSL the cost field should be updated. As we sampled the links and there's only one
+            # route per OD (and Sioux falls has no links with the same A and B nodes) there's no overlap, thus their are
+            # all 1.0 for probabilities and path overlap.
+            np.testing.assert_array_equal(
+                results["cost"].to_numpy(), links.sort_values(by=["a_node", "b_node"])["distance"].to_numpy()
+            )
+            np.testing.assert_array_equal(results["mask"].to_numpy(), True)
+            np.testing.assert_array_equal(results["path overlap"].to_numpy(), 1.0)
+            np.testing.assert_array_equal(results["probability"].to_numpy(), 1.0)
 
     def test_known_results(self):
         for cost in ["distance", "free_flow_time"]:
@@ -374,7 +493,7 @@ class TestRouteChoice(TestCase):
 
         self.project = Project()
         self.project.open(proj_path)
-        self.project.network.build_graphs(fields=["distance"], modes=["c"])
+        self.project.network.build_graphs(fields=["distance", "free_flow_time"], modes=["c"])
         self.graph = self.project.network.graphs["c"]
         self.graph.set_graph("distance")
         self.graph.set_blocked_centroid_flows(False)
@@ -383,6 +502,10 @@ class TestRouteChoice(TestCase):
         self.mat.computational_view()
 
         self.rc = RouteChoice(self.graph)
+
+    def tearDown(self) -> None:
+        self.mat.close()
+        self.project.close()
 
     def test_prepare(self):
         with self.assertRaises(ValueError):
@@ -473,6 +596,56 @@ class TestRouteChoice(TestCase):
             ),
         )
 
+    def test_execute_from_path_files(self):
+        tmp_path = pathlib.Path(self.project.project_base_path) / "rc"
+        tmp_path.mkdir()
+
+        self.rc.set_choice_set_generation("link-penalization", max_routes=20, penalty=1.1)
+        self.rc.add_demand(self.mat)
+        self.rc.prepare()
+        self.rc.execute(perform_assignment=True)
+
+        results = self.rc.get_results().to_pandas()
+        ll_res = self.rc.get_load_results()
+        self.rc.save_path_files(tmp_path)
+
+        rc = RouteChoice(self.graph)
+        rc.add_demand(self.mat)
+        rc.set_choice_set_generation(store_results=True)
+
+        with self.subTest(recompute_psl=False):
+            rc.execute_from_path_files(tmp_path, recompute_psl=False)
+            results_new = rc.get_results().to_pandas()
+            ll_res_new = rc.get_load_results()
+            pd.testing.assert_frame_equal(ll_res, ll_res_new)
+            pd.testing.assert_frame_equal(
+                results[["origin id", "destination id", "route set", "probability"]],
+                results_new[["origin id", "destination id", "route set", "probability"]],
+            )
+
+        with self.subTest(recompute_psl=True):
+            rc.execute_from_path_files(tmp_path, recompute_psl=True)
+            results_new = rc.get_results().to_pandas()
+            ll_res_new = rc.get_load_results()
+            pd.testing.assert_frame_equal(ll_res, ll_res_new)
+            pd.testing.assert_frame_equal(results, results_new)
+
+        with self.subTest(recompute_psl=True, msg="change the cost field"):
+            self.graph.set_graph("free_flow_time")
+            rc = RouteChoice(self.graph)
+            rc.add_demand(self.mat)
+            rc.set_choice_set_generation(store_results=True)
+
+            rc.execute_from_path_files(tmp_path, recompute_psl=True)
+            results_new = rc.get_results().to_pandas()
+            ll_res_new = rc.get_load_results()
+
+            pd.testing.assert_series_equal(results["origin id"], results["origin id"])
+            pd.testing.assert_series_equal(results["destination id"], results["destination id"])
+            pd.testing.assert_series_equal(results["route set"], results["route set"])
+            pd.testing.assert_series_equal(results["path overlap"], results["path overlap"])
+            # All other fields may be different
+
     def test_saving(self):
         self.rc.set_choice_set_generation("link-penalization", max_routes=20, penalty=1.1)
         self.rc.set_select_links({"sl1": [((23, 1),), ((26, 1),)], "sl2": [((11, 1),)]})
@@ -506,6 +679,8 @@ class TestRouteChoice(TestCase):
         for sl_name, v in self.rc.get_select_link_od_matrix_results().items():
             for demand_name, matrix in v.items():
                 np.testing.assert_allclose(matrix.to_scipy().toarray(), matrices.matrix[sl_name + "_" + demand_name])
+
+        matrices.close()
 
     def test_round_trip(self):
         self.rc.add_demand(self.mat)


### PR DESCRIPTION
This PR allows users to save path files, and then load them back into memory to perform a full assignment at a later date. This includes support for recomputing the path-sized logit with new graph costs and/or new PSL values, using the existing probabilities, conducting a select link analysis, and performing link loading.

This allows using routes from a Pandas DataFrame or a PyArrow hive dataset from disk.

This PR also includes patches for a handful of OOB access and memory leaks. I've also committed my debug and [sanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) options I had laying around in my setup.py. ASan required `LD_PRELOAD=libasan.so.8` when running.

#### TODO
- [x] Update documentation
- [x] Tests