### PR TITLE
Incorporate fixes found when working on the ATRF2026 submission

### DIFF
--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -1,28 +1,27 @@
 import logging
 import os
+import time
 from functools import partial
 from pathlib import Path
 from tempfile import gettempdir
-
 from typing import TYPE_CHECKING
 
 import numpy as np
-from aequilibrae.paths.cython.AoN import (
-    copy_two_dimensions,
-    copy_three_dimensions,
-    linear_combination,
-    linear_combination_skims,
-    aggregate_link_costs,
-    sum_a_times_b_minus_c,
-    linear_combination_1d,
-    triple_linear_combination,
-    triple_linear_combination_skims,
-)
 from scipy.optimize import root_scalar
 
 from aequilibrae.paths.all_or_nothing import allOrNothing
+from aequilibrae.paths.cython.AoN import (
+    aggregate_link_costs,
+    copy_three_dimensions,
+    copy_two_dimensions,
+    linear_combination,
+    linear_combination_1d,
+    linear_combination_skims,
+    sum_a_times_b_minus_c,
+    triple_linear_combination,
+    triple_linear_combination_skims,
+)
 from aequilibrae.paths.results import AssignmentResults
-
 from aequilibrae.utils.aeq_signal import SIGNAL, simple_progress
 from aequilibrae.utils.interface.worker_thread import WorkerThread
 
@@ -47,7 +46,7 @@ class LinearApproximation(WorkerThread):
         self.max_iter = assig_spec.max_iter
         self.cores = assig_spec.cores
         self.iteration_issue = []
-        self.convergence_report = {"iteration": [], "rgap": [], "alpha": [], "warnings": []}
+        self.convergence_report = {"iteration": [], "rgap": [], "alpha": [], "time": [], "warnings": []}
         if algorithm in ["cfw", "bfw"]:
             self.convergence_report["beta0"] = []
             self.convergence_report["beta1"] = []
@@ -253,7 +252,12 @@ class LinearApproximation(WorkerThread):
 
         # 2nd iteration is a fw step. if the previous step replaced the aggregated
         # solution so far, we need to start anew.
-        if self.iter == 2 or self.stepsize == 1.0 or self.do_fw_step or self.algorithm in ["msa", "frank-wolfe"]:
+        if (
+            self.iter == 2
+            or self.stepsize_has_been_reset
+            or self.do_fw_step
+            or self.algorithm in ["msa", "frank-wolfe"]
+        ):
             self.do_fw_step = False
             self.do_conjugate_step = True
             self.conjugate_stepsize = 0.0
@@ -613,6 +617,7 @@ class LinearApproximation(WorkerThread):
             converged = self.check_convergence() if self.iter > 1 else False
             self._update_congested_costs()
 
+            self.convergence_report["time"].append(time.perf_counter())
             self.convergence_report["iteration"].append(self.iter)
             self.convergence_report["rgap"].append(self.rgap)
             self.convergence_report["warnings"].append("; ".join(self.iteration_issue))

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -52,7 +52,6 @@ class LinearApproximation(WorkerThread):
             "iteration": [],
             "time": [],
             "rgap": [],
-            "rgap_direction": [],
             "alpha": [],
             "warnings": [],
         }
@@ -87,7 +86,6 @@ class LinearApproximation(WorkerThread):
 
         self.iter = 0
         self.rgap = np.inf
-        self.rgap_direction = np.inf
         self.stepsize = 1.0
         self.conjugate_stepsize = 0.0
         self.fw_class_flow = 0
@@ -625,7 +623,6 @@ class LinearApproximation(WorkerThread):
             self.convergence_report["time"].append(time.perf_counter() - self.__start_time)
             self.convergence_report["iteration"].append(self.iter)
             self.convergence_report["rgap"].append(self.rgap)
-            self.convergence_report["rgap_direction"].append(self.rgap_direction)
             self.convergence_report["warnings"].append("; ".join(self.iteration_issue))
             self.convergence_report["alpha"].append(self.stepsize)
 
@@ -634,7 +631,7 @@ class LinearApproximation(WorkerThread):
                 self.convergence_report["beta1"].append(self.betas[1])
                 self.convergence_report["beta2"].append(self.betas[2])
 
-            self.logger.info(f"{self.iter},{self.rgap},{self.rgap_direction},{self.stepsize}")
+            self.logger.info(f"{self.iter},{self.rgap},{self.stepsize}")
             if converged:
                 self.steps_below += 1
                 if self.steps_below >= self.steps_below_needed_to_terminate:
@@ -650,10 +647,7 @@ class LinearApproximation(WorkerThread):
                     idx = c.graph.skim_fields.index(self.time_field)
                     c.graph.skims[:, idx] = self.congested_time[:]
 
-            msg = (
-                f"Equilibrium Assignment - Iteration: {self.iter}/{self.max_iter} "
-                f"- RGap: {self.rgap:.6} - rgap_direction: {self.rgap_direction:.6}"
-            )
+            msg = f"Equilibrium Assignment - Iteration: {self.iter}/{self.max_iter} - RGap: {self.rgap:.6}"
             self.signal.emit(["set_text", msg])
 
         for c in self.traffic_classes:
@@ -663,10 +657,7 @@ class LinearApproximation(WorkerThread):
 
         if (self.rgap > self.rgap_target) and (self.algorithm != "all-or-nothing"):
             self.logger.error(f"Desired RGap of {self.rgap_target} was NOT reached")
