### PR TITLE
Update parentThread at NetworkSimplifier

### DIFF
--- a/aequilibrae/project/tools/network_simplifier.py
+++ b/aequilibrae/project/tools/network_simplifier.py
@@ -19,8 +19,8 @@ from aequilibrae.utils.interface.worker_thread import WorkerThread
 class NetworkSimplifier(WorkerThread):
     signal = SIGNAL(object)
 
-    def __init__(self, project=None, parentThread=None) -> None:
-        super().__init__(parentThread)
+    def __init__(self, project=None) -> None:
+        super().__init__(None)
 
         self.project = project or get_active_project()
         self.network = self.project.network

--- a/aequilibrae/project/tools/network_simplifier.py
+++ b/aequilibrae/project/tools/network_simplifier.py
@@ -19,7 +19,8 @@ from aequilibrae.utils.interface.worker_thread import WorkerThread
 class NetworkSimplifier(WorkerThread):
     signal = SIGNAL(object)
 
-    def __init__(self, project=None) -> None:
+    def __init__(self, project=None, parentThread=None) -> None:
+        super().__init__(parentThread)
 
         self.project = project or get_active_project()
         self.network = self.project.network


### PR DESCRIPTION
This PR updates the NetworkSimplifier class to include an additional parentThread parameter in its init method, allowing the thread to be properly passed to and managed by the base WorkerThread class. 