### PR TITLE
Fix missing tabs display in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,15 +66,11 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx_git",
-    "sphinx_tabs.tabs",
+    "sphinx_design",
     "sphinx_subfigure",
 ]
 
-if int(sphinx.__version__.split(".")[0]) >= 9:
-    # sphinx-tabs fails with Sphinx 9+ (KeyError: backrefs), so omit it.
-    extensions = [ext for ext in extensions if ext != "sphinx_tabs.tabs"]
 
-sphinx_tabs_disable_tab_closing = True
 
 # Change plot_gallery to True to start building examples again
 sphinx_gallery_conf = {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,6 @@ extensions = [
     "sphinx_design",
     "sphinx_copybutton",
     "sphinx_git",
-    "sphinx_design",
     "sphinx_subfigure",
 ]
 

--- a/docs/source/traffic_assignment/traffic_assignment_validation.rst
+++ b/docs/source/traffic_assignment/traffic_assignment_validation.rst
@@ -19,192 +19,192 @@ As shown below, the results produced by AequilibraE are within expected, althoug
 some differences have been found, particularly for Winnipeg. We suspect that there are 
 issues with the reference results and welcome further investigations.
 
-.. tabs::
+.. tab-set::
 
-   .. tab:: Chicago
+   .. tab-item:: Chicago
 
-      .. tabs::
+      .. tab-set::
 
-         .. tab:: Network stats
+         .. tab-item:: Network stats
 
             * Links: 39,018
             * Nodes: 12,982
             * Zones: 1,790
 
-         .. tab:: biconjugate Frank-Wolfe
+         .. tab-item:: biconjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/ChicagoRegional_bfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Chicago Biconjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Conjugate Frank-Wolfe
+         .. tab-item:: Conjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/ChicagoRegional_cfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Chicago Conjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Frank-Wolfe
+         .. tab-item:: Frank-Wolfe
 
             .. image:: ../_images/assig_validation/ChicagoRegional_fw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Chicago Frank-Wolfe 1000 iterations
 
-         .. tab:: MSA
+         .. tab-item:: MSA
 
             .. image:: ../_images/assig_validation/ChicagoRegional_msa-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Chicago MSA 1000 iterations
 
-   .. tab:: Barcelona
+   .. tab-item:: Barcelona
 
-      .. tabs::
+      .. tab-set::
 
-         .. tab:: Network stats
+         .. tab-item:: Network stats
 
             * Links: 2,522
             * Nodes: 1,020
             * Zones: 110
 
-         .. tab:: biconjugate Frank-Wolfe
+         .. tab-item:: biconjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Barcelona_bfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Barcelona Biconjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Conjugate Frank-Wolfe
+         .. tab-item:: Conjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Barcelona_cfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Barcelona Conjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Frank-Wolfe
+         .. tab-item:: Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Barcelona_fw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Barcelona Frank-Wolfe 1000 iterations
 
-         .. tab:: MSA
+         .. tab-item:: MSA
 
             .. image:: ../_images/assig_validation/Barcelona_msa-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Barcelona MSA 1000 iterations
 
-   .. tab:: Winnipeg
+   .. tab-item:: Winnipeg
 
-      .. tabs::
+      .. tab-set::
 
-         .. tab:: Network stats
+         .. tab-item:: Network stats
 
             * Links: 914
             * Nodes: 416
             * Zones: 38
 
-         .. tab:: biconjugate Frank-Wolfe
+         .. tab-item:: biconjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Winnipeg_bfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Winnipeg Biconjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Conjugate Frank-Wolfe
+         .. tab-item:: Conjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Winnipeg_cfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Winnipeg Conjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Frank-Wolfe
+         .. tab-item:: Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Winnipeg_fw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Winnipeg Frank-Wolfe 1000 iterations
 
-         .. tab:: MSA
+         .. tab-item:: MSA
 
             .. image:: ../_images/assig_validation/Winnipeg_msa-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Winnipeg MSA 1000 iterations
 
-   .. tab:: Anaheim
+   .. tab-item:: Anaheim
 
-      .. tabs::
+      .. tab-set::
 
-         .. tab:: Network stats
+         .. tab-item:: Network stats
 
             * Links: 914
             * Nodes: 416
             * Zones: 38
 
-         .. tab:: biconjugate Frank-Wolfe
+         .. tab-item:: biconjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Anaheim_bfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Anaheim Biconjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Conjugate Frank-Wolfe
+         .. tab-item:: Conjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Anaheim_cfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Anaheim Conjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Frank-Wolfe
+         .. tab-item:: Frank-Wolfe
 
             .. image:: ../_images/assig_validation/Anaheim_fw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Anaheim Frank-Wolfe 1000 iterations
 
-         .. tab:: MSA
+         .. tab-item:: MSA
 
             .. image:: ../_images/assig_validation/Anaheim_msa-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Anaheim MSA 1000 iterations
 
-   .. tab:: Sioux Falls
+   .. tab-item:: Sioux Falls
 
-      .. tabs::
+      .. tab-set::
 
-         .. tab:: Network stats
+         .. tab-item:: Network stats
 
             * Links: 76
             * Nodes: 24
             * Zones: 24
 
-         .. tab:: biconjugate Frank-Wolfe
+         .. tab-item:: biconjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/SiouxFalls_bfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Sioux Falls Biconjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Conjugate Frank-Wolfe
+         .. tab-item:: Conjugate Frank-Wolfe
 
             .. image:: ../_images/assig_validation/SiouxFalls_cfw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Sioux Falls Conjugate Frank-Wolfe 1000 iterations
 
-         .. tab:: Frank-Wolfe
+         .. tab-item:: Frank-Wolfe
 
             .. image:: ../_images/assig_validation/SiouxFalls_fw-1000_iter.png
                 :align: center
                 :width: 590
                 :alt: Sioux Falls Frank-Wolfe 1000 iterations
 
-         .. tab:: MSA
+         .. tab-item:: MSA
 
             .. image:: ../_images/assig_validation/SiouxFalls_msa-1000_iter.png
                 :align: center
@@ -220,37 +220,36 @@ as that instance has a comparable size to real-world models.
 
 .. _algorithm_convergence_comparison:
 
-.. tabs::
-
-   .. tab:: Chicago
+.. tab-set:: 
+   .. tab-item:: Chicago
 
       .. image:: ../_images/assig_validation/convergence_comparison_ChicagoRegional.png
           :align: center
           :width: 590
           :alt: Algorithm convergence comparison
 
-   .. tab:: Barcelona
+   .. tab-item:: Barcelona
 
       .. image:: ../_images/assig_validation/convergence_comparison_Barcelona.png
           :align: center
           :width: 590
           :alt: Algorithm convergence comparison
 
-   .. tab:: Winnipeg
+   .. tab-item:: Winnipeg
 
       .. image:: ../_images/assig_validation/convergence_comparison_Winnipeg.png
           :align: center
           :width: 590
           :alt: Algorithm convergence comparison
 
-   .. tab:: Anaheim
+   .. tab-item:: Anaheim
 
       .. image:: ../_images/assig_validation/convergence_comparison_Anaheim.png
           :align: center
           :width: 590
           :alt: Algorithm convergence comparison
 
-   .. tab:: Sioux-Falls
+   .. tab-item:: Sioux-Falls
 
       .. image:: ../_images/assig_validation/convergence_comparison_SiouxFalls.png
           :align: center

--- a/docs/source/useful_links/documentation.rst
+++ b/docs/source/useful_links/documentation.rst
@@ -34,7 +34,6 @@ add/remove them at the TOML.
         "sphinx_design",  # adds grids and cards
         "sphinx_copybutton",  # adds the copy button to code blocks
         "sphinx_git",  # adds SHA info to the version history
-        "sphinx_tabs.tabs",  # adds tabs 
         "sphinx_subfigure",  # allows placing more than one figure side by side
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ docs = [
   "sphinx-design",
   "sphinx-git",
   "nbconvert",
-  "sphinx-tabs",
   "sphinx-subfigure"
 ]
 


### PR DESCRIPTION
A [recent commit](https://github.com/AequilibraE/aequilibrae/commit/0ce291315037b5b5c6c26eb10029d8c124f9a850) disabled the `sphinx-tabs` extension when the sphinx version is too high, as it has been deprecated. This breaks rendering in the docs. For example, see the [expected output here](https://www.aequilibrae.com/docs/python/v1.4.1/traffic_assignment/traffic_assignment_validation.html) and the [broken output here](https://www.aequilibrae.com/latest/python/traffic_assignment/traffic_assignment_validation.html). 

`sphinx-design`, which is already being used in our docs, implements a tab style as well, so this PR removes `sphinx-tabs` and adjusts the docs to use `sphinx-design` instead.

The new style is (hopefully acceptably) different. See below for an example.

<img width="605" height="489" alt="Screenshot 2026-02-20 at 5 03 47 pm" src="https://github.com/user-attachments/assets/4de4c528-2343-4be6-be82-08f9dea609e4" />
