### PR TITLE
Set start method, add env var for spatialite load path

### DIFF
--- a/aequilibrae/utils/spatialite_utils.py
+++ b/aequilibrae/utils/spatialite_utils.py
@@ -51,7 +51,7 @@ def _connect_spatialite(path_to_file: os.PathLike, missing_ok: bool = False):
 
 def load_spatialite_extension(conn: Connection):
     conn.enable_load_extension(True)
-    conn.load_extension("mod_spatialite")
+    conn.load_extension(os.environ.get("AEQ_SPATIALITE_PATH", "mod_spatialite"))
 
 
 def is_spatialite(conn):

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,7 @@
+from multiprocessing import set_start_method
+
+set_start_method("fork")
+
 import os
 import uuid
 from pathlib import Path

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,5 @@
 from multiprocessing import set_start_method
 
-set_start_method("fork")
-
 import os
 import uuid
 from pathlib import Path
@@ -15,6 +13,8 @@ from aequilibrae import Project
 from aequilibrae.matrix import AequilibraeMatrix
 from aequilibrae.transit import Transit
 from aequilibrae.utils.create_example import create_example
+
+set_start_method("fork")
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
I'm not quite sure why, but changing the process start method fixes the segfaults on MacOS https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

"fork" is the *only* option that works, both "spawn" (default on Windows and MacOS) and "forkserver" (default on all platform from 3.14) do not work.

Interesting "spawn" was made the default on MacOS because "fork" was causing crashes. https://bugs.python.org/issue?@action=redirect&bpo=33725

I've also added a environment variable to allow changing which spatialite is loaded. This can accept a full path to avoid setting variables like `DYLD_LIBRARY_PATH`. This is what I used on AWS `export AEQ_SPATIALITE_PATH=/opt/homebrew/lib/mod_spatialite.dylib`