### PR TITLE
Fix run module import, fix PT skim column names, fix new field editor fiels not showing in QGIS

### DIFF
--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -500,7 +500,8 @@ class RouteChoice:
             added_dfs.append(pd.DataFrame({(*k, "tot"): df[(*k, "ab")] + df[(*k, "ba")]}))
 
         df = pd.concat([df] + added_dfs, axis=1).set_index("link_id")
-        df.columns = pd.MultiIndex.from_tuples(df.columns)
+        df.columns = ["_".join(x) for x in df.columns]
+
         return df.sort_index()
 
     def set_select_links(

--- a/aequilibrae/project/field_editor.py
+++ b/aequilibrae/project/field_editor.py
@@ -88,7 +88,11 @@ class FieldEditor:
         raise NotImplementedError
 
     def save(self) -> None:
-        """Saves any field descriptions which my have been changed to the database"""
+        """
+        Saves any field descriptions which my have been changed to the database and update layer statistics.
+
+        This is required for new fields to appear in applications like QGIS.
+        """
 
         qry = 'update attributes_documentation set description="{}" where attribute="{}" and name_table="{}"'
         for key, val in self._original_values.items():
@@ -96,6 +100,12 @@ class FieldEditor:
             if new_val != val:
                 self.__run_query_commit(qry.format(new_val, key, self._table))
                 self.logger.info(f"Metadata for field {key} on table {self._table} was updated to {new_val}")
+
+        self.logger.info(f"Updating layer statistics for {self._table}, this may take a moment")
+        with self.project.db_connection as conn:
+            conn.execute(f"SELECT InvalidateLayerStatistics('{self._table}');")
+            conn.execute(f"SELECT UpdateLayerStatistics('{self._table}');")
+        self.logger.info(f"Updated layer statistics for {self._table}")
 
     def all_fields(self) -> List[str]:
         """Returns the list of fields available in the database"""

--- a/aequilibrae/project/project.py
+++ b/aequilibrae/project/project.py
@@ -202,7 +202,7 @@ class Project:
         Refer to ``run/__init__.py`` file within the project folder for documentation.
         """
         entry_points = self.parameters["run"]
-        module = import_file_as_module(self.project_base_path / "run" / "__init__.py", "aequilibrae.run")
+        module = import_file_as_module(self.project_base_path / "run" / "__init__.py", "aequilibrae.run", force=True)
         sentinal = object()
         for name, kwargs in entry_points.items():
             attr = getattr(module, name)

--- a/aequilibrae/project/tools/migration_manager.py
+++ b/aequilibrae/project/tools/migration_manager.py
@@ -128,7 +128,7 @@ class Migration:
         conn.executescript(contents)
 
     def _apply_python(self, conn: sqlite3.Connection):
-        module = import_file_as_module(self.file, self.name)
+        module = import_file_as_module(self.file, self.name, force=True)
         try:
             migrate = module.migrate
         except AttributeError as e:
@@ -160,6 +160,7 @@ class MigrationManager:
         migrations = import_file_as_module(
             migration_file,
             "aequilibrae.project.database_specification.migrations",
+            force=True,
         ).migrations
 
         res = []

--- a/aequilibrae/utils/model_run_utils.py
+++ b/aequilibrae/utils/model_run_utils.py
@@ -3,7 +3,7 @@ import pathlib
 import importlib.util
 
 
-def import_file_as_module(file: pathlib.Path, module_name):
+def import_file_as_module(file: pathlib.Path, module_name, force: bool = False):
     """
     Import a file as a Python module.
 
@@ -11,6 +11,8 @@ def import_file_as_module(file: pathlib.Path, module_name):
         **file** (:obj:`pathlib.Path`): Path object pointing to the file to import
 
         **module_name**: Name to give the imported module
+
+        **force**: Replace the module in ``sys.modules`` if it exists.
 
     :Returns:
         The imported module
@@ -20,7 +22,7 @@ def import_file_as_module(file: pathlib.Path, module_name):
         raise ImportError(f"Could not find module spec for {file}")
 
     module = importlib.util.module_from_spec(spec)
-    if module_name in sys.modules:
+    if module_name in sys.modules and not force:
         raise ImportError(f"Module name '{module_name}' already exists in sys.modules")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)

--- a/aequilibrae/utils/model_run_utils.py
+++ b/aequilibrae/utils/model_run_utils.py
@@ -20,6 +20,8 @@ def import_file_as_module(file: pathlib.Path, module_name):
         raise ImportError(f"Could not find module spec for {file}")
 
     module = importlib.util.module_from_spec(spec)
+    if module_name in sys.modules:
+        raise ImportError(f"Module name '{module_name}' already exists in sys.modules")
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
 

--- a/aequilibrae/utils/model_run_utils.py
+++ b/aequilibrae/utils/model_run_utils.py
@@ -20,6 +20,7 @@ def import_file_as_module(file: pathlib.Path, module_name):
         raise ImportError(f"Could not find module spec for {file}")
 
     module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
     spec.loader.exec_module(module)
 
     return module

--- a/docs/source/examples/route_choice/plot_route_choice_basics.py
+++ b/docs/source/examples/route_choice/plot_route_choice_basics.py
@@ -119,8 +119,8 @@ import folium
 # %%
 def plot_results(link_loads):
 
