### PR TITLE
Fix broken references in docs

### DIFF
--- a/docs/source/aequilibrae_project/parameter_file.rst
+++ b/docs/source/aequilibrae_project/parameter_file.rst
@@ -213,5 +213,5 @@ use by AequilibraE is so small that it is likely not necessary to do so.
 
 .. seealso::
 
-    * :func:`aequilibrae.Parameters`
+    * :func:`aequilibrae.parameters.Parameters`
         Class documentation

--- a/docs/source/aequilibrae_project/project_components/aequilibrae_matrix.rst
+++ b/docs/source/aequilibrae_project/project_components/aequilibrae_matrix.rst
@@ -105,7 +105,7 @@ AequilibraE matrices in disk can be reused and loaded once again.
 
 .. seealso::
 
-    :func:`aequilibrae.matrix.AequilibraeMatrix`
+    :func:`aequilibrae.matrix.aequilibrae_matrix.AequilibraeMatrix`
         Class documentatiom
     :ref:`plot_assignment_without_model`
         Usage example 

--- a/docs/source/aequilibrae_project/project_components/components.rst
+++ b/docs/source/aequilibrae_project/project_components/components.rst
@@ -62,7 +62,7 @@ Each item in the 'links' table is a ``Link`` object.
 
 .. seealso::
     
-    * :func:`aequilibrae.project.network.Links`
+    * :func:`aequilibrae.project.network.links.Links`
         Class documentation 
     * :ref:`project_from_link_layer`
         Usage example
@@ -129,7 +129,7 @@ Each item in the 'nodes' table is a ``Node`` object.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.Nodes`
+    * :func:`aequilibrae.project.network.nodes.Nodes`
         Class documentation
     * :ref:`editing_network_nodes`
         Usage example
@@ -212,7 +212,7 @@ Each item in the 'zones' table is a ``Zone`` object.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Zoning`
+    * :func:`aequilibrae.project.zoning.Zoning`
         Class documentation
     * :ref:`create_zones`
         Usage example
@@ -253,7 +253,7 @@ this information, otherwise it will be lost.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.About`
+    * :func:`aequilibrae.project.about.About`
         Class documentation
     * :ref:`tables_about`
         Table documentation
@@ -299,7 +299,7 @@ All field descriptions are kept in the table 'attributes_documentation'.
 
 .. seealso::
 
-    *  :func:`aequilibrae.project.FieldEditor`
+    *  :func:`aequilibrae.project.field_editor.FieldEditor`
         Class documentation
 
 ``project.log``
@@ -327,7 +327,7 @@ It is possible to access the log file contents, as presented in the next code bl
 
 .. seealso::
     
-    * :func:`aequilibrae.project.Log`
+    * :func:`aequilibrae.log.Log`
         Class documentation
     * :ref:`useful-log-tips`
         Usage example
@@ -376,7 +376,7 @@ records in the 'matrices' table. Each item in the 'matrices' table  is a ``Matri
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Matrices`
+    * :func:`aequilibrae.project.data.matrices.Matrices`
         Class documentation
     * :ref:`matrix_table`
         Table documentation
@@ -429,7 +429,7 @@ Each item in the 'link_types' table is a ``LinkType`` object.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.LinkTypes`
+    * :func:`aequilibrae.project.network.link_types.LinkTypes`
         Class documentation
     * :ref:`tables_link_types`
         Table documentation
@@ -477,7 +477,7 @@ Each item in 'modes' table is a ``Mode`` object.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.Modes`
+    * :func:`aequilibrae.project.network.modes.Modes`
         Class documentation
     * :ref:`tables_modes`
         Table documentation
@@ -529,7 +529,7 @@ Each item in the 'periods' table is a ``Period`` object.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.Periods`
+    * :func:`aequilibrae.project.network.periods.Periods`
         Class documentation
     * :ref:`tables_period`
         Table documentation

--- a/docs/source/aequilibrae_project/project_database.rst
+++ b/docs/source/aequilibrae_project/project_database.rst
@@ -140,7 +140,7 @@ required.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.Modes`
+    * :func:`aequilibrae.project.network.modes.Modes`
         Class documentation
     * :ref:`modes_network_data_model`
         Data model
