### PR TITLE
Fix preload handling in FW line search

### DIFF
--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -109,7 +109,10 @@ class LinearApproximation(WorkerThread):
             self.preload = assig_spec.preloads[cols].sum(axis=1).to_numpy()
 
         self.free_flow_tt = assig_spec.free_flow_tt
-        self.fw_total_flow = assig_spec.total_flow
+        self.current_assigned_flow = np.array(assig_spec.total_flow, copy=True)
+        self.fw_total_flow = np.array(assig_spec.total_flow, copy=True)
+        if self.preload is not None:
+            self.fw_total_flow += self.preload
         self.congested_time = assig_spec.congested_time
         self.vdf_der = np.array(assig_spec.congested_time, copy=True)
         self.congested_value = np.array(assig_spec.congested_time, copy=True)
@@ -222,6 +225,27 @@ class LinearApproximation(WorkerThread):
         self.betas[0] = 1.0 / (1.0 + nu + mu)
         self.betas[1] = nu * self.betas[0]
         self.betas[2] = mu * self.betas[0]
+
+    def _set_current_flow(self, assigned_flow):
+        self.current_assigned_flow = np.array(assigned_flow, copy=True)
+        self.fw_total_flow = np.array(self.current_assigned_flow, copy=True)
+        if self.preload is not None:
+            self.fw_total_flow += self.preload
+
+    def _update_congested_costs(self):
+        self.vdf.apply_vdf(
+            self.congested_time,
+            self.fw_total_flow,
+            self.capacity,
+            self.free_flow_tt,
+            *self.vdf_parameters,
+            self.cores,
+        )
+
+        for c in self.traffic_classes:
+            if self.time_field in c.graph.skim_fields:
+                k = c.graph.skim_fields.index(self.time_field)
+                aggregate_link_costs(self.congested_time[:], c.graph.compact_skims[:, k], c.results.crosswalk)
 
     def __calculate_step_direction(self):
         """Calculates step direction depending on the method"""
@@ -476,6 +500,9 @@ class LinearApproximation(WorkerThread):
 
             self.aons[c._id] = allOrNothing(c._id, c.matrix, c.graph, c._aon_results)
 
+        self._set_current_flow(np.zeros_like(self.capacity))
+        self._update_congested_costs()
+
         self.logger.info(f"{self.algorithm} Assignment STATS")
         self.logger.info("Iteration, RelativeGap, stepsize")
 
@@ -576,9 +603,7 @@ class LinearApproximation(WorkerThread):
                     cls_res.total_flows()
                     flows.append(cls_res.total_link_loads)
 
-            self.fw_total_flow = np.sum(flows, axis=0)
-            if self.preload is not None:
-                self.fw_total_flow += self.preload
+            self._set_current_flow(np.sum(flows, axis=0))
 
             if self.algorithm == "all-or-nothing":
                 break
@@ -586,19 +611,7 @@ class LinearApproximation(WorkerThread):
             # Check convergence
             # This needs to be done with the current costs, and not the future ones
             converged = self.check_convergence() if self.iter > 1 else False
-            self.vdf.apply_vdf(
-                self.congested_time,
-                self.fw_total_flow,
-                self.capacity,
-                self.free_flow_tt,
-                *self.vdf_parameters,
-                self.cores,
-            )
-
-            for c in self.traffic_classes:
-                if self.time_field in c.graph.skim_fields:
-                    k = c.graph.skim_fields.index(self.time_field)
-                    aggregate_link_costs(self.congested_time[:], c.graph.compact_skims[:, k], c.results.crosswalk)
+            self._update_congested_costs()
 
             self.convergence_report["iteration"].append(self.iter)
             self.convergence_report["rgap"].append(self.rgap)
@@ -643,11 +656,13 @@ class LinearApproximation(WorkerThread):
         """The stepsize-dependent part of the derivative of the objective function. If fixed costs are defined,
         the corresponding contribution needs to be passed in"""
         x = np.zeros_like(self.fw_total_flow)
