### PR TITLE
Add bulk centroid connector creation method

### DIFF
--- a/aequilibrae/project/network/connector_creation.py
+++ b/aequilibrae/project/network/connector_creation.py
@@ -225,7 +225,7 @@ def bulk_connector_creation(
     new_connectors_sql = f"""
     INSERT INTO links
     (link_id, a_node, b_node, modes, direction, link_type, capacity_ab, capacity_ba, name, geometry)
-    VALUES(?,?,?,?,0,"centroid_connector",{INFINITE_CAPACITY},{INFINITE_CAPACITY},CONCAT('centroid connector zone ', ?2),GeomFromWKB(?, 4326))
+    VALUES(?,?,?,?,0,"centroid_connector",{INFINITE_CAPACITY},{INFINITE_CAPACITY},'centroid connector zone ' || ?2,GeomFromWKB(?, 4326))
     """
     with conn:
         conn.executemany(existing_connectors_sql, existing_connectors[["modes", "link_id"]].to_records(index=False))

--- a/aequilibrae/project/network/connector_creation.py
+++ b/aequilibrae/project/network/connector_creation.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from sqlite3 import Connection
-from typing import Optional
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -94,7 +94,7 @@ def bulk_connector_creation(
     k_connectors: int = 1,
     limit_to_zone: bool = True,
     distance_upper_bound: float = float("inf"),
-    projected_crs: str | int | None = None,
+    projected_crs: Union[str, int, None] = None,
 ):
     """
     Creates or updates centroid connectors between zone centroids and network nodes.
@@ -243,7 +243,7 @@ def k_nearest(
     centroids: gpd.GeoDataFrame,
     nodes: gpd.GeoDataFrame,
     distance_upper_bound: float,
-    crs: int | str,
+    crs: Union[int, str],
 ):
     """
     Finds the k nearest nodes to each centroid using a KDTree spatial index.
@@ -298,7 +298,7 @@ def k_nearest_in_zone(
     centroids: gpd.GeoDataFrame,
     nodes: gpd.GeoDataFrame,
     distance_upper_bound: float,
-    crs: int | str,
+    crs: Union[int, str],
 ):
     """
     Finds the k nearest nodes within each zone to the corresponding centroid.

--- a/aequilibrae/project/network/connector_creation.py
+++ b/aequilibrae/project/network/connector_creation.py
@@ -1,11 +1,19 @@
+import logging
+import time
 from sqlite3 import Connection
 from typing import Optional
 
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+from scipy.spatial import KDTree
 from shapely.geometry import LineString, Polygon
 
 from aequilibrae.utils.db_utils import commit_and_close
 
 INFINITE_CAPACITY = 99999
+
+logger = logging.getLogger(__name__)
 
 
 def connector_creation(
@@ -75,3 +83,291 @@ def connector_creation(
 
     if not joined.empty:
         logger.info(f"{joined.shape[0]} new centroid connectors for mode {mode_id} added for centroid {zone_id}")
+
+
+def bulk_connector_creation(
+    conn: Connection,
+    project_nodes: gpd.GeoDataFrame,
+    project_links: gpd.GeoDataFrame,
+    project_zones: gpd.GeoDataFrame,
+    modes: list[str],
+    k_connectors: int = 1,
+    limit_to_zone: bool = True,
+    distance_upper_bound: float = float("inf"),
+    projected_crs: str | int | None = None,
+):
+    """
+    Creates or updates centroid connectors between zone centroids and network nodes.
+
+    This function generates k-nearest neighbour connections from each zone centroid to nearby
+    network nodes that support the specified transport modes. It can either limit connections
+    to nodes within the same zone or find the globally nearest nodes.
+
+    :Arguments:
+        **conn** (:obj:`Connection`): Database connection for executing SQL operations.
+
+        **project_nodes** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing network nodes
+        with columns including node_id, is_centroid, modes, and geometry.
+
+        **project_links** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing network links
+        with columns including link_id, a_node, b_node, modes, direction, and link_type.
+
+        **project_zones** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing zone polygons
+        with columns including zone_id and geometry.
+
+        **modes** (:obj:`list[str]`): List of transport mode strings to create connectors for.
+
+        **k_connectors** (:obj:`int`, `Optional`): Number of nearest neighbour connections
+        to create per centroid. Defaults to 1.
+
+        **limit_to_zone** (:obj:`bool`, `Optional`): If True, only connects to nodes within
+        the same zone. If False, finds globally nearest nodes. Defaults to True.
+
+        **distance_upper_bound** (:obj:`float`, `Optional`): Maximum distance for connections.
+        Defaults to infinity.
+
+        **projected_crs** (:obj:`str | int`, `Optional`): Coordinate reference system for
+        distance calculations. If None, uses the CRS from the input data.
+    """
+    assert project_links.crs == project_nodes.crs == project_zones.crs, "mismatched CRS"
+
+    centroid_mask = project_nodes.is_centroid == 1
+    centroids = project_nodes.loc[centroid_mask, ["node_id", "geometry"]]
+    nodes = project_nodes.loc[~centroid_mask, ["node_id", "modes", "geometry"]]
+
+    assert np.array_equal(np.unique(project_zones["zone_id"].to_numpy()), np.unique(centroids["node_id"].to_numpy()))
+
+    connectors = []
+    for mode in modes:
+        if limit_to_zone:
+            df = k_nearest_in_zone(
+                k_connectors,
+                project_zones,
+                centroids,
+                nodes[nodes.modes.str.contains(mode)],
+                distance_upper_bound=distance_upper_bound,
+                crs=projected_crs if projected_crs is not None else centroids.crs,
+            )
+        else:
+            df = k_nearest(
+                k_connectors,
+                centroids,
+                nodes[nodes.modes.str.contains(mode)],
+                distance_upper_bound=distance_upper_bound,
+                crs=projected_crs if projected_crs is not None else centroids.crs,
+            )
+
+        connectors.append(df.assign(modes=mode))
+
+    # We now need to combine the modes of the all node pairs, but we only care about the set of modes. Sorting is to
+    # provide some sort of standard ordering.
+    connectors = pd.concat(connectors).groupby(["a_node", "b_node"]).modes.apply(normalise_mode_strings).reset_index()
+
+    # We need to find out which connectors already exist so we can update the links instead of inserting them.
+    centroid_connectors = project_links[project_links.link_type == "centroid_connector"]
+    centroid_connectors["modes"] = centroid_connectors["modes"].apply(normalise_mode_strings)
+    existing_connectors = centroid_connectors.merge(
+        connectors.assign(connector_index=connectors.index), on=["a_node", "b_node"], how="inner"
+    )[["link_id", "direction", "modes_x", "modes_y", "connector_index"]]
+
+    # We'll drop any of the existing connectors from our new connectors dataframe.
+    connectors = connectors.drop(existing_connectors["connector_index"])
+
+    if (uni_directional_connectors := (existing_connectors["direction"] != 0)).any():
+        logger.warning(
+            f"Found {uni_directional_connectors.sum()} non-bidirectional existing centroid connectors that overlap "
+            "with connectors that would be have created. These connectors will not be updated. link_ids: "
+            f"{existing_connectors.loc[uni_directional_connectors, 'link_id'].to_list()}"
+        )
+        existing_connectors = existing_connectors[~uni_directional_connectors]
+
+    # Find the connectors we need to update, we then find the union of the mode strings. These are the links we will
+    # update with the new modes. We will not change anything else about them.
+    existing_connectors = existing_connectors[existing_connectors["modes_x"] != existing_connectors["modes_y"]]
+    existing_connectors = existing_connectors[["link_id"]].assign(
+        modes=existing_connectors[["modes_x", "modes_y"]].sum(axis=1).apply(normalise_mode_strings)
+    )
+
+    if existing_connectors.empty and connectors.empty:
+        logger.info("No new connectors to create nor any to update")
+        return
+
+    logger.info(f"Creating {len(connectors)} new connectors")
+    logger.info(f"Updating {len(existing_connectors)} existing connectors' modes")
+
+    # We now need to form the geometry of our connectors
+    connectors = (
+        connectors.merge(centroids, left_on="a_node", right_on="node_id", how="left")
+        .drop(columns="node_id")
+        .merge(nodes[["node_id", "geometry"]], left_on="b_node", right_on="node_id", how="left")
+        .drop(columns="node_id")
+    )
+    connectors["geometry"] = connectors.apply(
+        lambda row: LineString((row.geometry_x, row.geometry_y)), axis=1, result_type="reduce"
+    )
+    connectors = gpd.GeoDataFrame(
+        connectors.drop(columns=["geometry_x", "geometry_y"]), geometry="geometry", crs=project_links.crs
+    )
+
+    # Links need new link_ids so just use the max + 1 as a starting point
+    max_link_id = project_links.link_id.max()
+    connectors["link_id"] = np.arange(max_link_id + 1, max_link_id + 1 + len(connectors))
+
+    existing_connectors_sql = "UPDATE links SET modes=? WHERE link_id=?"
+    new_connectors_sql = f"""
+    INSERT INTO links
+    (link_id, a_node, b_node, modes, direction, link_type, capacity_ab, capacity_ba, name, geometry)
+    VALUES(?,?,?,?,0,"centroid_connector",{INFINITE_CAPACITY},{INFINITE_CAPACITY},CONCAT('centroid connector zone ', ?2),GeomFromWKB(?, 4326))
+    """
+    with conn:
+        conn.executemany(existing_connectors_sql, existing_connectors[["modes", "link_id"]].to_records(index=False))
+        conn.executemany(
+            new_connectors_sql,
+            connectors[["link_id", "a_node", "b_node", "modes", "geometry"]]
+            .to_crs(4326)
+            .to_wkb()
+            .to_records(index=False),
+        )
+
+
+def k_nearest(
+    k: int,
+    centroids: gpd.GeoDataFrame,
+    nodes: gpd.GeoDataFrame,
+    distance_upper_bound: float,
+    crs: int | str,
+):
+    """
+    Finds the k nearest nodes to each centroid using a KDTree spatial index.
+
+    :Arguments:
+        **k** (:obj:`int`): Number of nearest neighbours to find for each centroid.
+
+        **centroids** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing centroid points
+        with node_id and geometry columns.
+
+        **nodes** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing network nodes with
+        node_id and geometry columns to search within.
+
+        **distance_upper_bound** (:obj:`float`): Maximum distance for neighbour search.
+
+        **crs** (:obj:`int | str`): Coordinate reference system for distance calculations.
+
+    :Returns:
+        **pd.DataFrame**: DataFrame with columns a_node (centroid), b_node (nearest node),
+        and distance, sorted by a_node and distance.
+    """
+    kdTree = KDTree(nodes.to_crs(crs).get_coordinates().to_numpy())
+
+    distance, index = kdTree.query(
+        centroids.to_crs(crs).get_coordinates().to_numpy(), k=k, distance_upper_bound=distance_upper_bound
+    )
+
+    # Add a new axis to make the slicing consistent
+    if k == 1:
+        distance = distance[:, None]
+        index = index[:, None]
+
+    res = []
+    for i in range(k):
+        # If a centroid doesn't have k neighbours then the "index" is returned as kdTree.n (or len(nodes))
+        ith_nearest_nodes_mask = index[:, i] != kdTree.n
+        df = pd.DataFrame(
+            data={
+                "a_node": centroids["node_id"].to_numpy(),
+                "b_node": nodes["node_id"].iloc[index[ith_nearest_nodes_mask, i]].to_numpy(),
+                "distance": distance[ith_nearest_nodes_mask, i],
+            }
+        )
+        res.append(df)
+
+    return pd.concat(res).sort_values(by=["a_node", "distance"])
+
+
+def k_nearest_in_zone(
+    k: int,
+    zones: gpd.GeoDataFrame,
+    centroids: gpd.GeoDataFrame,
+    nodes: gpd.GeoDataFrame,
+    distance_upper_bound: float,
+    crs: int | str,
+):
+    """
+    Finds the k nearest nodes within each zone to the corresponding centroid.
+
+    Uses spatial indexing to first determine which nodes fall within each zone, then
+    calculates distances only between centroids and nodes in the same zone.
+
+    :Arguments:
+        **k** (:obj:`int`): Number of nearest neighbours to find for each centroid.
+
+        **zones** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing zone polygons with
+        zone_id and geometry columns.
+
+        **centroids** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing centroid points
+        with node_id and geometry columns, corresponding to zones.
+
+        **nodes** (:obj:`gpd.GeoDataFrame`): GeoDataFrame containing network nodes with
+        node_id and geometry columns to search within.
+
+        **distance_upper_bound** (:obj:`float`): Maximum distance for neighbour search.
+
+        **crs** (:obj:`int | str`): Coordinate reference system for distance calculations.
+
+    :Returns:
+        **pd.DataFrame**: DataFrame with columns a_node (centroid), b_node (nearest node),
+        and distance, limited to k nearest nodes per centroid within the same zone.
+    """
+    res = zones.sindex.query(nodes.geometry, predicate="within")
+
+    # If the mapping doesn't include all zones and all nodes then we should make it known. While possible to have nodes
+    # lie outside of zones, because we have the "within zone" requirement means we should ignore but make it known. The
+    # more concerning case is when a zone doesn't have any nodes within it.
+    if len(zones_idx_with_nodes := np.unique(res[1])) != len(zones):
+        logger.warning(f"There are {len(zones) - len(zones_idx_with_nodes)} zones without nodes!")
+
+    if len(nodes_idx_with_zones := np.unique(res[0])) != len(nodes):
+        logger.warning(f"There are {len(nodes) - len(nodes_idx_with_zones)} nodes not within the supplied zones!")
+
+    # We now explode the dataframes to form that centroid -> set of nodes mapping (indexing into centroids should be the
+    # same as zones)
+    centroids_exploded = centroids.iloc[res[1]]
+    nodes_exploded = nodes.iloc[res[0]]
+
+    # We then compute the distance from a zone to all of the nodes it contains. This operation doesn't suffer quadratic
+    # blow up that the naive approach does, because (typically) the mapping from nodes to zones is injective (the
+    # distance is to a zone for a node is only calculated once per node). It's possible that multiple zones overlap and
+    # thus can share nodes, but it should be fine for small numbers of overlapping zones.
+    df = pd.DataFrame(
+        data={
+            "a_node": centroids_exploded.node_id.to_numpy(),
+            "b_node": nodes_exploded.node_id.to_numpy(),
+            "distance": centroids_exploded.geometry.to_crs(crs).distance(
+                nodes_exploded.geometry.to_crs(crs), align=False
+            ),
+        },
+    )
+
+    # Before we do this filter, just make sure it's not the default value of inf.
+    if distance_upper_bound < float("inf"):
+        df = df[df["distance"] < distance_upper_bound]
+
+    # This was considerable faster than using a groupby -> nsmallest operation for some reason in my testing.
+    df = df.sort_values(by=["a_node", "distance"])
+    return df.groupby(by="a_node").head(k)
+
+
+def normalise_mode_strings(x):
+    """
+    Normalises a collection of mode strings by sorting unique characters.
+
+    Takes a sequence of mode strings and returns a single string containing
+    unique characters sorted alphabetically.
+
+    :Arguments:
+        **x** (:obj:`Iterable[str]`): Collection of mode strings to normalise.
+
+    :Returns:
+        **str**: Normalised string with unique characters sorted alphabetically.
+    """
+    return "".join(sorted(set(x)))

--- a/aequilibrae/project/network/connector_creation.py
+++ b/aequilibrae/project/network/connector_creation.py
@@ -136,9 +136,9 @@ def bulk_connector_creation(
     centroids = project_nodes.loc[centroid_mask, ["node_id", "geometry"]]
     nodes = project_nodes.loc[~centroid_mask, ["node_id", "modes", "geometry"]]
 
-    assert project_zones["zone_id"].isin(centroids["node_id"]).all(), (
-        "All provided zones must have their corresponding centroid provided"
-    )
+    assert (
+        project_zones["zone_id"].isin(centroids["node_id"]).all()
+    ), "All provided zones must have their corresponding centroid provided"
 
     connectors = []
     for mode in modes:

--- a/aequilibrae/project/network/connector_creation.py
+++ b/aequilibrae/project/network/connector_creation.py
@@ -129,13 +129,16 @@ def bulk_connector_creation(
         **projected_crs** (:obj:`str | int`, `Optional`): Coordinate reference system for
         distance calculations. If None, uses the CRS from the input data.
     """
-    assert project_links.crs == project_nodes.crs == project_zones.crs, "mismatched CRS"
+    assert project_links.crs == project_nodes.crs == project_zones.crs, "Mismatched CRS"
+    assert modes, "Modes must be provided"
 
     centroid_mask = project_nodes.is_centroid == 1
     centroids = project_nodes.loc[centroid_mask, ["node_id", "geometry"]]
     nodes = project_nodes.loc[~centroid_mask, ["node_id", "modes", "geometry"]]
 
-    assert np.array_equal(np.unique(project_zones["zone_id"].to_numpy()), np.unique(centroids["node_id"].to_numpy()))
+    assert project_zones["zone_id"].isin(centroids["node_id"]).all(), (
+        "All provided zones must have their corresponding centroid provided"
+    )
 
     connectors = []
     for mode in modes:
@@ -162,6 +165,11 @@ def bulk_connector_creation(
     # We now need to combine the modes of the all node pairs, but we only care about the set of modes. Sorting is to
     # provide some sort of standard ordering.
     connectors = pd.concat(connectors).groupby(["a_node", "b_node"]).modes.apply(normalise_mode_strings).reset_index()
+    if connectors.empty:
+        raise ValueError(
+            f"No connects found for any modes ({modes}), ensure the modes are correct and the distance "
+            "bound matches the units of the CRS"
+        )
 
     # We need to find out which connectors already exist so we can update the links instead of inserting them.
     centroid_connectors = project_links[project_links.link_type == "centroid_connector"]

--- a/aequilibrae/project/project_creation.py
+++ b/aequilibrae/project/project_creation.py
@@ -36,7 +36,7 @@ def add_triggers(conn: Connection, logger: logging.Logger, db_type: str) -> None
         run_queries_from_sql_file(conn, logger, qry_file)
 
 
-def remove_triggers(conn: Connection, logger: logging.Logger, db_type: str) -> None:
+def remove_triggers(conn: Connection, logger: logging.Logger, db_type: str, use_aequilibrae_prefix: bool = True) -> None:
     spec_folder = join(dirname(realpath(__file__)), "database_specification", db_type, "triggers")
     with open(join(spec_folder, "triggers_list.txt"), "r") as file_list:
         all_trigger_sets = file_list.readlines()
@@ -58,8 +58,12 @@ def remove_triggers(conn: Connection, logger: logging.Logger, db_type: str) -> N
 
                 m = re.search(create_drop_regex, qry)
                 if m:
+                    name = m.group(1).lower()
+                    if not use_aequilibrae_prefix:
+                        name = name.removeprefix("aequilibrae_")
+
                     try:
-                        conn.execute(f"drop trigger if exists {m.group(1).lower()}")
+                        conn.execute(f"drop trigger if exists {name}")
                     except Exception as e:
                         logger.error(f"Failed removing triggers table - > {e.args}")
                         logger.error(f"Point of failure - > {qry}")

--- a/aequilibrae/project/project_creation.py
+++ b/aequilibrae/project/project_creation.py
@@ -59,8 +59,7 @@ def remove_triggers(conn: Connection, logger: logging.Logger, db_type: str) -> N
                 m = re.search(create_drop_regex, qry)
                 if m:
                     try:
-                        conn.execute(f"drop trigger if exists {m.group(1).lower().removeprefix('aequilibrae_')}")
-                        logger.info(f"Removed {m.group(1).lower().removeprefix('aequilibrae_')}")
+                        conn.execute(f"drop trigger if exists {m.group(1).lower()}")
                     except Exception as e:
                         logger.error(f"Failed removing triggers table - > {e.args}")
                         logger.error(f"Point of failure - > {qry}")

--- a/aequilibrae/project/project_creation.py
+++ b/aequilibrae/project/project_creation.py
@@ -36,7 +36,9 @@ def add_triggers(conn: Connection, logger: logging.Logger, db_type: str) -> None
         run_queries_from_sql_file(conn, logger, qry_file)
 
 
-def remove_triggers(conn: Connection, logger: logging.Logger, db_type: str, use_aequilibrae_prefix: bool = True) -> None:
+def remove_triggers(
+    conn: Connection, logger: logging.Logger, db_type: str, use_aequilibrae_prefix: bool = True
+) -> None:
     spec_folder = join(dirname(realpath(__file__)), "database_specification", db_type, "triggers")
     with open(join(spec_folder, "triggers_list.txt"), "r") as file_list:
         all_trigger_sets = file_list.readlines()

--- a/aequilibrae/project/project_creation.py
+++ b/aequilibrae/project/project_creation.py
@@ -59,7 +59,8 @@ def remove_triggers(conn: Connection, logger: logging.Logger, db_type: str) -> N
                 m = re.search(create_drop_regex, qry)
                 if m:
                     try:
-                        conn.execute(f"drop trigger if exists {m.group(1).lower()}")
+                        conn.execute(f"drop trigger if exists {m.group(1).lower().removeprefix('aequilibrae_')}")
+                        logger.info(f"Removed {m.group(1).lower().removeprefix('aequilibrae_')}")
                     except Exception as e:
                         logger.error(f"Failed removing triggers table - > {e.args}")
                         logger.error(f"Point of failure - > {qry}")

--- a/aequilibrae/project/zoning.py
+++ b/aequilibrae/project/zoning.py
@@ -168,7 +168,9 @@ class Zoning(BasicTable):
                 zones_todo = [x for x in self.__items.keys() if x not in connected_centroids]
                 for zone_id in simple_progress(zones_todo, SIGNAL(object), "Connecting zones"):
                     if zone_id not in centroids:
-                        self.project.logger.warning(f"Centroid for zone {zone_id} does not exist. Please create it first.")
+                        self.project.logger.warning(
+                            f"Centroid for zone {zone_id} does not exist. Please create it first."
+                        )
                         continue
 
                     zone = self.__items[zone_id]

--- a/aequilibrae/project/zoning.py
+++ b/aequilibrae/project/zoning.py
@@ -11,7 +11,7 @@ from shapely.geometry import Point, Polygon, LineString, MultiLineString
 
 from aequilibrae.project.basic_table import BasicTable
 from aequilibrae.project.data_loader import DataLoader
-from aequilibrae.project.network.connector_creation import connector_creation
+from aequilibrae.project.network.connector_creation import connector_creation, bulk_connector_creation
 from aequilibrae.project.project_creation import run_queries_from_sql_file
 from aequilibrae.project.table_loader import TableLoader
 from aequilibrae.project.zone import Zone
@@ -125,8 +125,9 @@ class Zoning(BasicTable):
         else:
             self.project.logger.info("No new centroids added to the network")
 
-    def connect_mode(self, mode_id: str, link_types="", connectors=1, limit_to_zone=True):
-        """Adds centroid connectors for the desired mode to the network file
+    def connect_mode(self, mode_id: str, link_types="", connectors=1, limit_to_zone=True, bulk: bool = False):
+        """
+        Adds centroid connectors for the desired mode to the network file
 
         Centroid connectors are created by connecting each zone centroid to one or more nodes selected from
         all those that satisfy the mode and link_types criteria and are inside the zone.
@@ -142,11 +143,14 @@ class Zoning(BasicTable):
             **mode_id** (:obj:`str`): Mode ID we are trying to connect
 
             **link_types** (:obj:`str`, *Optional*): String with all the link type IDs that can be considered.
-            eg: yCdR. Defaults to ALL link types
+                eg: yCdR. Defaults to ALL link types
 
             **connectors** (:obj:`int`, *Optional*): Number of connectors to add. Defaults to 1
 
             **limit_to_zone** (:obj:`bool`): Limits the search for nodes inside the zone. Defaults to ``True``.
+
+            **bulk** (:obj:`bool`, *Optional*): Whether to use the bulk connector method or not. This is method is
+                considerably faster for connecting a large amount of centroids but has a high runtime overhead.
         """
 
         proj_nodes = self.project.network.nodes.data
@@ -159,24 +163,48 @@ class Zoning(BasicTable):
 
         with self.project.db_connection_spatial as conn, warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=UserWarning, module="geopandas")
-            zones_todo = [x for x in self.__items.keys() if x not in connected_centroids]
-            for zone_id in simple_progress(zones_todo, SIGNAL(object), "Connecting zones"):
-                if zone_id not in centroids:
-                    self.project.logger.warning(f"Centroid for zone {zone_id} does not exist. Please create it first.")
-                    continue
 
-                zone = self.__items[zone_id]
-                area = zone.geometry if limit_to_zone else None
-                connector_creation(
-                    zone_id=zone_id,
-                    mode_id=mode_id,
-                    link_types=link_types,
-                    connectors=connectors,
-                    proj_nodes=proj_nodes,
-                    proj_links=link_data,
-                    network=self.project.network,
-                    conn=conn,
-                    delimiting_area=area,
+            if not bulk:
+                zones_todo = [x for x in self.__items.keys() if x not in connected_centroids]
+                for zone_id in simple_progress(zones_todo, SIGNAL(object), "Connecting zones"):
+                    if zone_id not in centroids:
+                        self.project.logger.warning(f"Centroid for zone {zone_id} does not exist. Please create it first.")
+                        continue
+
+                    zone = self.__items[zone_id]
+                    area = zone.geometry if limit_to_zone else None
+                    connector_creation(
+                        zone_id=zone_id,
+                        mode_id=mode_id,
+                        link_types=link_types,
+                        connectors=connectors,
+                        proj_nodes=proj_nodes,
+                        proj_links=link_data,
+                        network=self.project.network,
+                        conn=conn,
+                        delimiting_area=area,
+                    )
+            else:
+                if len(link_types) > 0:
+                    nodes = proj_nodes[proj_nodes.link_types.str.contains("|".join(list(link_types)))]
+                else:
+                    nodes = proj_nodes
+
+                zones = self.data
+                zones = zones[~zones.zone_id.isin(connected_centroids)]
+
+                if zones.empty:
+                    return
+
+                bulk_connector_creation(
+                    conn,
+                    nodes,
+                    link_data,
+                    zones,
+                    modes=[mode_id],
+                    k_connectors=connectors,
+                    projected_crs=None,
+                    limit_to_zone=limit_to_zone,
                 )
 
     def get_closest_zone(self, geometry: Union[Point, LineString, MultiLineString]) -> int:

--- a/tests/aeq/project/test_connector_creation.py
+++ b/tests/aeq/project/test_connector_creation.py
@@ -16,9 +16,7 @@ def initial_state(coquimbo_example):
         "nodes": project.network.nodes.data,
         "links": project.network.links.data,
         "zones": project.zoning.data,
-        "initial_connectors": project.network.links.data[
-            project.network.links.data.link_type == "centroid_connector"
-        ],
+        "initial_connectors": project.network.links.data[project.network.links.data.link_type == "centroid_connector"],
     }
 
 
@@ -46,9 +44,9 @@ def test_bulk_connector_creation_single_mode(coquimbo_example, initial_state):
 
     # Should have connectors
     new_connectors = updated_links[updated_links.link_type == "centroid_connector"]
-    assert len(new_connectors) >= len(initial_state["initial_connectors"]), (
-        "Should have at least as many connectors as before"
-    )
+    assert len(new_connectors) >= len(
+        initial_state["initial_connectors"]
+    ), "Should have at least as many connectors as before"
 
     # Check new connectors properties
     added_connectors = new_connectors[~new_connectors.link_id.isin(initial_state["initial_connectors"].link_id)]
@@ -117,9 +115,9 @@ def test_bulk_connector_creation_k_connectors(coquimbo_example, initial_state, k
     for centroid_id in centroid_node_ids:
         centroid_connectors = added_connectors[added_connectors.a_node == centroid_id]
         # Should have at most k_connectors (may be fewer if not enough nodes available)
-        assert len(centroid_connectors) <= k_connectors, (
-            f"Centroid {centroid_id} should have at most {k_connectors} connectors"
-        )
+        assert (
+            len(centroid_connectors) <= k_connectors
+        ), f"Centroid {centroid_id} should have at most {k_connectors} connectors"
 
 
 @pytest.mark.parametrize("limit_to_zone", [True, False])

--- a/tests/aeq/project/test_connector_creation.py
+++ b/tests/aeq/project/test_connector_creation.py
@@ -1,0 +1,266 @@
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import LineString, Point
+
+from aequilibrae.project import Project
+from aequilibrae.project.network.connector_creation import bulk_connector_creation
+
+
+@pytest.fixture
+def initial_state(coquimbo_example):
+    """Get initial state of the project for comparison."""
+    project = coquimbo_example
+    return {
+        "nodes": project.network.nodes.data,
+        "links": project.network.links.data,
+        "zones": project.zoning.data,
+        "initial_connectors": project.network.links.data[
+            project.network.links.data.link_type == "centroid_connector"
+        ],
+    }
+
+
+def test_bulk_connector_creation_single_mode(coquimbo_example, initial_state):
+    """Test basic connector creation with a single mode."""
+    project = coquimbo_example
+
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=1,
+            limit_to_zone=True,
+        )
+
+    # Refresh data after operation
+    updated_links = project.network.links.data
+    updated_nodes = project.network.nodes.data
+
+    # Number of nodes should remain constant
+    assert len(updated_nodes) == len(initial_state["nodes"]), "Node count should not change"
+
+    # Should have connectors
+    new_connectors = updated_links[updated_links.link_type == "centroid_connector"]
+    assert len(new_connectors) >= len(initial_state["initial_connectors"]), (
+        "Should have at least as many connectors as before"
+    )
+
+    # Check new connectors properties
+    added_connectors = new_connectors[~new_connectors.link_id.isin(initial_state["initial_connectors"].link_id)]
+
+    if len(added_connectors) > 0:
+        assert all(added_connectors.direction == 0), "All new connectors should be bidirectional"
+        assert all(added_connectors.link_type == "centroid_connector"), "All should be centroid connectors"
+        assert all(added_connectors.modes.str.contains("c")), "All should support car mode"
+
+
+@pytest.mark.parametrize("modes", [["c"], ["c", "w", "b", "t"]])
+def test_bulk_connector_creation_multiple_modes(coquimbo_example, initial_state, modes):
+    """Test connector creation with different mode combinations."""
+    project = coquimbo_example
+
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=modes,
+            k_connectors=1,
+            limit_to_zone=True,
+        )
+
+    updated_links = project.network.links.data
+    updated_nodes = project.network.nodes.data
+
+    assert len(updated_nodes) == len(initial_state["nodes"]), "Node count should not change"
+
+    new_connectors = updated_links[updated_links.link_type == "centroid_connector"]
+    added_connectors = new_connectors[~new_connectors.link_id.isin(initial_state["initial_connectors"].link_id)]
+
+    if len(added_connectors) > 0:
+        # Check that connectors support the requested modes
+        for mode in modes:
+            mode_connectors = added_connectors[added_connectors.modes.str.contains(mode)]
+            assert len(mode_connectors) > 0, f"Should have connectors supporting mode {mode}"
+
+
+@pytest.mark.parametrize("k_connectors", [1, 2, 3])
+def test_bulk_connector_creation_k_connectors(coquimbo_example, initial_state, k_connectors):
+    """Test creating multiple connectors per centroid."""
+    project = coquimbo_example
+
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=k_connectors,
+            limit_to_zone=True,
+        )
+
+    updated_links = project.network.links.data
+
+    new_connectors = updated_links[updated_links.link_type == "centroid_connector"]
+    added_connectors = new_connectors[~new_connectors.link_id.isin(initial_state["initial_connectors"].link_id)]
+
+    # Count connectors per centroid
+    centroid_node_ids = initial_state["nodes"][initial_state["nodes"].is_centroid == 1].node_id.values
+
+    for centroid_id in centroid_node_ids:
+        centroid_connectors = added_connectors[added_connectors.a_node == centroid_id]
+        # Should have at most k_connectors (may be fewer if not enough nodes available)
+        assert len(centroid_connectors) <= k_connectors, (
+            f"Centroid {centroid_id} should have at most {k_connectors} connectors"
+        )
+
+
+@pytest.mark.parametrize("limit_to_zone", [True, False])
+def test_bulk_connector_creation_zone_limitation(coquimbo_example, initial_state, limit_to_zone):
+    """Test connector creation with and without zone limitation."""
+    project = coquimbo_example
+
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=2,
+            limit_to_zone=limit_to_zone,
+        )
+
+    updated_links = project.network.links.data
+
+    new_connectors = updated_links[updated_links.link_type == "centroid_connector"]
+    added_connectors = new_connectors[~new_connectors.link_id.isin(initial_state["initial_connectors"].link_id)]
+
+    assert len(added_connectors) >= 0, "Should create some connectors"
+
+    if len(added_connectors) > 0:
+        # Verify a_nodes are centroids and b_nodes are regular nodes
+        centroid_node_ids = initial_state["nodes"][initial_state["nodes"].is_centroid == 1].node_id.values
+        regular_node_ids = initial_state["nodes"][initial_state["nodes"].is_centroid == 0].node_id.values
+
+        assert all(added_connectors.a_node.isin(centroid_node_ids)), "A-nodes should be centroids"
+        assert all(added_connectors.b_node.isin(regular_node_ids)), "B-nodes should be regular nodes"
+
+
+def test_bulk_connector_creation_geometry_validation(coquimbo_example, initial_state):
+    """Test that connector geometries are properly formed."""
+    project = coquimbo_example
+
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=1,
+            limit_to_zone=True,
+        )
+
+    updated_links = project.network.links.data
+
+    new_connectors = updated_links[updated_links.link_type == "centroid_connector"]
+    added_connectors = new_connectors[~new_connectors.link_id.isin(initial_state["initial_connectors"].link_id)]
+
+    if len(added_connectors) > 0:
+        for _, connector in added_connectors.iterrows():
+            assert isinstance(connector.geometry, LineString), "Connector geometry should be LineString"
+
+            # Get centroid and node geometries
+            centroid_geom = initial_state["nodes"][initial_state["nodes"].node_id == connector.a_node].geometry.iloc[0]
+            node_geom = initial_state["nodes"][initial_state["nodes"].node_id == connector.b_node].geometry.iloc[0]
+
+            # LineString should connect these points
+            line_coords = list(connector.geometry.coords)
+            assert len(line_coords) == 2, "LineString should have exactly 2 coordinates"
+            assert Point(line_coords[0]).equals(centroid_geom), "LineString should start at centroid"
+            assert Point(line_coords[1]).equals(node_geom), "LineString should end at node"
+
+
+def test_bulk_connector_creation_distance_upper_bound(coquimbo_example, initial_state):
+    """Test connector creation with distance upper bound."""
+    project = coquimbo_example
+
+    # Test with very small distance bound - should create fewer connectors
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=5,
+            limit_to_zone=True,
+            distance_upper_bound=0.001,
+        )
+
+    updated_links_small = project.network.links.data
+    connectors_small = updated_links_small[updated_links_small.link_type == "centroid_connector"]
+
+    # Reset and test with large distance bound
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=project.network.links.data,
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=5,
+            limit_to_zone=True,
+            distance_upper_bound=float("inf"),
+        )
+
+    updated_links_large = project.network.links.data
+    connectors_large = updated_links_large[updated_links_large.link_type == "centroid_connector"]
+
+    # With larger distance bound, should generally have same or more connectors
+    # (accounting for potential existing connectors)
+    assert len(connectors_large) >= len(connectors_small), "Larger distance bound should allow more connectors"
+
+
+def test_bulk_connector_creation_no_changes_when_no_work(coquimbo_example, initial_state):
+    """Test that function handles gracefully when no work needs to be done."""
+    project = coquimbo_example
+
+    # First, create some connectors
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=initial_state["nodes"],
+            project_links=initial_state["links"],
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=1,
+            limit_to_zone=True,
+        )
+
+    intermediate_links = project.network.links.data.copy()
+
+    # Run again with same parameters - should not create duplicate connectors
+    with project.db_connection_spatial as conn:
+        bulk_connector_creation(
+            conn=conn,
+            project_nodes=project.network.nodes.data,
+            project_links=project.network.links.data,
+            project_zones=initial_state["zones"],
+            modes=["c"],
+            k_connectors=1,
+            limit_to_zone=True,
+        )
+
+    final_links = project.network.links.data
+
+    # Should have same number of links
+    assert len(final_links) == len(intermediate_links), "Should not create duplicate connectors"

--- a/tests/aeq/project/test_zoning.py
+++ b/tests/aeq/project/test_zoning.py
@@ -1,4 +1,5 @@
 from shapely.geometry import Polygon
+import pytest
 
 
 def zoning_setup(project):
@@ -19,11 +20,12 @@ def test_add_centroid(coquimbo_example):
     assert num_centroids > centroids, "Centroids should've been added."
 
 
-def test_connect_mode(coquimbo_example):
+@pytest.mark.parametrize("bulk", [True, False])
+def test_connect_mode(coquimbo_example, bulk):
     proj, _ = zoning_setup(coquimbo_example)
     links_before = proj.network.links.data.shape[0]
     proj.zoning.add_centroids()
-    proj.zoning.connect_mode(mode_id="c", connectors=1)
+    proj.zoning.connect_mode(mode_id="c", connectors=1, bulk=bulk)
     links_after = proj.network.links.data.shape[0]
     assert links_after > links_before, "Centroid connectors should've been added."
 


### PR DESCRIPTION
I'm my testing this is considerable faster for bulk centroid connector creation. It operators on all zones at once and then reconciles the modes after. Providing `limit_to_zone=False` runs slightly faster ~5s on my test network.

Rough performance metrics
- Old method connecting ~5k zones on a network with 1.8M links and 1.3M nodes was estimated to take ~1h per mode
- Bulk method takes ~40s for all 4 modes and about ~25s for the `c` mode. The high overhead is due to the database operations, setup, and mode reconciliation. The geospatial operations are all pretty fast.

When limited to the zone it finds all nodes within that zone then computes the distance and finds the closest `k` via a naive method, but by partitioning the nodes first this becomes quite fast.
When not limited to the zone it constructs a KDTree of all non-centroid nodes then queries for all the centroids against it.

I've exposed this as an option to the `zoning.connect_mode` method. While this can be used to connect one mode at a time it's best to connect them all at once. I haven't exposed a method for that because it's a little hairy to make the `CENTROIDS THAT ARE CURRENTLY CONNECTED ARE SKIPPED ALTOGETHER` requirement work for different modes all at once.

It is pretty easy to use on it's own though
```python
from aequilibrae.project.network.connector_creation import bulk_connector_creation

links = project.network.links.data
nodes = project.network.nodes.data
zones = project.zoning.data

with project.db_connection_spatial as conn:
    bulk_connector_creation(
        conn,
        nodes,
        links,
        zones,
        modes=["c", "b", "t", "w"],
        k_connectors=1,
        projected_crs=None,
        limit_to_zone=True
    )
```

There is an option to use another CRS for the distance calculations, when not provided it will use the current CRS of the dataframes. The geometry will not be created using the alternative CRS.

When operating on a network that already has centroid connectors they will not be considered except for one case. If the existing centroid connector and the new centroid connectors share the same `a_node`, `b_node`, and have direction `0`, the `modes` string will be updated to include the new modes. No other changes will be made.