@@ -267,7 +267,7 @@ required.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.LinkTypes`
+    * :func:`aequilibrae.project.network.link_types.LinkTypes`
        Class documentation
     * :ref:`link_types_network_data_model`
         Data model
@@ -291,7 +291,7 @@ You can check :ref:`this example <create_zones>` to learn how to add zones to yo
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Zone`
+    * :func:`aequilibrae.project.zone.Zone`
         Class documentation
     * :ref:`zones_network_data_model`
         Data model
@@ -318,7 +318,7 @@ types (AEM and OMX) without prejudice to functionality.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Matrices`
+    * :func:`aequilibrae.project.data.matrices.Matrices`
         Class documentation
     * :ref:`matrices_network_data_model`
         Data model
@@ -350,7 +350,7 @@ opportunities for version upgrades.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.About`
+    * :func:`aequilibrae.project.about.About`
         Class documentation
     * :ref:`about_network_data_model`
         Data model
@@ -413,7 +413,7 @@ Periods table
 
 .. seealso::
 
-    * :func:`aequilibrae.project.network.Periods`
+    * :func:`aequilibrae.project.network.periods.Periods`
         Class documentation
     * :ref:`periods_network_data_model`
         Data model

--- a/docs/source/aequilibrae_project/transit_database.rst
+++ b/docs/source/aequilibrae_project/transit_database.rst
@@ -13,9 +13,9 @@ for the first time and it can take a little while.
 
 .. seealso::
 
-    * :func:`aequilibrae.transit.Transit`
+    * :func:`aequilibrae.transit.transit.Transit`
         Class documentation
-    * :func:`aequilibrae.transit.TransitGraphBuilder`
+    * :func:`aequilibrae.transit.transit_graph_builder.TransitGraphBuilder`
         Class documentation
 
 In the following sections, we'll dive deep into the tables existing in the public transport database.

--- a/docs/source/distribution_procedures/classes.rst
+++ b/docs/source/distribution_procedures/classes.rst
@@ -24,9 +24,9 @@ documentation.
 
 .. seealso::
     
-    * :func:`aequilibrae.distribution.SyntheticGravityModel`
+    * :func:`aequilibrae.distribution.synthetic_gravity_model.SyntheticGravityModel`
         Function documentation
-    * :func:`aequilibrae.distribution.GravityApplication`
+    * :func:`aequilibrae.distribution.gravity_application.GravityApplication`
         Function documentation
 
 
@@ -46,7 +46,7 @@ documentation.
 
 .. seealso::
     
-    * :func:`aequilibrae.distribution.GravityCalibration`
+    * :func:`aequilibrae.distribution.gravity_calibration.GravityCalibration`
         Function documentation
 
 .. 
@@ -68,7 +68,7 @@ IPF.
 
 .. seealso::
 
-    * :func:`aequilibrae.distribution.Ipf`
+    * :func:`aequilibrae.distribution.ipf.Ipf`
         Function documentation
     * :ref:`plot_ipf_without_model`
         Usage example