-        linear_combination_1d(x, self.step_direction_flow, self.fw_total_flow, stepsize, self.cores)
-        # x = self.fw_total_flow + stepsize * (self.step_direction_flow - self.fw_total_flow)
+        linear_combination_1d(x, self.step_direction_flow, self.current_assigned_flow, stepsize, self.cores)
+        if self.preload is not None:
+            x += self.preload
+        # x = preload + current_assigned_flow + stepsize * (self.step_direction_flow - self.current_assigned_flow)
         self.vdf.apply_vdf(self.congested_value, x, self.capacity, self.free_flow_tt, *self.vdf_parameters, self.cores)
         link_cost_term = sum_a_times_b_minus_c(
-            self.congested_value, self.step_direction_flow, self.fw_total_flow, self.cores
+            self.congested_value, self.step_direction_flow, self.current_assigned_flow, self.cores
         )
         return link_cost_term + const_term
 
@@ -731,7 +746,10 @@ class LinearApproximation(WorkerThread):
             return False
 
         aon_cost = np.sum(self.congested_time * self.aon_total_flow)
-        current_cost = np.sum(self.congested_time * self.fw_total_flow)
+        current_cost = np.sum(self.congested_time * self.current_assigned_flow)
+        if current_cost == 0.0:
+            self.rgap = 0.0
+            return True
         self.rgap = abs(current_cost - aon_cost) / current_cost
         if self.rgap_target >= self.rgap:
             return True

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -109,8 +109,8 @@ class LinearApproximation(WorkerThread):
             self.preload = assig_spec.preloads[cols].sum(axis=1).to_numpy()
 
         self.free_flow_tt = assig_spec.free_flow_tt
-        self.current_assigned_flow = np.array(assig_spec.total_flow, copy=True)
-        self.fw_total_flow = np.array(assig_spec.total_flow, copy=True)
+        self.current_assigned_flow = np.array(assig_spec.total_flow, dtype=np.float64, copy=True)
+        self.fw_total_flow = np.array(assig_spec.total_flow, dtype=np.float64, copy=True)
         if self.preload is not None:
             self.fw_total_flow += self.preload
         self.congested_time = assig_spec.congested_time
@@ -227,8 +227,8 @@ class LinearApproximation(WorkerThread):
         self.betas[2] = mu * self.betas[0]
 
     def _set_current_flow(self, assigned_flow):
-        self.current_assigned_flow = np.array(assigned_flow, copy=True)
-        self.fw_total_flow = np.array(self.current_assigned_flow, copy=True)
+        self.current_assigned_flow = np.array(assigned_flow, dtype=np.float64, copy=True)
+        self.fw_total_flow = np.array(self.current_assigned_flow, dtype=np.float64, copy=True)
         if self.preload is not None:
             self.fw_total_flow += self.preload
 
@@ -748,8 +748,11 @@ class LinearApproximation(WorkerThread):
         aon_cost = np.sum(self.congested_time * self.aon_total_flow)
         current_cost = np.sum(self.congested_time * self.current_assigned_flow)
         if current_cost == 0.0:
-            self.rgap = 0.0
-            return True
+            if aon_cost == 0.0:
+                self.rgap = 0.0
+                return True
+            self.rgap = np.inf
+            return False
         self.rgap = abs(current_cost - aon_cost) / current_cost
         if self.rgap_target >= self.rgap:
             return True