-        self.logger.info(
-            f"{self.algorithm} Assignment finished. {self.iter} iterations, "
-            f"final AoN rgap = {self.rgap}, final step-direction rgap = {self.rgap_direction}"
-        )
+        self.logger.info(f"{self.algorithm} Assignment finished. {self.iter} iterations, final AoN rgap = {self.rgap}")
 
         self.signal.emit(["finished"])
 
@@ -872,7 +863,6 @@ class LinearApproximation(WorkerThread):
           ``|Σ flow·cost − Σ AON·cost| / Σ flow·cost``. **This is the only
           quantity used for the stopping criterion** (compared against
           ``self.rgap_target``).
-        * ``self.rgap_direction`` - the gap in the BFW step direction,
           ``(Σ flow·cost − Σ direction·cost) / Σ flow·cost``, where
           ``direction`` is the BFW combined step direction
           (``self.step_direction_flow``). Reported alongside ``self.rgap``
@@ -884,15 +874,12 @@ class LinearApproximation(WorkerThread):
 
         aon_cost = 0.0
         current_cost = 0.0
-        direction_cost = 0.0
         for c in self.traffic_classes:
             aon_class_flow = c._aon_results.total_link_loads
             current_class_flow = c.results.total_link_loads
-            step_direction_flow = self.step_direction[c._id].total_link_loads
 
             aon_cost += np.sum((self.congested_time + c.fixed_cost) * aon_class_flow)
             current_cost += np.sum((self.congested_time + c.fixed_cost) * current_class_flow)
-            direction_cost += np.sum((self.congested_time + c.fixed_cost) * step_direction_flow)
 
         if current_cost == 0.0:
             if aon_cost == 0.0:
@@ -901,13 +888,6 @@ class LinearApproximation(WorkerThread):
             self.rgap = np.inf
             return False
         self.rgap = abs(current_cost - aon_cost) / current_cost
-
-        # ``step_direction_flow`` is set by ``__calculate_step_direction``
-        # which only runs when ``self.iter > 1`` (and not for the
-        # all-or-nothing algorithm, which short-circuits before this method
-        # is called). Both conditions are already satisfied by the gate in
-        # ``execute()``: ``converged = self.check_convergence() if self.iter > 1 else False``.
-        self.rgap_direction = (current_cost - direction_cost) / current_cost
 
         if self.rgap_target >= self.rgap:
             return True

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -576,7 +576,7 @@ class LinearApproximation(WorkerThread):
                         )
 
                     if c._selected_links:
-                        for name, idx in c._aon_results._selected_links.items():
+                        for name, _idx in c._aon_results._selected_links.items():
                             # Copy the temporary results into the final od matrix, referenced by link_set name
                             # The temp flows have an index associated with the link_set name
                             linear_combination_skims(

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -882,9 +882,24 @@ class LinearApproximation(WorkerThread):
         if self.stepsize_has_been_reset:
             return False
 
-        current_cost = np.sum(self.congested_time * self.fw_total_flow)
+        aon_cost = 0.0
+        current_cost = 0.0
+        direction_cost = 0.0
+        for c in self.traffic_classes:
+            aon_class_flow = c._aon_results.total_link_loads
+            current_class_flow = c.results.total_link_loads
+            step_direction_flow = self.step_direction[c._id].total_link_loads
 
-        aon_cost = np.sum(self.congested_time * self.aon_total_flow)
+            aon_cost += np.sum((self.congested_time + c.fixed_cost) * aon_class_flow)
+            current_cost += np.sum((self.congested_time + c.fixed_cost) * current_class_flow)
+            direction_cost += np.sum((self.congested_time + c.fixed_cost) * step_direction_flow)
+
+        if current_cost == 0.0:
+            if aon_cost == 0.0:
+                self.rgap = 0.0
+                return True
+            self.rgap = np.inf
+            return False
         self.rgap = abs(current_cost - aon_cost) / current_cost
 
         # ``step_direction_flow`` is set by ``__calculate_step_direction``
@@ -892,7 +907,6 @@ class LinearApproximation(WorkerThread):
         # all-or-nothing algorithm, which short-circuits before this method
         # is called). Both conditions are already satisfied by the gate in
         # ``execute()``: ``converged = self.check_convergence() if self.iter > 1 else False``.
-        direction_cost = np.sum(self.congested_time * self.step_direction_flow)
         self.rgap_direction = (current_cost - direction_cost) / current_cost
 
         if self.rgap_target >= self.rgap:

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -7,10 +7,10 @@ from tempfile import gettempdir
 from typing import TYPE_CHECKING
 
 import numpy as np
-from scipy.optimize import root_scalar
+from scipy.optimize import minimize_scalar, root_scalar
 
 from aequilibrae.paths.all_or_nothing import allOrNothing
-from aequilibrae.paths.cython.AoN import (
+from aequilibrae.paths.AoN import (
     aggregate_link_costs,
     copy_three_dimensions,
     copy_two_dimensions,
@@ -22,11 +22,13 @@ from aequilibrae.paths.cython.AoN import (
     triple_linear_combination_skims,
 )
 from aequilibrae.paths.results import AssignmentResults
-from aequilibrae.utils.aeq_signal import SIGNAL, simple_progress
-from aequilibrae.utils.interface.worker_thread import WorkerThread
 
 if TYPE_CHECKING:
-    from aequilibrae.paths.traffic_assignment import TrafficAssignment, TrafficClass
+    from aequilibrae.paths.traffic_assignment import TrafficAssignment
+    from aequilibrae.paths.traffic_class import TrafficClass
+
+from aequilibrae.utils.aeq_signal import SIGNAL, simple_progress
+from aequilibrae.utils.interface.worker_thread import WorkerThread
 
 
 class LinearApproximation(WorkerThread):
@@ -46,7 +48,14 @@ class LinearApproximation(WorkerThread):
         self.max_iter = assig_spec.max_iter
         self.cores = assig_spec.cores
         self.iteration_issue = []
-        self.convergence_report = {"iteration": [], "rgap": [], "alpha": [], "time": [], "warnings": []}
+        self.convergence_report = {
+            "iteration": [],
+            "time": [],
+            "rgap": [],
+            "rgap_direction": [],
+            "alpha": [],
+            "warnings": [],
+        }
         if algorithm in ["cfw", "bfw"]:
             self.convergence_report["beta0"] = []
             self.convergence_report["beta1"] = []
@@ -78,6 +87,7 @@ class LinearApproximation(WorkerThread):
 
         self.iter = 0
         self.rgap = np.inf
+        self.rgap_direction = np.inf
         self.stepsize = 1.0
         self.conjugate_stepsize = 0.0
         self.fw_class_flow = 0
@@ -108,13 +118,22 @@ class LinearApproximation(WorkerThread):
             self.preload = assig_spec.preloads[cols].sum(axis=1).to_numpy()
 
         self.free_flow_tt = assig_spec.free_flow_tt
-        self.current_assigned_flow = np.array(assig_spec.total_flow, dtype=np.float64, copy=True)
-        self.fw_total_flow = np.array(assig_spec.total_flow, dtype=np.float64, copy=True)
-        if self.preload is not None:
-            self.fw_total_flow += self.preload
+        self.fw_total_flow = assig_spec.total_flow
         self.congested_time = assig_spec.congested_time
         self.vdf_der = np.array(assig_spec.congested_time, copy=True)
         self.congested_value = np.array(assig_spec.congested_time, copy=True)
+
+        # Private scratch buffers for the trapezoidal Beckmann line search
+        # (``__objective_change_at_stepsize``). Kept separate from
+        # ``self.congested_value`` (which is the analytic-derivative line
+        # search's scratch buffer) so that the trapezoidal helper does not
+        # clobber the public-looking attribute as a side effect, and so that
+        # the per-call ``congested_time + congested_value`` sum can be
+        # written into a pre-allocated buffer instead of allocating fresh
+        # each call.
+        self._trap_new_flow = np.zeros_like(self.congested_time)
+        self._trap_new_cost = np.zeros_like(self.congested_time)
+        self._trap_avg_cost = np.zeros_like(self.congested_time)
 
         self.step_direction: dict[str, AssignmentResults] = {}
         self.previous_step_direction: dict[str, AssignmentResults] = {}
@@ -225,39 +244,13 @@ class LinearApproximation(WorkerThread):
         self.betas[1] = nu * self.betas[0]
         self.betas[2] = mu * self.betas[0]
 
-    def _set_current_flow(self, assigned_flow):
-        self.current_assigned_flow = np.array(assigned_flow, dtype=np.float64, copy=True)
-        self.fw_total_flow = np.array(self.current_assigned_flow, dtype=np.float64, copy=True)
-        if self.preload is not None:
-            self.fw_total_flow += self.preload
-
-    def _update_congested_costs(self):
-        self.vdf.apply_vdf(
-            self.congested_time,
-            self.fw_total_flow,
-            self.capacity,
-            self.free_flow_tt,
-            *self.vdf_parameters,
-            self.cores,
-        )
-
-        for c in self.traffic_classes:
-            if self.time_field in c.graph.skim_fields:
-                k = c.graph.skim_fields.index(self.time_field)
-                aggregate_link_costs(self.congested_time[:], c.graph.compact_skims[:, k], c.results.crosswalk)
-
     def __calculate_step_direction(self):
         """Calculates step direction depending on the method"""
         sd_flows = []
 
         # 2nd iteration is a fw step. if the previous step replaced the aggregated
         # solution so far, we need to start anew.
-        if (
-            self.iter == 2
-            or self.stepsize_has_been_reset
-            or self.do_fw_step
-            or self.algorithm in ["msa", "frank-wolfe"]
-        ):
+        if self.iter == 2 or self.do_fw_step or self.algorithm in ["msa", "frank-wolfe"]:
             self.do_fw_step = False
             self.do_conjugate_step = True
             self.conjugate_stepsize = 0.0
@@ -448,6 +441,7 @@ class LinearApproximation(WorkerThread):
         self.execute()
 
     def execute(self):  # noqa: C901
+        self.__start_time = time.perf_counter()
         # We build the fixed cost field
 
         self.sl_step_dir_ll = {}
@@ -504,11 +498,8 @@ class LinearApproximation(WorkerThread):
 
             self.aons[c._id] = allOrNothing(c._id, c.matrix, c.graph, c._aon_results)
 
-        self._set_current_flow(np.zeros_like(self.capacity))
-        self._update_congested_costs()
-
-        self.logger.info(f"{self.algorithm} Assignment STATS")
-        self.logger.info("Iteration, RelativeGap, stepsize")
+        self.logger.info(f"{self.algorithm} Assignment stats")
+        self.logger.info("Iteration, RelativeGap (AoN), RelativeGap (Step direction), stepsize")
 
         msg = "Equilibrium Assignment"
         for self.iter in simple_progress(range(1, self.max_iter + 1), self.signal, msg):  # noqa: B020
@@ -557,7 +548,7 @@ class LinearApproximation(WorkerThread):
                                 self.cores,  # core count
                             )
                             copy_two_dimensions(
-                                c.results.select_link_loading[name],  # output matrix
+                                c.results.select_link_loading[name],  # ouput matrix
                                 np.sum(self.aons[c._id].aux_res.temp_sl_link_loading, axis=0)[idx, :, :],  # matrix 1
                                 self.cores,  # core count
                             )
@@ -585,7 +576,7 @@ class LinearApproximation(WorkerThread):
                         )
 
                     if c._selected_links:
-                        for name, _idx in c._aon_results._selected_links.items():
+                        for name, idx in c._aon_results._selected_links.items():
                             # Copy the temporary results into the final od matrix, referenced by link_set name
                             # The temp flows have an index associated with the link_set name
                             linear_combination_skims(
@@ -607,7 +598,9 @@ class LinearApproximation(WorkerThread):
                     cls_res.total_flows()
                     flows.append(cls_res.total_link_loads)
 
-            self._set_current_flow(np.sum(flows, axis=0))
+            self.fw_total_flow = np.sum(flows, axis=0)
+            if self.preload is not None:
+                self.fw_total_flow += self.preload
 
             if self.algorithm == "all-or-nothing":
                 break
@@ -615,11 +608,24 @@ class LinearApproximation(WorkerThread):
             # Check convergence
             # This needs to be done with the current costs, and not the future ones
             converged = self.check_convergence() if self.iter > 1 else False
-            self._update_congested_costs()
+            self.vdf.apply_vdf(
+                self.congested_time,
+                self.fw_total_flow,
+                self.capacity,
+                self.free_flow_tt,
+                *self.vdf_parameters,
+                self.cores,
+            )
 
-            self.convergence_report["time"].append(time.perf_counter())
+            for c in self.traffic_classes:
+                if self.time_field in c.graph.skim_fields:
+                    k = c.graph.skim_fields.index(self.time_field)
+                    aggregate_link_costs(self.congested_time[:], c.graph.compact_skims[:, k], c.results.crosswalk)
+
+            self.convergence_report["time"].append(time.perf_counter() - self.__start_time)
             self.convergence_report["iteration"].append(self.iter)
             self.convergence_report["rgap"].append(self.rgap)
+            self.convergence_report["rgap_direction"].append(self.rgap_direction)
             self.convergence_report["warnings"].append("; ".join(self.iteration_issue))
             self.convergence_report["alpha"].append(self.stepsize)
 
@@ -628,7 +634,7 @@ class LinearApproximation(WorkerThread):
                 self.convergence_report["beta1"].append(self.betas[1])
                 self.convergence_report["beta2"].append(self.betas[2])
 
-            self.logger.info(f"{self.iter},{self.rgap},{self.stepsize}")
+            self.logger.info(f"{self.iter},{self.rgap},{self.rgap_direction},{self.stepsize}")
             if converged:
                 self.steps_below += 1
                 if self.steps_below >= self.steps_below_needed_to_terminate:
@@ -644,7 +650,10 @@ class LinearApproximation(WorkerThread):
                     idx = c.graph.skim_fields.index(self.time_field)
                     c.graph.skims[:, idx] = self.congested_time[:]
 
-            msg = f"Equilibrium Assignment - Iteration: {self.iter}/{self.max_iter} - RGap: {self.rgap:.6}"
+            msg = (
+                f"Equilibrium Assignment - Iteration: {self.iter}/{self.max_iter} "
+                f"- RGap: {self.rgap:.6} - rgap_direction: {self.rgap_direction:.6}"
+            )
             self.signal.emit(["set_text", msg])
 
         for c in self.traffic_classes:
@@ -654,20 +663,22 @@ class LinearApproximation(WorkerThread):
 
         if (self.rgap > self.rgap_target) and (self.algorithm != "all-or-nothing"):
             self.logger.error(f"Desired RGap of {self.rgap_target} was NOT reached")
-        self.logger.info(f"{self.algorithm} Assignment finished. {self.iter} iterations and {self.rgap} final gap")
+        self.logger.info(
+            f"{self.algorithm} Assignment finished. {self.iter} iterations, "
+            f"final AoN rgap = {self.rgap}, final step-direction rgap = {self.rgap_direction}"
+        )
+
         self.signal.emit(["finished"])
 
     def __derivative_of_objective_stepsize_dependent(self, stepsize, const_term):
         """The stepsize-dependent part of the derivative of the objective function. If fixed costs are defined,
         the corresponding contribution needs to be passed in"""
         x = np.zeros_like(self.fw_total_flow)
-        linear_combination_1d(x, self.step_direction_flow, self.current_assigned_flow, stepsize, self.cores)
-        if self.preload is not None:
-            x += self.preload
-        # x = preload + current_assigned_flow + stepsize * (self.step_direction_flow - self.current_assigned_flow)
+        linear_combination_1d(x, self.step_direction_flow, self.fw_total_flow, stepsize, self.cores)
+        # x = self.fw_total_flow + stepsize * (self.step_direction_flow - self.fw_total_flow)
         self.vdf.apply_vdf(self.congested_value, x, self.capacity, self.free_flow_tt, *self.vdf_parameters, self.cores)
         link_cost_term = sum_a_times_b_minus_c(
-            self.congested_value, self.step_direction_flow, self.current_assigned_flow, self.cores
+            self.congested_value, self.step_direction_flow, self.fw_total_flow, self.cores
         )
         return link_cost_term + const_term
 
@@ -683,12 +694,110 @@ class LinearApproximation(WorkerThread):
             class_specific_term += class_link_costs
         return class_specific_term
 
+    def __objective_change_at_stepsize(self, stepsize: float) -> float:
+        """Trapezoidal approximation of the Beckmann objective change
+        ``Z(x + α·d) − Z(x)`` for a given line-search step ``α = stepsize``.
+
+        On large congested networks (e.g. Chicago, BPR β=4), this trapezoidal line search picks smaller,
+        more conservative α values than the analytic-derivative line search and yields materially better
+        BFW convergence because the smaller α reduces the magnitude of the ``μ·α/(1-α)`` bias term in
+        the next iteration's BFW formula.
+
+        All intermediate buffers are pre-allocated on the instance (``self._trap_new_flow``, ``self._trap_new_cost``,
+        ``self._trap_avg_cost``) so that this helper does NOT clobber ``self.congested_value`` (which the
+        analytic-derivative line search uses as scratch) and does NOT allocate fresh arrays on every Brent probe.
+        """
+        linear_combination_1d(
+            self._trap_new_flow,
+            self.step_direction_flow,
+            self.fw_total_flow,
+            stepsize,
+            self.cores,
+        )
+        self.vdf.apply_vdf(
+            self._trap_new_cost,
+            self._trap_new_flow,
+            self.capacity,
+            self.free_flow_tt,
+            *self.vdf_parameters,
+            self.cores,
+        )
+        np.add(self.congested_time, self._trap_new_cost, out=self._trap_avg_cost)
+        link_term = (
+            0.5
+            * stepsize
+            * sum_a_times_b_minus_c(
+                self._trap_avg_cost,
+                self.step_direction_flow,
+                self.fw_total_flow,
+                self.cores,
+            )
+        )
+        fixed_cost_term = stepsize * self.__derivative_of_objective_stepsize_independent()
+        return link_term + fixed_cost_term
+
     def calculate_stepsize(self):
         """Calculate optimal stepsize in descent direction"""
         self.stepsize_has_been_reset = False
 
         if self.algorithm == "msa":
             self.stepsize = 1.0 / self.iter
+            return
+
+        # For BFW/CFW use trapezoidal Beckmann minimiser on
+        # [0, α_max] instead of root-finding the analytic derivative.
+        #
+        # Two cooperating mechanisms vs. the analytic root_scalar approach:
+        #
+        # (1) Trapezoidal objective. The analytic and trapezoidal lines
+        #     agree when c(x) is approximately quadratic between x and
+        #     x + d, but diverge significantly when the BPR exponent is
+        #     large (β=4 on Chicago).
+        # (2) The inspiration for a cap α_max = 1/sqrt(iter) comes from Quetzal. Prevents the line
+        #     search from ever returning α = 1.0 - the boundary case that
+        #     would otherwise trigger a 3-iteration FW+CFW restart in
+        #     ``__calculate_step_direction`` and poison the BFW history
+        #     (s^{k-1} collapses onto the new x^k). The cap also keeps
+        #     the ``μ·α/(1-α)`` bias term in the next BFW iteration
+        #     bounded.
+        #
+        # Combined Chicago-50 rgap: 1.14e-3 (was 1.54e-3 at HEAD baseline).
+        if self.algorithm in ("bfw", "cfw"):
+            alpha_max = min(1.0, 1.0 / max(self.iter, 1) ** 0.5)
+            res = minimize_scalar(
+                self.__objective_change_at_stepsize,
+                bounds=(0.0, alpha_max),
+                method="Bounded",
+                options={"xatol": 1e-4, "maxiter": 10},
+            )
+            candidate = float(res.x)
+            # Brent's bounded method does not evaluate the endpoints exactly.
+            # Compare the interior optimum against α_max explicitly so a true
+            # boundary case (descent throughout the cap interval) still picks
+            # α_max instead of a value just inside it.
+            z_interior = float(res.fun)
+            z_at_max = self.__objective_change_at_stepsize(alpha_max)
+            if z_at_max < z_interior and z_at_max < 0.0:
+                self.stepsize = alpha_max
+            elif z_interior < 0.0:
+                self.stepsize = candidate
+            else:
+                # Trapezoidal line search found no improvement on (0, α_max].
+                # Mirror the analytic-branch fallback: do an FW reset on the
+                # next iteration. Without this reset, α=0 means the flow
+                # never updates and the next BFW iter has the same bad
+                # direction.
+                self.stepsize = 0.0
+                self.do_fw_step = True
+                self.conjugate_failed = True
+                msg = "BFW/CFW direction yielded no improvement; falling back to FW."
+                self.logger.warning(msg)
+                self.iteration_issue.append(msg)
+                assert 0 <= self.stepsize <= alpha_max + 1e-12
+                return
+            self.conjugate_failed = False
+            self.do_fw_step = False
+            assert 0 <= self.stepsize <= alpha_max + 1e-12
             return
 
         class_specific_term = self.__derivative_of_objective_stepsize_independent()
@@ -707,16 +816,24 @@ class LinearApproximation(WorkerThread):
             self.conjugate_failed = False
 
         except ValueError as e:
-            # We can have iterations where the objective function is not *strictly* convex, but the
-            # scipy method cannot deal with this. Stepsize is then either given by 1 or 0, depending
-            # on where the objective function is smaller. However, using zero would mean the overall
-            # solution would not get updated, and therefore we assert the stepsize
-            # in order to add a small fraction of the AoN. A heuristic value equal to the corresponding MSA step size
-            # seems to work well in practice.
-            if self.algorithm == "bfw":
-                self.betas.fill(-1)
+            # `root_scalar` raises ValueError when the derivative does not change sign in [0, 1].
+            # There are two genuinely distinct cases:
+            #   * derivative(0) < 0  ⇒  direction is descent at the current point. Since the
+            #     derivative is monotone non-decreasing along the (convex) line, descent
+            #     persists throughout [0, 1] and the optimum sits at α = 1 (or beyond).
+            #     This is a perfectly valid line-search outcome and only happens because we
+            #     bracket the search to the feasible interval. We must NOT treat it as a
+            #     "reset" - the resulting solution is fine and convergence may be checked.
+            #   * derivative(0) >= 0 ⇒  direction is *not* a descent direction. We then need
+            #     to reset to a Frank-Wolfe step (or, if FW itself failed, take a tiny MSA
+            #     step to avoid stalling).
+            d0_for_branch = derivative_of_objective(0.0)
 
-            if abs(derivative_of_objective(0.0)) < abs(derivative_of_objective(1.0)):
+            if d0_for_branch >= 0:
+                # Direction is not descent at α = 0. Mark BFW betas as invalid for reporting.
+                if self.algorithm == "bfw":
+                    self.betas.fill(-1)
+
                 if self.algorithm == "frank-wolfe" or self.conjugate_failed:
                     tiny_step = 1e-2 / self.iter  # use a fraction of the MSA stepsize. We observe that using 1e-4
                     # works well in practice, however for a large number of iterations this might be too much so
@@ -736,29 +853,48 @@ class LinearApproximation(WorkerThread):
                     # By doing it recursively, we avoid doing the same AoN again
                     self.__calculate_step_direction()
                     self.calculate_stepsize()
-
             else:
-                # Do we want to keep some of the old solution, or just throw away everything?
+                # derivative(0) < 0 (and derivative(1) must also be ≤ 0, otherwise the bracket
+                # search would have succeeded). The objective is still decreasing at α = 1, so
+                # the constrained optimum on [0, 1] is α = 1. Take the full step; do NOT mark
+                # this as a reset - convergence checking remains valid.
                 self.stepsize = 1.0
-                self.logger.warning("Reset line search")
-                self.stepsize_has_been_reset = True
+                self.logger.info("Line-search optimum at the boundary (alpha = 1.0); descent throughout [0, 1]")
 
         assert 0 <= self.stepsize <= 1.0
 
     def check_convergence(self):
-        """Calculate relative gap and return ``True`` if it is smaller than desired precision"""
+        """Calculate relative gap and return ``True`` if it is smaller than desired precision.
+
+        Two relative gaps are computed and stored on the instance:
+
+        * ``self.rgap`` - the AequilibraE convention,
+          ``|Σ flow·cost − Σ AON·cost| / Σ flow·cost``. **This is the only
+          quantity used for the stopping criterion** (compared against
+          ``self.rgap_target``).
+        * ``self.rgap_direction`` - the gap in the BFW step direction,
+          ``(Σ flow·cost − Σ direction·cost) / Σ flow·cost``, where
+          ``direction`` is the BFW combined step direction
+          (``self.step_direction_flow``). Reported alongside ``self.rgap``
+          in the iteration log and the convergence report so the two
+          measures can be compared. NOT used for stopping.
+        """
         if self.stepsize_has_been_reset:
             return False
 
+        current_cost = np.sum(self.congested_time * self.fw_total_flow)
+
         aon_cost = np.sum(self.congested_time * self.aon_total_flow)
-        current_cost = np.sum(self.congested_time * self.current_assigned_flow)
-        if current_cost == 0.0:
-            if aon_cost == 0.0:
-                self.rgap = 0.0
-                return True
-            self.rgap = np.inf
-            return False
         self.rgap = abs(current_cost - aon_cost) / current_cost
+
+        # ``step_direction_flow`` is set by ``__calculate_step_direction``
+        # which only runs when ``self.iter > 1`` (and not for the
+        # all-or-nothing algorithm, which short-circuits before this method
+        # is called). Both conditions are already satisfied by the gate in
+        # ``execute()``: ``converged = self.check_convergence() if self.iter > 1 else False``.
+        direction_cost = np.sum(self.congested_time * self.step_direction_flow)
+        self.rgap_direction = (current_cost - direction_cost) / current_cost
+
         if self.rgap_target >= self.rgap:
             return True
         return False

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -694,7 +694,9 @@ class LinearApproximation(WorkerThread):
             class_specific_term += class_link_costs
         return class_specific_term
 
-    def __objective_change_at_stepsize(self, stepsize: float) -> float:
+    def __objective_change_at_stepsize(
+        self, derivative_of_objective_stepsize_independent: np.ndarray, stepsize: float
+    ) -> float:
         """Trapezoidal approximation of the Beckmann objective change
         ``Z(x + α·d) − Z(x)`` for a given line-search step ``α = stepsize``.
 
@@ -733,7 +735,7 @@ class LinearApproximation(WorkerThread):
                 self.cores,
             )
         )
-        fixed_cost_term = stepsize * self.__derivative_of_objective_stepsize_independent()
+        fixed_cost_term = stepsize * derivative_of_objective_stepsize_independent
         return link_term + fixed_cost_term
 
     def calculate_stepsize(self):
@@ -764,8 +766,12 @@ class LinearApproximation(WorkerThread):
         # Combined Chicago-50 rgap: 1.14e-3 (was 1.54e-3 at HEAD baseline).
         if self.algorithm in ("bfw", "cfw"):
             alpha_max = min(1.0, 1.0 / max(self.iter, 1) ** 0.5)
+            derivative_of_objective_stepsize_independent = self.__derivative_of_objective_stepsize_independent()
             res = minimize_scalar(
-                self.__objective_change_at_stepsize,
+                partial(
+                    self.__objective_change_at_stepsize,
+                    derivative_of_objective_stepsize_independent,
+                ),
                 bounds=(0.0, alpha_max),
                 method="Bounded",
                 options={"xatol": 1e-4, "maxiter": 10},
@@ -776,7 +782,7 @@ class LinearApproximation(WorkerThread):
             # boundary case (descent throughout the cap interval) still picks
             # α_max instead of a value just inside it.
             z_interior = float(res.fun)
-            z_at_max = self.__objective_change_at_stepsize(alpha_max)
+            z_at_max = self.__objective_change_at_stepsize(derivative_of_objective_stepsize_independent, alpha_max)
             if z_at_max < z_interior and z_at_max < 0.0:
                 self.stepsize = alpha_max
             elif z_interior < 0.0:

--- a/aequilibrae/paths/linear_approximation.py
+++ b/aequilibrae/paths/linear_approximation.py
@@ -242,6 +242,26 @@ class LinearApproximation(WorkerThread):
         self.betas[1] = nu * self.betas[0]
         self.betas[2] = mu * self.betas[0]
 
+    def _set_current_flow(self, assigned_flow):
+        self.fw_total_flow = np.array(assigned_flow, dtype=np.float64, copy=True)
+        if self.preload is not None:
+            self.fw_total_flow += self.preload
+
+    def _update_congested_costs(self):
+        self.vdf.apply_vdf(
+            self.congested_time,
+            self.fw_total_flow,
+            self.capacity,
+            self.free_flow_tt,
+            *self.vdf_parameters,
+            self.cores,
+        )
+
+        for c in self.traffic_classes:
+            if self.time_field in c.graph.skim_fields:
+                k = c.graph.skim_fields.index(self.time_field)
+                aggregate_link_costs(self.congested_time[:], c.graph.compact_skims[:, k], c.results.crosswalk)
+
     def __calculate_step_direction(self):
         """Calculates step direction depending on the method"""
         sd_flows = []
@@ -496,6 +516,9 @@ class LinearApproximation(WorkerThread):
 
             self.aons[c._id] = allOrNothing(c._id, c.matrix, c.graph, c._aon_results)
 
+        self._set_current_flow(np.zeros_like(self.capacity))
+        self._update_congested_costs()
+
         self.logger.info(f"{self.algorithm} Assignment stats")
         self.logger.info("Iteration, RelativeGap (AoN), RelativeGap (Step direction), stepsize")
 
@@ -546,7 +569,7 @@ class LinearApproximation(WorkerThread):
                                 self.cores,  # core count
                             )
                             copy_two_dimensions(
-                                c.results.select_link_loading[name],  # ouput matrix
+                                c.results.select_link_loading[name],  # output matrix
                                 np.sum(self.aons[c._id].aux_res.temp_sl_link_loading, axis=0)[idx, :, :],  # matrix 1
                                 self.cores,  # core count
                             )
@@ -596,9 +619,7 @@ class LinearApproximation(WorkerThread):
                     cls_res.total_flows()
                     flows.append(cls_res.total_link_loads)
 
-            self.fw_total_flow = np.sum(flows, axis=0)
-            if self.preload is not None:
-                self.fw_total_flow += self.preload
+            self._set_current_flow(np.sum(flows, axis=0))
 
             if self.algorithm == "all-or-nothing":
                 break
@@ -606,19 +627,7 @@ class LinearApproximation(WorkerThread):
             # Check convergence
             # This needs to be done with the current costs, and not the future ones
             converged = self.check_convergence() if self.iter > 1 else False
-            self.vdf.apply_vdf(
-                self.congested_time,
-                self.fw_total_flow,
-                self.capacity,
-                self.free_flow_tt,
-                *self.vdf_parameters,
-                self.cores,
-            )
-
-            for c in self.traffic_classes:
-                if self.time_field in c.graph.skim_fields:
-                    k = c.graph.skim_fields.index(self.time_field)
-                    aggregate_link_costs(self.congested_time[:], c.graph.compact_skims[:, k], c.results.crosswalk)
+            self._update_congested_costs()
 
             self.convergence_report["time"].append(time.perf_counter() - self.__start_time)
             self.convergence_report["iteration"].append(self.iter)

--- a/tests/aeq/paths/test_linear_approximation_preload.py
+++ b/tests/aeq/paths/test_linear_approximation_preload.py
@@ -1,4 +1,5 @@
 import numpy as np
+from types import SimpleNamespace
 
 from aequilibrae.paths.linear_approximation import LinearApproximation
 
@@ -9,7 +10,7 @@ class DummyVDF:
         congested_time[:] = fftime + scale * link_flows + offset
 
 
-def test_stepsize_derivative_treats_preload_as_constant_background_flow():
+def test_stepsize_derivative_uses_fw_total_flow_state():
     assignment = LinearApproximation.__new__(LinearApproximation)
     assignment.cores = 1
     assignment.preload = np.array([10.0, 20.0])
@@ -25,11 +26,10 @@ def test_stepsize_derivative_treats_preload_as_constant_background_flow():
     stepsize = 0.25
     derivative = assignment._LinearApproximation__derivative_of_objective_stepsize_dependent(stepsize, 0.0)
 
-    candidate_assigned_flow = (
-        assignment.step_direction_flow * stepsize + assignment.current_assigned_flow * (1.0 - stepsize)
+    candidate_total_flow = assignment.fw_total_flow + stepsize * (
+        assignment.step_direction_flow - assignment.fw_total_flow
     )
-    candidate_total_flow = candidate_assigned_flow + assignment.preload
-    expected = np.sum(candidate_total_flow * (assignment.step_direction_flow - assignment.current_assigned_flow))
+    expected = np.sum(candidate_total_flow * (assignment.step_direction_flow - assignment.fw_total_flow))
 
     assert np.isclose(derivative, expected)
 
@@ -38,15 +38,25 @@ def test_relative_gap_ignores_constant_preload():
     assignment = LinearApproximation.__new__(LinearApproximation)
     assignment.stepsize_has_been_reset = False
     assignment.congested_time = np.array([2.0, 3.0])
-    assignment.aon_total_flow = np.array([10.0, 1.0])
-    assignment.current_assigned_flow = np.array([8.0, 2.0])
-    assignment.fw_total_flow = assignment.current_assigned_flow + np.array([100.0, 100.0])
+
+    cls = SimpleNamespace(
+        _id="car",
+        fixed_cost=np.array([0.5, 1.5]),
+        _aon_results=SimpleNamespace(total_link_loads=np.array([10.0, 1.0])),
+        results=SimpleNamespace(total_link_loads=np.array([8.0, 2.0])),
+    )
+    assignment.traffic_classes = [cls]
+    assignment.step_direction = {"car": SimpleNamespace(total_link_loads=np.array([9.0, 1.5]))}
+
+    # Preload contributes to VDF calculations via fw_total_flow but should not affect rgap.
+    assignment.preload = np.array([100.0, 100.0])
+    assignment.fw_total_flow = cls.results.total_link_loads + assignment.preload
     assignment.rgap_target = 0.1
 
     assert assignment.check_convergence()
 
-    expected_current_cost = np.sum(assignment.congested_time * assignment.current_assigned_flow)
-    expected_aon_cost = np.sum(assignment.congested_time * assignment.aon_total_flow)
+    expected_current_cost = np.sum((assignment.congested_time + cls.fixed_cost) * cls.results.total_link_loads)
+    expected_aon_cost = np.sum((assignment.congested_time + cls.fixed_cost) * cls._aon_results.total_link_loads)
     expected_rgap = abs(expected_current_cost - expected_aon_cost) / expected_current_cost
 
     assert np.isclose(assignment.rgap, expected_rgap)
@@ -56,9 +66,16 @@ def test_relative_gap_is_not_converged_for_zero_current_cost_and_nonzero_aon_cos
     assignment = LinearApproximation.__new__(LinearApproximation)
     assignment.stepsize_has_been_reset = False
     assignment.congested_time = np.array([2.0, 3.0])
-    assignment.aon_total_flow = np.array([10.0, 1.0])
-    assignment.current_assigned_flow = np.zeros(2)
-    assignment.fw_total_flow = np.array([100.0, 100.0])
+
+    cls = SimpleNamespace(
+        _id="car",
+        fixed_cost=np.zeros(2),
+        _aon_results=SimpleNamespace(total_link_loads=np.array([10.0, 1.0])),
+        results=SimpleNamespace(total_link_loads=np.zeros(2)),
+    )
+    assignment.traffic_classes = [cls]
+    assignment.step_direction = {"car": SimpleNamespace(total_link_loads=np.zeros(2))}
+
     assignment.rgap_target = 0.1
 
     assert not assignment.check_convergence()


### PR DESCRIPTION
Includes:
- a per iteration timestamps in the assignment report for easier graph creation,
- line search improvements found by @pedrocamargo, including bounded step-sizes inspired by [Quetzal](https://github.com/systragroup/quetzal),
- fixes to the stability of the rgap metric (results unaffected) when using fixed costs by @janzill .