--- a/docs/source/examples/aequilibrae_project/plot_connections.py
+++ b/docs/source/examples/aequilibrae_project/plot_connections.py
@@ -1,0 +1,70 @@
+"""
+.. _example_aequilibrae_connections:
+
+Project Connections
+===================
+
+In this example, we show how to use AequilibraE's database connections within a project.
+"""
+
+# %%
+# .. admonition:: References
+#
+#   * :doc:`../../aequilibrae_project`
+
+# %%
+# .. seealso::
+#     Several functions, methods, classes and modules are used in this example:
+#
+#     * :func:`aequilibrae.project.project.Project.db_connection`
+#     * :func:`aequilibrae.project.project.Project.db_connection_spatial`
+#     * :func:`aequilibrae.project.project.Project.results_connection`
+#     * :func:`aequilibrae.project.project.Project.transit_connection`
+
+# %%
+
+# Imports
+from uuid import uuid4
+from tempfile import gettempdir
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+
+from aequilibrae.utils.create_example import create_example
+
+# %%
+
+# We create the example project inside our temp folder.
+fldr = Path(gettempdir()) / uuid4().hex
+project = create_example(fldr, "sioux_falls")
+
+# %%
+# All AequilibraE projects presents four types of connections in the form of properties:
+#
+#    * General connection to the project database
+#    * Spatial connection to the project database
+#    * General connection to the results database
+#    * Spatial connection to the transit database
+
+# %%
+# Each connection can be easily accessed as follows:
+with project.db_connection as conn:
+    matrices = pd.read_sql("SELECT * FROM matrices", conn)
+
+# %%
+matrices
+
+# %%
+# We encourage using spatial connections only when handling spatial data.
+with project.db_connection_spatial as conn:
+    nodes = gpd.read_postgis("SELECT zone_id, ST_AsBinary(geometry) geom FROM zones;", con=conn, geom_col="geom", crs=4326)
+
+# %%
+nodes.head()
+
+# %%
+# For accessing both results and transit databases, the procedure is the same.
+#
+# When you're done, don't forget to close the project.
+project.close()

--- a/docs/source/network_manipulation/import_and_export_network.rst
+++ b/docs/source/network_manipulation/import_and_export_network.rst
@@ -41,7 +41,7 @@ platform that does not support both R-Tree and SpatiaLite.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Network.create_from_osm`
+    * :func:`aequilibrae.project.network.network.Network.create_from_osm`
         Function documentation
     * :ref:`plot_from_osm`
         Usage example
@@ -97,7 +97,7 @@ specification.
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Network.create_from_gmns`
+    * :func:`aequilibrae.project.network.network.Network.create_from_gmns`
         Function documentation
     * :ref:`import_from_gmns`
         Usage example
@@ -139,7 +139,7 @@ You can find the GMNS specification
 
 .. seealso::
 
-    * :func:`aequilibrae.project.Network.export_to_gmns`
+    * :func:`aequilibrae.project.network.network.Network.export_to_gmns`
         Function documentation
     * :ref:`export_to_gmns`
         Usage example

--- a/docs/source/path_computation.rst
+++ b/docs/source/path_computation.rst
@@ -34,7 +34,7 @@ entirely dedicated to this object.
 
 .. seealso::
     
-    * :func:`aequilibrae.paths.PathResults`
+    * :func:`aequilibrae.paths.results.path_results.PathResults`
         Class documentation
     * :ref:`example_usage_path_computation` 
         Usage example

--- a/docs/source/path_computation/aequilibrae_graph.rst
+++ b/docs/source/path_computation/aequilibrae_graph.rst
@@ -97,7 +97,6 @@ result in simplification beyond pure topological simplification.
     >>> graph.prepare_graph(np.array([13, 169, 2197, 28561, 37123], np.int32), remove_dead_ends=False)
 
 
-
 Graphs from a model
 -------------------
 
@@ -177,9 +176,9 @@ not blocking flows through "centroids".**
 
 .. seealso::
 
-    * :func:`aequilibrae.paths.Graph`
+    * :func:`aequilibrae.paths.graph.Graph`
         Class documentation
-    * :func:`aequilibrae.paths.TransitGraph`
+    * :func:`aequilibrae.paths.graph.TransitGraph`
         Class documentation
 
 Blocking flows through centroids

--- a/docs/source/traffic_assignment/assignment_procedures.rst
+++ b/docs/source/traffic_assignment/assignment_procedures.rst
@@ -200,17 +200,27 @@ For now, the VDF functions available in AequilibraE are
 
 .. math:: CongestedTime_{i} = FreeFlowTime_{i} * (1 + \alpha * (\frac{Volume_{i}}{Capacity_{i}})^\beta)
 