-    link_loads = link_loads[link_loads.tot > 0]
-    max_load = link_loads["tot"].max()
+    link_loads = link_loads[link_loads["demand_tot"] > 0]
+    max_load = link_loads["demand_tot"].max()
     links = project.network.links.data
     loaded_links = links.merge(link_loads, on="link_id", how="inner")
 
@@ -133,7 +133,7 @@ def plot_results(link_loads):
         color="red",
         style_kwds={
             "style_function": lambda x: {
-                "weight": x["properties"]["tot"] * factor,
+                "weight": x["properties"]["demand_tot"] * factor,
             }
         },
     )
@@ -172,7 +172,7 @@ res = rc.get_results()
 res.head()
 
 # %%
-plot_results(rc.get_load_results()["demand"])
+plot_results(rc.get_load_results())
 
 # %%
 # Batch operations
@@ -193,7 +193,7 @@ rc.get_load_results()
 
 # %% 
 # We can plot these as well
-plot_results(rc.get_load_results()["demand"])
+plot_results(rc.get_load_results())
 
 # %%
 # Select link analysis

--- a/docs/source/examples/route_choice/plot_subarea_analysis.py
+++ b/docs/source/examples/route_choice/plot_subarea_analysis.py
@@ -184,8 +184,8 @@ subarea_zone = folium.Polygon(
 # %%
 # We create a function to plot out link loads data more easily
 def plot_results(link_loads):
-    link_loads = link_loads[link_loads.tot > 0]
-    max_load = link_loads["tot"].max()
+    link_loads = link_loads[link_loads["demand_tot"] > 0]
+    max_load = link_loads[["demand_tot"]].max()
     links = project.network.links.data
     loaded_links = links.merge(link_loads, on="link_id", how="inner")
     factor = 10 / max_load
@@ -194,7 +194,7 @@ def plot_results(link_loads):
         color="red",
         style_kwds={
             "style_function": lambda x: {
-                "weight": x["properties"]["tot"] * factor,
+                "weight": x["properties"]["demand_tot"] * factor,
             }
         },
     )
@@ -202,7 +202,7 @@ def plot_results(link_loads):
 
 # %%
 # And plot our data!
-map = plot_results(rc.get_load_results()["demand"])
+map = plot_results(rc.get_load_results())
 subarea_zone.add_to(map)
 map
 
@@ -297,7 +297,7 @@ rc.execute(perform_assignment=True)
 
 # %%
 # We can visualise the current links loads
-map = plot_results(rc.get_load_results()["demand"])
+map = plot_results(rc.get_load_results())
 subarea_zone.add_to(map)
 map
 
@@ -385,7 +385,7 @@ rc.execute(perform_assignment=True)
 
 # %%
 # And plot the link loads for easy viewing
-map = plot_results(rc.get_load_results()["demand"])
+map = plot_results(rc.get_load_results())
 subarea_zone.add_to(map)
 map
 

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -668,9 +668,6 @@ class TestRouteChoice(TestCase):
             ]:
                 with self.subTest(table=table):
                     df2 = pd.read_sql(f"select * from {table}", conn).set_index("link_id")
-                    # NOTE: Pandas to_sql serialises the columns of a multiindex as a str, to avoid annoying parsing we
-                    # use eval here.
-                    df2.columns = pd.MultiIndex.from_tuples([eval(x) for x in df2.columns])
                     pd.testing.assert_frame_equal(df2, df)
         conn.close()
 

--- a/tests/aequilibrae/paths/test_route_choice.py
+++ b/tests/aequilibrae/paths/test_route_choice.py
@@ -580,22 +580,20 @@ class TestRouteChoice(TestCase):
         df = self.rc.get_load_results()
         u_sl = self.rc.get_select_link_loading_results()
 
-        pd.testing.assert_index_equal(
-            df.columns,
-            pd.MultiIndex.from_tuples([(mat_name, dir) for dir in ["ab", "ba", "tot"] for mat_name in self.mat.names]),
+        self.assertListEqual(
+            list(df.columns),
+            [f"{mat_name}_{dir}" for dir in ["ab", "ba", "tot"] for mat_name in self.mat.names],
         )
 
-        pd.testing.assert_index_equal(
-            u_sl.columns,
-            pd.MultiIndex.from_tuples(
-                [
-                    (mat_name, sl_name, dir)
-                    for sl_name in ["sl1", "sl2"]
-                    for dir in ["ab", "ba"]
-                    for mat_name in self.mat.names
-                ]
-                + [(mat_name, sl_name, "tot") for sl_name in ["sl1", "sl2"] for mat_name in self.mat.names]
-            ),
+        self.assertListEqual(
+            list(u_sl.columns),
+            [
+                f"{mat_name}_{sl_name}_{dir}"
+                for sl_name in ["sl1", "sl2"]
+                for dir in ["ab", "ba"]
+                for mat_name in self.mat.names
+            ]
+            + [f"{mat_name}_{sl_name}_tot" for sl_name in ["sl1", "sl2"] for mat_name in self.mat.names],
         )
 
     def test_execute_from_path_files(self):


### PR DESCRIPTION
Insert the loaded module into sys.modules so we can use relative imports. I think I removed this after seeing Jamie’s version but this break modules that use relative imports.

This also pulls over a commit from #672 which we need, to fix the RC column names.
This also fixes fields added via the field editor not appear in the QGIS by updating the geo column stats table.