### PR TITLE
Build od_node_mapping when build from transit DB, fix docs to use the correct graph

### DIFF
--- a/aequilibrae/transit/transit_graph_builder.py
+++ b/aequilibrae/transit/transit_graph_builder.py
@@ -1537,6 +1537,8 @@ class TransitGraphBuilder:
         graph.edges.a_node = graph.edges.a_node.astype("int64")
         graph.edges.direction = graph.edges.direction.astype("int8")
 
+        graph.create_od_node_mapping()
+
         return graph
 
     def convert_demand_matrix_from_zone_to_node_ids(

--- a/docs/source/examples/public_transport/plot_public_transit_skimming.py
+++ b/docs/source/examples/public_transport/plot_public_transit_skimming.py
@@ -84,7 +84,7 @@ graph_db = TransitGraphBuilder.from_db(pt_con, project.network.periods.default_p
 graph_db.vertices.drop(columns="geometry")
 
 # To perform an assignment we need to convert the graph builder into a graph.
-transit_graph = graph.to_transit_graph()
+transit_graph = graph_db.to_transit_graph()
 
 # %%
 


### PR DESCRIPTION
When building a graph from the transit DB the OD node mapping wasn't being built. The docs avoided this issue by using the wrong graph.