+* BPR2
+
+Before capacity (is the same as BPR)
+
+.. math:: CongestedTime_{i} = FreeFlowTime_{i} * (1 + \alpha * (\frac{Volume_{i}}{Capacity_{i}})^\beta)
+
+After capacity
+
+.. math:: CongestedTime_{i} = FreeFlowTime_{i} * (1 + \alpha * (\frac{Volume_{i}}{Capacity_{i}})^{2*\beta})
+
 * Spiess' conical [2]_
 
 .. math:: CongestedTime_{i} = FreeFlowTime_{i} * (2 + \sqrt[2][\alpha^2*(1- \frac{Volume_{i}}{Capacity_{i}})^2 + \beta^2] - \alpha *(1-\frac{Volume_{i}}{Capacity_{i}})-\beta)
 
-* and French INRETS (alpha < 1)
+* French INRETS (alpha < 1)
 
 Before capacity
 
 .. math:: CongestedTime_{i} = FreeFlowTime_{i} * \frac{1.1- (\alpha *\frac{Volume_{i}}{Capacity_{i}})}{1.1-\frac{Volume_{i}}{Capacity_{i}}}
 
-and after capacity
+After capacity
 
 .. math:: CongestedTime_{i} = FreeFlowTime_{i} * \frac{1.1- \alpha}{0.1} * (\frac{Volume_{i}}{Capacity_{i}})^2
 

--- a/docs/source/useful_links/development.rst
+++ b/docs/source/useful_links/development.rst
@@ -205,6 +205,9 @@ Next, build the documentation in html format with the following commands run fro
     cd docs
     make html
 