--- a/tests/aeq/paths/test_linear_approximation_preload.py
+++ b/tests/aeq/paths/test_linear_approximation_preload.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+from aequilibrae.paths.linear_approximation import LinearApproximation
+
+
+class DummyVDF:
+    def apply_vdf(self, congested_time, link_flows, capacity, fftime, scale, offset, cores):
+        del capacity, cores
+        congested_time[:] = fftime + scale * link_flows + offset
+
+
+def test_stepsize_derivative_treats_preload_as_constant_background_flow():
+    assignment = LinearApproximation.__new__(LinearApproximation)
+    assignment.cores = 1
+    assignment.preload = np.array([10.0, 20.0])
+    assignment.current_assigned_flow = np.array([3.0, 4.0])
+    assignment.fw_total_flow = assignment.current_assigned_flow + assignment.preload
+    assignment.step_direction_flow = np.array([7.0, 8.0])
+    assignment.congested_value = np.zeros(2)
+    assignment.capacity = np.ones(2)
+    assignment.free_flow_tt = np.zeros(2)
+    assignment.vdf_parameters = [1.0, 0.0]
+    assignment.vdf = DummyVDF()
+
+    stepsize = 0.25
+    derivative = assignment._LinearApproximation__derivative_of_objective_stepsize_dependent(stepsize, 0.0)
+
+    candidate_assigned_flow = (
+        assignment.step_direction_flow * stepsize + assignment.current_assigned_flow * (1.0 - stepsize)
+    )
+    candidate_total_flow = candidate_assigned_flow + assignment.preload
+    expected = np.sum(candidate_total_flow * (assignment.step_direction_flow - assignment.current_assigned_flow))
+
+    assert np.isclose(derivative, expected)
+
+
+def test_relative_gap_ignores_constant_preload():
+    assignment = LinearApproximation.__new__(LinearApproximation)
+    assignment.stepsize_has_been_reset = False
+    assignment.congested_time = np.array([2.0, 3.0])
+    assignment.aon_total_flow = np.array([10.0, 1.0])
+    assignment.current_assigned_flow = np.array([8.0, 2.0])
+    assignment.fw_total_flow = assignment.current_assigned_flow + np.array([100.0, 100.0])
+    assignment.rgap_target = 0.1
+
+    assert assignment.check_convergence()
+
+    expected_current_cost = np.sum(assignment.congested_time * assignment.current_assigned_flow)
+    expected_aon_cost = np.sum(assignment.congested_time * assignment.aon_total_flow)
+    expected_rgap = abs(expected_current_cost - expected_aon_cost) / expected_current_cost
+
+    assert np.isclose(assignment.rgap, expected_rgap)
+
+
+def test_relative_gap_is_not_converged_for_zero_current_cost_and_nonzero_aon_cost():
+    assignment = LinearApproximation.__new__(LinearApproximation)
+    assignment.stepsize_has_been_reset = False
+    assignment.congested_time = np.array([2.0, 3.0])
+    assignment.aon_total_flow = np.array([10.0, 1.0])
+    assignment.current_assigned_flow = np.zeros(2)
+    assignment.fw_total_flow = np.array([100.0, 100.0])
+    assignment.rgap_target = 0.1
+
+    assert not assignment.check_convergence()
+    assert np.isinf(assignment.rgap)


### PR DESCRIPTION
## Summary
- fix FW line search so preload remains a constant background flow
- fix rgap consistency under preload-aware costs
- initialize first-iteration costs with preload included
- add regression tests for preload-related line search behavior

## Problem
Preload is intended to act as a fixed background flow that affects link costs but is not itself reassigned.

The core issue was in the FW line search:
AoN directions were generated from costs based on total flow (`assigned flow + preload`),
but the line search mixed:
- a preload-inclusive current solution
- a demand-only search direction

That means `alpha` was being optimized on the wrong 1D path.
In other words, the step-size calculation treated preload inconsistently, which could distort
FW/CFW/BFW updates and make convergence behavior unreliable under preload.

## Fix
This change separates:
- the assigned flow that is actually updated by the algorithm
- the total flow used for VDF/cost evaluation (`assigned flow + preload`)

With that split:
- AoN/search directions remain demand-only
- preload stays constant during line search
- `alpha` is optimized on the correct preload-aware path
- congested costs are always evaluated from total flow
- rgap is computed consistently under preload-aware costs