+More information on writing and contributing to AequilibraE's documentation are available
+:ref:`in this page <guide_to_docs>`.
+
 Working with progress bars
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/useful_links/documentation.rst
+++ b/docs/source/useful_links/documentation.rst
@@ -1,0 +1,247 @@
+:orphan:
+
+.. _guide_to_docs:
+
+Documentation
+=============
+
+AequilibraE's documentation is built with 
+`PyData Sphinx Theme <https://pydata-sphinx-theme.readthedocs.io/en/stable/>`_.
+
+In the following sections, we briefely present some useful documentation writing tips.
+
+conf.py file
+------------
+
+It stores the configuration of the documentation. For instance what extensions are we using, how to
+build the examples gallery, HTML set up, and PDF building, but also where custom theme configs
+are stored.
+
+Regarding the extensions, we mostly use Sphinx built-in extensions that should be loaded. However,
+to enhance rendering, we use external extensions. When using external extensions, remember to
+add/remove them at the TOML.
+
+.. code-block:: python
+
+    extensions = [
+        "sphinx.ext.autodoc",
+        "sphinx.ext.napoleon",
+        "sphinx.ext.mathjax",
+        "sphinx.ext.viewcode",
+        "sphinx.ext.autosummary",
+        "sphinx.ext.doctest",
+        "sphinx_gallery.gen_gallery",  # renders the examples gallery
+        "sphinx_design",  # adds grids and cards
+        "sphinx_copybutton",  # adds the coppy button to code blocks
+        "sphinx_git",  # adds SHA info to the version history
+        "sphinx_tabs.tabs",  # adds tabs 
+        "sphinx_subfigure",  # allows placing more than one figure side by side
+    ]
+
+LaTeX PDF builder
+-----------------
+
+To build the docs PDF file, we use LaTeX engine ``xelatex`` in the conf.py file.
+
+Not everything we have in the docs folder goes to the PDF file. Thus we created an index file
+``_latex/index.rst`` containing the sequence and the contents that compose the PDF file. Any
+changes in the docs structure need to appear here too.
+
+If you want to build the PDF in your machine, make sure that the following packages are also
+installed.
+
+.. code-block::
+
+    sudo apt install -y latexmk texlive-xetex fonts-freefont-otf xindy
+
+API documentation
+-----------------
+
+We generate the API documentation automatically using ``_autosummary``. The outputs are placed
+into a homonymous folder inside ``docs/source/useful_links``.
+
+The API outputs in autosummary are generated based on the ``aequilibrae`` folder. To use the
+API docs within other files, add a reference to the file path based on the same folder structure.
+For example, the class documentation for ``Parameters`` is in ``aequilibrae/parameters.py`` so
+we refer to it as:
+
+.. code-block:: text
+
+    * :func:`aequilibrae.parameters.Parameters`
+        Class documentation
+
+Docstrings
+----------
+
+We have some docstrings in the API documentation that are tested at ``documentation.yml`` workflow.
+Although the functions and modules the docstrings refer to are properly tested in unit tests, 
+testing the docstrings ensure that in-line examples we display to the user are also correct and
+up to date.
+
+In AequilibraE, we have docstrings on python and RST files. To write them, you can use the 
+`Pandas docstring guide <https://pandas.pydata.org/docs/development/contributing_docstring.html>`_.
+
+To make the code clean when using docstrings, we can use pytest fixtures and
+`doctest directives <https://docs.python.org/3/library/doctest.html>`_. For docstrings in RST
+files, we have to create the fixtures. In our current workflow, this is done when running the
+``docs/create_docs_data.py``. Unlike docstrings in Python files that are independent from each
+other, docstrings in the same RST file correspond to one very large code block. So make sure to
+open/close projects when needed. 
+
+When writing docstrings, don't forget to add them at the testing workflow in ``documentation.yml``.
+
+Writing examples
+----------------
+
+All AequilibraE examples consist in rendered RST from a python file (.py). The extension that
+does this job is `Sphinx-Gallery <https://sphinx-gallery.github.io/stable/getting_started.html>`_.
+
+By default only files prefixed with `plot_` will be executed.
+
+When writing the example, we usually add a file reference to the docstring, so the user can
+be easily redirected to the example (and you don't relay on relative paths).
+
+Adding a thumbnail is also a plus and we place this information after the libraries imports. 
+We use  the option ``# sphinx_gallery_thumbnail_path`` and the path to file. Make sure the path
+is correct, otherwise no thumbnail is displayed.
+
+We can add `admonitions and directives <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives>`_
+to the example file.
+
+Check out `Sphinx-Gallery docs <https://sphinx-gallery.github.io/stable/syntax.html) or in one of the [examples in the gallery](https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
+for more information.
+
+Version history
+---------------
+
+Version history file is manually updated when we have new releases. Currently we have rows
+with three grid-cards each with the version number. 
+
+To follow the current pattern, we can add empty cards (``.. grid-item::``) if the line has less
+than 3 cards. Not adding grid-item makes the cards with contents to 'adjust' themselves in the
+same column length, leaving the row with more or less than 3 columns.
+
+The code block below presents an example with two rows, represented by ``.. grid::``, where the
+latter line has two empty cards.
+
+.. code-block:: text
+
+    .. grid::
+
+        .. grid-item-card:: 1.4.2
+            :link:  https://www.aequilibrae.com/docs/python/v1.4.2/
+            :link-type: url
+            :text-align: center
+
+        .. grid-item-card:: 1.4.3
+            :link:  https://www.aequilibrae.com/docs/python/v1.4.3/
+            :link-type: url
+            :text-align: center
+
+        .. grid-item-card:: 1.5.0
+            :link:  https://www.aequilibrae.com/docs/python/v1.5.0/
+            :link-type: url
+            :text-align: center
+ 
+    .. grid::
+
+        .. grid-item-card:: Upcoming version
+            :link:  https://www.aequilibrae.com/develop/python/index.html
+            :link-type: url
+            :text-align: center
+
+        .. grid-item::
+
+        .. grid-item::
+
+Build documentation
+-------------------
+
+In this sections, we go over the statements in the 'build documentation' step of the
+``documentation.yml`` file. To check if the documentation is building properly, you can run
+these steps in your local machine.
+
+.. code-block:: text
+
+    # We convert the IPF_benchmark in the Jupyter Notebook to a .rst file.
+    jupyter nbconvert --to rst docs/source/distribution_procedures/IPF_benchmark.ipynb
+    # We build the .tex file without plotting the gallery. Some examples display progress
+    # bars, and its characters usually don't render properly. The code blocks are 
+    # rendered, but not the outputs.
+    sphinx-build -b latex docs/source docs/source/_static/latex -D plot_gallery=False
+    # Let's go to the folder where our .tex file is
+    cd docs/source/_static/latex
+    # And render the PDF.
+    LATEXMKOPTS="-xelatex" make all-pdf
+    # Go back to docs root
+    cd ../../../..
+    # We copy the AequilibraE icon to the source/_static folder because it is one of the
+    # folders that go to the build
+    cp large_icon.png docs/source/_static/large_icon.png
+    # We build the documentation at the build folder (this runs all examples)
+    sphinx-build -M html docs/source docs/build
+    # We zip the entire HTML documentation in a file named 'aequilibrae.zip'
+    python -m zipfile -c aequilibrae.zip docs/build/html
+    # And copy this file to the build/html folder (because the docs are already rendered
+    # and refer to this location).
+    cp aequilibrae.zip docs/build/html/aequilibrae.zip
+
+Uploading docs to S3
+--------------------
+
+To upload AequilibraE docs to S3, the steps are:
+
+1. Prepare the links
+2. Upload the Python documentation
+3. Upload the home page
+
+If you look at the ``documentation.yml``, you notice conditional steps for link preparation.
+By default, all external links for the AequilibraE webpage refer to LATEST. When uploading
+docs to DEV or DEVELOP, these links are changed in one of 'prepare links for DEV' or
+'prepare links for DEVELOP' steps.
+
+When preparing links for DEV, each pull request has its own documentation page, so changes
+in the documentation from different PR's won't overwrite the one in the branch you're working.
+
+Because we have a home page that does not correspond to ``index.rst`` we have to specifically
+declare it when uploading the docs. We use two different `actions <https://github.com/jakejarvis/s3-sync-action>`_
+to sync the docs with S3. The code block below is an example. What differentiates the steps
+are ``args`` and ``DEST_DIR``. When building the docs with ``make html``, ``home.html`` and
+the contents of the so called 'python' folder are at the same level, so we have to upload
+them to the right folder.
+
+.. code-block:: text
+
+    # We first upload the contents of the 'python' folder ('DEST_DIR'), but when
+    # deleting the files in the bucket that are not present in the latest version of 
+    # the repository build, we end up losing our home page. To prevent it, we use the
+    # exclude flag to indicate that we don't want to delete the 'home.html' file.
+    - name: Upload python to DEV on S3
+      if: ${{(github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true')}}
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --delete --exclude 'home.html'
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: 'docs/build/html/'
+        DEST_DIR: 'dev/${{ github.event.number }}/python/'
+
+    # Then we upload the home page and its related contents. The argument here is different
+    # from the one above. Notice that we exclude the existing contents in the 'python' 
+    # folder from the command, and we include the 'home.html', its images and indexes
+    # (one per flag). All the data is uploaded to the "root" of 'dev/number_of_pull_request'.
+    - name: Upload home page to DEV on S3
+      if: ${{(github.event_name == 'pull_request') && (env.HAS_SECRETS == 'true')}}
+      uses: jakejarvis/s3-sync-action@master
+      with:
+        args: --acl public-read --follow-symlinks --exclude '*' --include 'home.html' --include '_images/sponsor*' --include '_images/banner*' --include '_static/*' --include 'search*' --include 'genindex.html' --include '_sphinx_design_static/*'
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-1'
+        SOURCE_DIR: 'docs/build/html/'
+        DEST_DIR: 'dev/${{ github.event.number }}/'

--- a/docs/source/useful_links/documentation.rst
+++ b/docs/source/useful_links/documentation.rst
@@ -8,7 +8,7 @@ Documentation
 AequilibraE's documentation is built with 
 `PyData Sphinx Theme <https://pydata-sphinx-theme.readthedocs.io/en/stable/>`_.
 
-In the following sections, we briefely present some useful documentation writing tips.
+In the following sections, we briefly present some useful documentation writing tips.
 
 conf.py file
 ------------
@@ -32,7 +32,7 @@ add/remove them at the TOML.
         "sphinx.ext.doctest",
         "sphinx_gallery.gen_gallery",  # renders the examples gallery
         "sphinx_design",  # adds grids and cards
-        "sphinx_copybutton",  # adds the coppy button to code blocks
+        "sphinx_copybutton",  # adds the copy button to code blocks
         "sphinx_git",  # adds SHA info to the version history
         "sphinx_tabs.tabs",  # adds tabs 
         "sphinx_subfigure",  # allows placing more than one figure side by side
@@ -108,7 +108,8 @@ is correct, otherwise no thumbnail is displayed.
 We can add `admonitions and directives <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#directives>`_
 to the example file.
 
-Check out `Sphinx-Gallery docs <https://sphinx-gallery.github.io/stable/syntax.html) or in one of the [examples in the gallery](https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
+Check out `Sphinx-Gallery docs <https://sphinx-gallery.github.io/stable/syntax.html>`_ or 
+one of the `examples in gallery <https://sphinx-gallery.github.io/stable/auto_examples/index.html>`_
 for more information.
 
 Version history

--- a/docs/source/useful_links/version_history.rst
+++ b/docs/source/useful_links/version_history.rst
@@ -198,64 +198,54 @@ In the meantime, you can find the documentation for all versions since 0.5.3.
 .. grid::
 
     .. grid-item-card:: 1.2.0
-        :link:  https://www.aequilibrae.com/docs/python/V.1.2.0/
+        :link:  https://www.aequilibrae.com/docs/python/v1.2.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.3.0
-        :link:  https://www.aequilibrae.com/docs/python/V.1.3.0/
+        :link:  https://www.aequilibrae.com/docs/python/v1.3.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.3.1
-        :link:  https://www.aequilibrae.com/docs/python/V.1.3.1/
+        :link:  https://www.aequilibrae.com/docs/python/v1.3.1/
         :link-type: url
         :text-align: center
 
 .. grid::
 
-    .. grid-item-card:: 1.3.2
-        :link:  https://www.aequilibrae.com/docs/python/V.1.3.2/
-        :link-type: url
-        :text-align: center
-
     .. grid-item-card:: 1.4.0
-        :link:  https://www.aequilibrae.com/docs/python/V.1.4.0/
+        :link:  https://www.aequilibrae.com/docs/python/v1.4.0/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.4.1
-        :link:  https://www.aequilibrae.com/docs/python/V.1.4.1/
+        :link:  https://www.aequilibrae.com/docs/python/v1.4.1/
+        :link-type: url
+        :text-align: center
+
+    .. grid-item-card:: 1.4.2
+        :link:  https://www.aequilibrae.com/docs/python/v1.4.2/
         :link-type: url
         :text-align: center
 
 .. grid::
 
-    .. grid-item-card:: 1.4.2
-        :link:  https://www.aequilibrae.com/docs/python/V.1.4.2/
-        :link-type: url
-        :text-align: center
-
     .. grid-item-card:: 1.4.3
-        :link:  https://www.aequilibrae.com/docs/python/V.1.4.3/
+        :link:  https://www.aequilibrae.com/docs/python/v1.4.3/
         :link-type: url
         :text-align: center
 
     .. grid-item-card:: 1.5.0
-        :link:  https://www.aequilibrae.com/docs/python/V.1.5.0/
+        :link:  https://www.aequilibrae.com/docs/python/v1.5.0/
         :link-type: url
         :text-align: center
-
-.. grid::
 
     .. grid-item-card:: Upcoming version
         :link:  https://www.aequilibrae.com/develop/python/index.html
         :link-type: url
         :text-align: center
 
-    .. grid-item::
-
-    .. grid-item::
 
 This documentation correspond to software version:
 

--- a/docs/website/check_documentation_versions.py
+++ b/docs/website/check_documentation_versions.py
@@ -15,5 +15,5 @@ release_version = pkg_resources.get_distribution("aequilibrae").version
 with open(os.path.join(npth, "docs/source/useful_links/version_history.rst"), mode="r") as f:
     txt = f.read()
 
-print(f"python/V.{release_version}")
-assert f"python/V.{release_version}" in txt
+print(f"python/v{release_version}")
+assert f"python/v{release_version}" in txt


### PR DESCRIPTION
In this PR we fix the documentation references to use the correct path. We also:

* Added a new example demonstrating how to use AequilibraE's project database connections
* Added information about the BPR2 volume-delay function 
* Included a reference to the documentation guide for contributing and writing docs in the development section