### PR TITLE
Add VISUM GeoJSON and SQLite network import pipelines

### DIFF
--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.codex/skills/openspec-archive-change/SKILL.md
+++ b/.codex/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.codex/skills/openspec-explore/SKILL.md
+++ b/.codex/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.codex/skills/openspec-propose/SKILL.md
+++ b/.codex/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,10 @@ build/
 coverage.xml
 .pytest_cache/
 .pytest-tmp*/
+.pytest-temp/
+
+# Generated local VISUM import smoke-test projects
+karlsruhe-*-example*/
 
 #### End snippet
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ build/
 .coverage
 .coverage.*
 coverage.xml
+.pytest_cache/
+.pytest-tmp*/
 
 #### End snippet
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# AGENTS.md
+
+Guidance for Codex, GitHub Copilot, and other coding agents working in this repository.
+
+## Document Roles
+
+- `AGENTS.md` is the operational contract for AI agents: how to work in this repo.
+- `openspec/project.md` is the detailed brownfield project context and should be treated as the most complete architecture snapshot.
+- `README.md` is the public package overview and quick orientation for users/contributors.
+
+When these documents disagree, check the source files, tests, CI, and SQL schema before editing.
+
+## Project Snapshot
+
+AequilibraE is a Python 3.10+ transportation modeling package. CI currently tests Python 3.10 through 3.14. The package includes traffic assignment, transit and GTFS tooling, trip distribution, matrix handling, geospatial import/export, and SQLite/SpatiaLite-backed project data.
+
+Performance-critical code uses Cython, C++17, and OpenMP. Be conservative around algorithms, numerical behavior, database schemas, and bundled reference datasets.
+
+## Repository Map
+
+- `aequilibrae/` - main Python package
+  - `paths/` - graph building, path computation, VDFs, traffic assignment, Cython path algorithms
+  - `distribution/` - gravity models and IPF
+  - `matrix/` - AequilibraE matrix, OMX, sparse matrix types, Cython matrix code
+  - `project/` - project lifecycle, scenarios, network management, database schema, migrations, OSM/GMNS tools
+  - `transit/` - GTFS import, route systems, transit graph and assignment support
+  - `utils/` - shared utilities and SimWrapper export
+  - `reference_files/` - bundled sample/test datasets
+- `tests/` - pytest suite and test data
+- `docs/` - Sphinx documentation source
+- `benchmarking/` - performance benchmarks
+- `openspec/` - OpenSpec project context, specs, and changes
+- `.codex/skills/` - OpenSpec skills generated for Codex
+- `.github/prompts/` and `.github/skills/` - OpenSpec prompts/skills generated for GitHub Copilot
+- `.github/copilot-instructions.md` - additional project-specific guidance; consult it when details are missing here
+- `pyproject.toml` - project metadata, dependencies, ruff and coverage configuration
+- `setup.py` - Cython extension build configuration
+
+## OpenSpec Workflow
+
+OpenSpec is the intended spec-driven layer for this brownfield project. It is initialized with `schema: spec-driven` under `openspec/config.yaml`.
+
+Before substantive code changes:
+
+1. Read this file.
+2. Read `openspec/project.md`.
+3. Search `openspec/specs/` for capabilities related to the request.
+4. If the request changes behavior, public APIs, data model, algorithms, CLI behavior, or documentation promises, create or update an OpenSpec change before implementation.
+5. Keep the implementation aligned with the approved proposal, design notes, tasks, and spec deltas.
+
+Small mechanical fixes may proceed without a new OpenSpec change when they do not alter intended behavior. Examples: typos, formatting, narrow lint fixes, obvious test maintenance, or comments. Still mention that no spec change was needed.
+
+When working inside an OpenSpec change:
+
+- Keep `proposal.md` focused on user-visible or maintainer-visible intent.
+- Keep `design.md` for technical tradeoffs, migration strategy, algorithmic risk, and compatibility concerns.
+- Keep `tasks.md` as an executable checklist and update it as tasks complete.
+- Write specs as durable requirements using `SHALL` language and concrete scenarios.
+- Do not treat a spec delta as implementation detail; it describes intended behavior.
+- After implementation, verify tests and docs, then archive or prepare the change according to the OpenSpec workflow.
+
+If OpenSpec commands are available, prefer the native OpenSpec commands. If they are not available, maintain the same folder and document structure manually.
+
+Use `openspec.cmd` from PowerShell if execution policy blocks the npm-generated `openspec.ps1` shim.
+
+## Development Commands
+
+Install in editable development mode:
+
+```bash
+pip install -e ".[dev]"
+```
+
+CI commonly uses `uv`:
+
+```bash
+uv pip install -e ".[dev]"
+```
+
+Run the main test suite:
+
+```bash
+pytest tests/ --durations=50 --dist=loadscope -n 4 --random-order --verbose
+```
+
+Run a quicker local test pass:
+
+```bash
+pytest tests/ -x
+```
+
+Run linting:
+
+```bash
+ruff check aequilibrae/
+```
+
+Build docs locally from `docs/`:
+
+```bash
+make html
+```
+
+On Windows, SpatiaLite setup for tests may require:
+
+```bash
+python tests/setup_windows_spatialite.py
+```
+
+The wheel workflow currently builds wheels on Ubuntu, Windows, and Ubuntu ARM. The test workflow covers Windows, Ubuntu, and macOS; macOS wheel builds are configured in `pyproject.toml` but skipped by the current wheel workflow/configuration.
+
+## Coding Rules
+
+- Follow existing module style and public API patterns.
+- Prefer small, reviewable changes over broad refactors.
+- Preserve backward compatibility unless an OpenSpec change explicitly approves a break.
+- Use Python 3.10+ syntax.
+- Keep ruff's configured 120-character line length.
+- Use `logger` from `aequilibrae.log`; avoid `print` in library code.
+- Use parameterized SQL queries with `?` placeholders; never format user data into SQL.
+- For pandas/NumPy work, avoid unsafe in-place mutation through `.values`; prefer `.to_numpy(copy=...)` and explicit assignment.
+- Use existing `Parameters` behavior instead of hardcoding defaults.
+- Keep docstrings compatible with the Sphinx/reST style used nearby.
+- Treat `Project`, `Graph`, `TrafficAssignment`, `AequilibraeMatrix`, and the database table schemas as public-facing contracts unless an approved spec says otherwise.
+
+## Cython And Performance-Sensitive Code
+
+- Cython files live mainly under `aequilibrae/paths/cython/`, `aequilibrae/distribution/cython/`, and `aequilibrae/matrix/`.
+- Rebuild after changing `.pyx`, `.pxd`, or `.pxi` files.
+- Be careful with memoryviews, `nogil`, `prange`, and OpenMP behavior.
+- Add or update tests around numerical algorithms whenever behavior changes.
+- Treat benchmark-impacting changes as design-worthy; document expected performance effects in OpenSpec when applicable.
+
+## Database And Migration Rules
+
+- Database schema, triggers, and migrations live under `aequilibrae/project/database_specification/` and related project modules.
+- Schema changes require migration logic and tests.
+- Maintain SpatiaLite compatibility.
+- Preserve data integrity guarantees enforced by triggers unless an approved spec change says otherwise.
+- Remember that project data spans `project_database.sqlite`, `public_transport.sqlite`, `results_database.sqlite`, and matrix files under `matrices/`.
+
+## Security And Robustness Notes
+
+- Do not load pickled graph files from untrusted sources.
+- Validate table/field identifiers before dynamic SQL; parameterize all user-provided SQL values.
+- Treat migrations as high-risk because they can span multiple databases and must preserve transaction integrity.
+- Be explicit about network access in tests or docs examples; OSM and some setup paths can reach external URLs.
+- Be careful with SpatiaLite extension loading and `AEQ_SPATIALITE_DIR`, especially on Windows.
+
+## Testing Expectations
+
+- Add focused tests for changed behavior.
+- Use existing pytest fixtures and sample data helpers from `conftest.py` and `tests/conftest.py`.
+- Integration tests may use bundled datasets such as `nauru.zip` and `sioux_falls.zip`.
+- Keep coverage above the configured threshold in `pyproject.toml`.
+- If full tests are too expensive, run the narrowest meaningful subset and say what remains unverified.
+
+## Documentation Expectations
+
+- Update Sphinx docs when public APIs, user workflows, model behavior, parameters, or database behavior change.
+- Keep examples executable and compatible with doctest expectations where applicable.
+- For behavior changes, make sure OpenSpec specs and user-facing docs do not contradict each other.
+
+## Git And Collaboration
+
+- Do not revert user changes or unrelated work.
+- Inspect the worktree before large edits.
+- Keep changes scoped to the requested task and related spec artifacts.
+- Do not commit unless the user asks.
+- In reviews, prioritize bugs, behavioral regressions, missing tests, and spec drift.
+
+## Agent Operating Principles
+
+- For brownfield work, understand the existing behavior before changing it.
+- Search first with `rg` or `rg --files`.
+- Prefer structured parsers and existing APIs over ad hoc text manipulation.
+- Ask a concise question only when the next step is blocked by an important ambiguity.
+- Report commands run and verification results in the final response.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@ When working inside an OpenSpec change:
 - Keep `tasks.md` as an executable checklist and update it as tasks complete.
 - Write specs as durable requirements using `SHALL` language and concrete scenarios.
 - Do not treat a spec delta as implementation detail; it describes intended behavior.
+- When user feedback changes scope, behavior, requirements, data model decisions, API shape, or deferred-work boundaries during an active OpenSpec change, update the affected OpenSpec artifacts before coding. Usually this means `design.md`, `tasks.md`, and any relevant spec delta.
+- When a user resolves an open question in conversation, remove or move that question from the open-question list and reflect the decision in the appropriate decision, spec, or task text. Leave only genuinely unresolved or deferred questions visible.
 - After implementation, verify tests and docs, then archive or prepare the change according to the OpenSpec workflow.
 
 If OpenSpec commands are available, prefer the native OpenSpec commands. If they are not available, maintain the same folder and document structure manually.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,24 @@ Guidance for Codex, GitHub Copilot, and other coding agents working in this repo
 
 - `AGENTS.md` is the operational contract for AI agents: how to work in this repo.
 - `openspec/project.md` is the detailed brownfield project context and should be treated as the most complete architecture snapshot.
+- `openspec/config.yaml` shapes OpenSpec artifact generation with concise repo-wide context and rules.
+- `openspec/specs/*/spec.md` files are the durable capability behavior source of truth after changes are archived.
+- `openspec/changes/*` contains in-flight proposals, designs, tasks, spec deltas, and change-specific investigation notes.
 - `README.md` is the public package overview and quick orientation for users/contributors.
 
 When these documents disagree, check the source files, tests, CI, and SQL schema before editing.
+
+## Context Routing
+
+Keep `AGENTS.md` small. Use it to find the right context, not to carry every project fact.
+
+- For architecture and brownfield orientation, read `openspec/project.md`.
+- For current capability behavior, read the relevant file under `openspec/specs/`.
+- For active sprint decisions, open questions, mapping contracts, reviewer notes, or implementation notes, read the relevant `openspec/changes/<change>/` folder.
+- For user workflows and examples, read `docs/source/` and the corresponding gallery example.
+- For generated or platform-specific agent behavior, use `.codex/skills/`, `.github/prompts/`, `.github/skills/`, and `.github/copilot-instructions.md`.
+
+When new durable knowledge emerges, place it in the narrowest durable home: capability specs for behavior, `openspec/project.md` for architecture context, Sphinx docs for user-facing workflows, and change-local design notes for decisions that are not yet archived.
 
 ## Project Snapshot
 
@@ -45,8 +60,9 @@ Before substantive code changes:
 1. Read this file.
 2. Read `openspec/project.md`.
 3. Search `openspec/specs/` for capabilities related to the request.
-4. If the request changes behavior, public APIs, data model, algorithms, CLI behavior, or documentation promises, create or update an OpenSpec change before implementation.
-5. Keep the implementation aligned with the approved proposal, design notes, tasks, and spec deltas.
+4. Apply the artifact rules in `openspec/config.yaml` when creating or updating OpenSpec proposals, designs, specs, and tasks.
+5. If the request changes behavior, public APIs, data model, algorithms, CLI behavior, or documentation promises, create or update an OpenSpec change before implementation.
+6. Keep the implementation aligned with the approved proposal, design notes, tasks, and spec deltas.
 
 Small mechanical fixes may proceed without a new OpenSpec change when they do not alter intended behavior. Examples: typos, formatting, narrow lint fixes, obvious test maintenance, or comments. Still mention that no spec change was needed.
 
@@ -139,6 +155,7 @@ The wheel workflow currently builds wheels on Ubuntu, Windows, and Ubuntu ARM. T
 - Schema changes require migration logic and tests.
 - Maintain SpatiaLite compatibility.
 - Preserve data integrity guarantees enforced by triggers unless an approved spec change says otherwise.
+- For importer-specific provenance fields, source-ID mappings, or dynamically added columns, check the relevant importer code, OpenSpec change/spec, and docs in addition to static SQL schema files.
 - Remember that project data spans `project_database.sqlite`, `public_transport.sqlite`, `results_database.sqlite`, and matrix files under `matrices/`.
 
 ## Security And Robustness Notes
@@ -154,6 +171,7 @@ The wheel workflow currently builds wheels on Ubuntu, Windows, and Ubuntu ARM. T
 - Add focused tests for changed behavior.
 - Use existing pytest fixtures and sample data helpers from `conftest.py` and `tests/conftest.py`.
 - Integration tests may use bundled datasets such as `nauru.zip` and `sioux_falls.zip`.
+- For importer work, check for focused fixture tests and any opt-in smoke-test flags before assuming the full validation surface.
 - Keep coverage above the configured threshold in `pyproject.toml`.
 - If full tests are too expensive, run the narrowest meaningful subset and say what remains unverified.
 

--- a/README.md
+++ b/README.md
@@ -6,59 +6,54 @@
 [![Code coverage](https://github.com/AequilibraE/aequilibrae/actions/workflows/test_linux_with_coverage.yml/badge.svg)](https://github.com/AequilibraE/aequilibrae/actions/workflows/test_linux_with_coverage.yml)
 [![Packaging](https://github.com/AequilibraE/aequilibrae/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/AequilibraE/aequilibrae/actions/workflows/build_wheels.yml)
 
-AequilibraE is a fully-featured Open-Source transportation modeling package and
-the first comprehensive package of its kind for the Python ecosystem, and is 
-released under an extremely permissive and business-friendly license.
+AequilibraE is an open-source transportation modeling package for Python 3.10+,
+released under a permissive, business-friendly license.
 
-It is developed as general-purpose modeling software and imposes very little 
-underlying structure on models built upon it. This flexibility also extends to
-the ability of using all its core algorithms without an actual AequilibraE 
-model by simply building very simple memory objects from Pandas DataFrames, and
-NumPY arrays, making it the perfect candidate for use-cases where transport is 
-one component of a bigger and more general planning or otherwise analytical 
-modeling pipeline.
+It is designed as general-purpose modeling software and imposes very little
+structure on models built with it. Many core algorithms can also be used without
+an AequilibraE project by working directly with pandas DataFrames and NumPy
+arrays, which makes the package useful when transportation modeling is one
+component of a larger analytical pipeline.
 
-Different than in traditional packages, AequilibraE's network is stored in 
-SQLite/Spatialite, a widely supported open format, and its editing capabilities
-are built into its data layer through a series of spatial database triggers, 
-which allows network editing to be done on Any GIS package supporting SpatiaLite, 
-through a dedicated Python API or directly from an SQL console while maintaining
-full geographical consistency between links and nodes, as well as data integrity
-and consistency with other model tables.
+## What it provides
 
-AequilibraE provides full support for OMX matrices, which can be used as input
-for any AequilibraE procedure, and makes its outputs, particularly skim matrices 
-readily available to other modeling activities.
+- Project-based network modeling backed by SQLite/SpatiaLite databases.
+- Network editing through the Python API, SQL, or GIS tools that support SpatiaLite.
+- Data integrity support through spatial database triggers.
+- Native AequilibraE matrices, OMX matrix interoperability, sparse matrices, and skim outputs.
+- Multi-class traffic assignment with class-specific networks, value of time, generalized costs, MSA, Frank-Wolfe, conjugate Frank-Wolfe, and biconjugate Frank-Wolfe workflows.
+- Public transport support including GTFS import, route map matching, transit graph construction, preloading, and Optimal Strategies transit assignment.
+- Trip distribution models, including gravity models and cache-optimized IPF.
+- OSM and GMNS network import/export support.
+- Performance-critical Cython kernels built with C++17 and OpenMP.
 
-AequilibraE includes multi-class user-equilibrium assignment with full support
-for class-specific networks, value-of-time and generalized cost functions, and 
-includes a range of equilibration algorithms, including MSA, the traditional 
-Frank-Wolfe as well as the state-of-the-art Bi-conjugate Frank-Wolfe.
+AequilibraE project data is primarily stored in SQLite/SpatiaLite databases,
+with matrix files stored alongside the project. This keeps project data in
+widely supported formats while allowing AequilibraE to maintain consistency
+between links, nodes, zones, modes, matrices, results, scenarios, and transit
+data.
 
-AequilibraE's support for public transport includes a GTFS importer that can 
-map-match routes into the model network and an optimized version of the
-traditional "Optimal-Strategies" transit assignment, and full support in the data 
-model for other schedule-based assignments to be implemented in the future.
+## Development status
 
-State-of-the-art computational performance and full multi-threading can be 
-expected from all key algorithms in AequilibraE, from cache-optimized IPF, 
-to path-computation based on sophisticated data structures and cascading network
-loading, which all ensure that AequilibraE performs at par with the best
-commercial packages current available on the market.
+AequilibraE is developed in the open and uses GitHub Actions for linting,
+testing, coverage, documentation, source distributions, and wheels. The test
+workflow covers Windows, Ubuntu Linux, and macOS across Python 3.10 through
+3.14. The current wheel workflow builds on Ubuntu, Windows, and Ubuntu ARM.
 
-AequilibraE has also a Graphical Interface for the popular GIS package QGIS, 
-which gives access to most AequilibraE procedures and includes a wide range of
-visualization tools, such as flow maps, desire and delaunay lines, scenario 
-comparison, matrix visualization, etc. This GUI, called QAequilibraE, is 
-currently available in English, French and Portuguese and more languages are
-continuously being added, which is another substantial point of difference from 
-commercial packages.
+For local development:
 
-Finally, AequilibraE is developed 100% in the open and incorporates software-development 
-best practices for testing and documentation. AequilibraE's testing includes all 
-major operating systems (Windows, Linux and MacOS) and all currently supported versions
-of Python. AequilibraE is also supported on ARM-based cloud computation nodes, making 
-cloud deployments substantially less expensive.
+```bash
+pip install -e ".[dev]"
+pytest tests/ --durations=50 --dist=loadscope -n 4 --random-order --verbose
+ruff check aequilibrae/
+```
+
+The Sphinx documentation lives under `docs/`, and doctests are part of the
+documentation workflow.
+
+This repository also contains OpenSpec/Codex/Copilot context for
+spec-driven brownfield development. See `AGENTS.md` for agent operating rules
+and `openspec/project.md` for the detailed project architecture snapshot.
 
 ## Comprehensive documentation
 
@@ -71,5 +66,5 @@ Some common resources for transportation modeling are inherently visual, and the
 available within a GIS platform. For that reason, many resources are available only from AequilibraE's 
 [QGIS plugin](http://plugins.qgis.org/plugins/qaequilibrae/),
 which uses AequilibraE as its computational workhorse and also provides GUIs for most of AequilibraE's tools. Said tool
-is developed independently and a little delayed with relationship to the Python package, and more details can be found in its 
+is developed independently and may lag behind the Python package. More details can be found in its
 [GitHub repository](https://github.com/AequilibraE/qaequilibrae).

--- a/aequilibrae/project/data/matrices.py
+++ b/aequilibrae/project/data/matrices.py
@@ -1,5 +1,7 @@
 import os
 from os.path import isfile, join
+from pathlib import Path
+from shutil import copy2
 
 import pandas as pd
 
@@ -10,6 +12,8 @@ from aequilibrae.project.table_loader import TableLoader
 
 class Matrices:
     """Gateway into the matrices available/recorded in the model"""
+
+    _supported_extensions = {".aem", ".omx"}
 
     def __init__(self, project):
         self.project = project
@@ -142,6 +146,72 @@ class Matrices:
         """Deletes a Matrix Record from the model and attempts to remove from disk"""
         mr = self.get_record(matrix_name)
         mr.delete()
+
+    def import_file(self, path: str | Path, name: str = None, file_name: str = None) -> MatrixRecord:
+        """Imports an existing matrix file into the project matrix registry.
+
+        The source matrix is copied into the project's ``matrices`` folder and registered in the project database.
+        Supported formats are OMX (``.omx``) and native AequilibraE matrices (``.aem``).
+
+        :Arguments:
+            **path** (:obj:`str` | :obj:`Path`): Path to the existing matrix file to import.
+
+            **name** (:obj:`str`, *Optional*): Matrix record name. Defaults to the destination file stem.
+
+            **file_name** (:obj:`str`, *Optional*): Destination file name inside the project ``matrices`` folder.
+            Defaults to the source file name.
+
+        :Returns:
+            **matrix_record** (:obj:`MatrixRecord`): Registered project matrix record.
+        """
+        source = Path(path).expanduser()
+        if not source.is_file():
+            raise FileNotFoundError(f"Matrix file does not exist: {source}")
+
+        if source.suffix.lower() not in self._supported_extensions:
+            raise ValueError("Matrix needs to be either OMX or native AequilibraE")
+
+        destination_file = str(file_name) if file_name is not None else source.name
+        destination_name = Path(destination_file)
+        if destination_name.name != destination_file:
+            raise ValueError("file_name must be a file name, not a path")
+        if destination_name.suffix.lower() not in self._supported_extensions:
+            raise ValueError("Matrix needs to be either OMX or native AequilibraE")
+
+        record_name = name or destination_name.stem.lower().replace(".", "_").replace(" ", "_")
+        if self.check_exists(record_name):
+            raise ValueError(f"There is already a matrix of name ({record_name}). It must be unique.")
+
+        for mat in self.__items.values():
+            if Path(mat.file_name).name.lower() == destination_name.name.lower():
+                raise ValueError(f"There is already a matrix record for file name ({destination_name.name}).")
+
+        matrix = AequilibraeMatrix()
+        try:
+            matrix.load(source)
+        finally:
+            if matrix.cores > 0:
+                matrix.close()
+
+        matrix_folder = Path(self.fldr)
+        matrix_folder.mkdir(parents=True, exist_ok=True)
+        destination = matrix_folder / destination_name.name
+        same_path = source.resolve() == destination.resolve()
+
+        if destination.exists() and not same_path:
+            raise FileExistsError(f"{destination_name.name} already exists. Choose a different name or matrix format")
+
+        copied = False
+        if not same_path:
+            copy2(source, destination)
+            copied = True
+
+        try:
+            return self.new_record(record_name, destination.name)
+        except Exception:
+            if copied and destination.exists():
+                destination.unlink()
+            raise
 
     def new_record(self, name: str, file_name: str, matrix=None) -> MatrixRecord:
         """Creates a new record for a matrix in disk, but does not save it

--- a/aequilibrae/project/network/network.py
+++ b/aequilibrae/project/network/network.py
@@ -257,11 +257,14 @@ class Network(WorkerThread):
         path_or_layers,
         *,
         mode_mapping: dict[str, str] = None,
+        ignored_transport_systems: set[str] | list[str] | tuple[str, ...] = None,
         link_type_mapping: dict[object, str] = None,
         source_crs: str | int = None,
         accept_default_crs: bool = False,
         allow_non_empty: bool = False,
         geometry_tolerance: float = 1e-6,
+        duplicate_node_policy: str = "offset",
+        duplicate_node_offset_meters: float = 0.25,
     ) -> VisumGeoJSONReport:
         """
         Creates an AequilibraE private-traffic network from VISUM GeoJSON layers.
@@ -272,6 +275,9 @@ class Network(WorkerThread):
 
             **mode_mapping** (:obj:`dict`, *Optional*): Mapping from VISUM transport systems to single-character
             AequilibraE mode IDs. Defaults to ``{"CAR": "c", "HGV": "h"}``.
+
+            **ignored_transport_systems** (:obj:`set`, :obj:`list`, or :obj:`tuple`, *Optional*): VISUM transport
+            systems to ignore explicitly. Any transport system outside ``mode_mapping`` must be mapped or ignored.
 
             **link_type_mapping** (:obj:`dict`, *Optional*): Mapping from VISUM link class/type values to
             AequilibraE link type names.
@@ -285,6 +291,13 @@ class Network(WorkerThread):
             **geometry_tolerance** (:obj:`float`, *Optional*): Maximum coordinate-unit distance allowed between VISUM
             topology references and line endpoints.
 
+            **duplicate_node_policy** (:obj:`str`, *Optional*): Policy for VISUM nodes with identical coordinates.
+            ``"offset"`` preserves source topology with a tiny deterministic coordinate offset. ``"error"`` rejects
+            coincident source nodes before database writes.
+
+            **duplicate_node_offset_meters** (:obj:`float`, *Optional*): Approximate offset distance used when
+            ``duplicate_node_policy="offset"``.
+
         :Returns:
             :class:`aequilibrae.project.network.visum_geojson_importer.VisumGeoJSONReport`: Import diagnostics,
             mapping choices, field inventory, imported row counts, and source-record references.
@@ -294,11 +307,14 @@ class Network(WorkerThread):
             self,
             path_or_layers,
             mode_mapping=mode_mapping,
+            ignored_transport_systems=ignored_transport_systems,
             link_type_mapping=link_type_mapping,
             source_crs=source_crs,
             accept_default_crs=accept_default_crs,
             allow_non_empty=allow_non_empty,
             geometry_tolerance=geometry_tolerance,
+            duplicate_node_policy=duplicate_node_policy,
+            duplicate_node_offset_meters=duplicate_node_offset_meters,
         )
         report = importer.doWork()
 

--- a/aequilibrae/project/network/network.py
+++ b/aequilibrae/project/network/network.py
@@ -21,6 +21,7 @@ from aequilibrae.project.network.osm.osm_builder import OSMBuilder
 from aequilibrae.project.network.osm.osm_downloader import OSMDownloader
 from aequilibrae.project.network.osm.place_getter import placegetter
 from aequilibrae.project.network.periods import Periods
+from aequilibrae.project.network.visum_geojson_importer import VisumGeoJSONImporter, VisumGeoJSONReport
 from aequilibrae.project.project_creation import req_link_flds, req_node_flds, protected_fields
 from aequilibrae.utils.aeq_signal import SIGNAL
 from aequilibrae.utils.interface.worker_thread import WorkerThread
@@ -250,6 +251,59 @@ class Network(WorkerThread):
         gmns_builder.doWork()
 
         self.logger.info("Network built successfully")
+
+    def create_from_visum_geojson(
+        self,
+        path_or_layers,
+        *,
+        mode_mapping: dict[str, str] = None,
+        link_type_mapping: dict[object, str] = None,
+        source_crs: str | int = None,
+        accept_default_crs: bool = False,
+        allow_non_empty: bool = False,
+        geometry_tolerance: float = 1e-6,
+    ) -> VisumGeoJSONReport:
+        """
+        Creates an AequilibraE private-traffic network from VISUM GeoJSON layers.
+
+        :Arguments:
+            **path_or_layers** (:obj:`str`, :obj:`Path`, or :obj:`dict`): Folder with conventional VISUM GeoJSON
+            layer names, or an explicit mapping from layer names to files.
+
+            **mode_mapping** (:obj:`dict`, *Optional*): Mapping from VISUM transport systems to single-character
+            AequilibraE mode IDs. Defaults to ``{"CAR": "c", "HGV": "h"}``.
+
+            **link_type_mapping** (:obj:`dict`, *Optional*): Mapping from VISUM link class/type values to
+            AequilibraE link type names.
+
+            **source_crs** (:obj:`str` or :obj:`int`, *Optional*): CRS to assign to layers that do not declare one.
+
+            **accept_default_crs** (:obj:`bool`, *Optional*): Accept ``EPSG:4326`` for layers without CRS metadata.
+
+            **allow_non_empty** (:obj:`bool`, *Optional*): Allow importing into a project that already has links.
+
+            **geometry_tolerance** (:obj:`float`, *Optional*): Maximum coordinate-unit distance allowed between VISUM
+            topology references and line endpoints.
+
+        :Returns:
+            :class:`aequilibrae.project.network.visum_geojson_importer.VisumGeoJSONReport`: Import diagnostics,
+            mapping choices, field inventory, imported row counts, and source-record references.
+        """
+
+        importer = VisumGeoJSONImporter(
+            self,
+            path_or_layers,
+            mode_mapping=mode_mapping,
+            link_type_mapping=link_type_mapping,
+            source_crs=source_crs,
+            accept_default_crs=accept_default_crs,
+            allow_non_empty=allow_non_empty,
+            geometry_tolerance=geometry_tolerance,
+        )
+        report = importer.doWork()
+
+        self.logger.info("VISUM GeoJSON network imported successfully")
+        return report
 
     def export_to_gmns(self, path: str):
         """

--- a/aequilibrae/project/network/network.py
+++ b/aequilibrae/project/network/network.py
@@ -415,7 +415,18 @@ class Network(WorkerThread):
             # For any link in net that doesn't support mode 'm', set a_node = b_node (these will be culled when
             # the compressed graph representation is created)
             net = pd.DataFrame(data, copy=True)
-            net.loc[~net.modes.str.contains(m), "b_node"] = net.loc[~net.modes.str.contains(m), "a_node"]
+            excluded = ~net.modes.str.contains(m, na=False)
+            numeric_fields = [
+                field
+                for field in net.select_dtypes(np.number).columns
+                if field not in {"link_id", "a_node", "b_node", "direction", "ogc_fid"}
+                and not field.endswith("_id")
+                and not field.endswith("_no")
+            ]
+            for field in numeric_fields:
+                invalid = net[field].isna() | (net[field] <= 0)
+                net.loc[excluded & invalid, field] = 1.0
+            net.loc[excluded, "b_node"] = net.loc[excluded, "a_node"]
 
             g = Graph()
             g.mode = m

--- a/aequilibrae/project/network/network.py
+++ b/aequilibrae/project/network/network.py
@@ -22,6 +22,7 @@ from aequilibrae.project.network.osm.osm_downloader import OSMDownloader
 from aequilibrae.project.network.osm.place_getter import placegetter
 from aequilibrae.project.network.periods import Periods
 from aequilibrae.project.network.visum_geojson_importer import VisumGeoJSONImporter, VisumGeoJSONReport
+from aequilibrae.project.network.visum_sqlite_importer import VisumSQLiteImporter, VisumSQLiteReport
 from aequilibrae.project.project_creation import req_link_flds, req_node_flds, protected_fields
 from aequilibrae.utils.aeq_signal import SIGNAL
 from aequilibrae.utils.interface.worker_thread import WorkerThread
@@ -319,6 +320,81 @@ class Network(WorkerThread):
         report = importer.doWork()
 
         self.logger.info("VISUM GeoJSON network imported successfully")
+        return report
+
+    def create_from_visum_sqlite(
+        self,
+        path,
+        *,
+        mode_mapping: dict[str, str] = None,
+        ignored_transport_systems: set[str] | list[str] | tuple[str, ...] = None,
+        link_type_mapping: dict[object, str] = None,
+        source_crs: str | int = None,
+        accept_default_crs: bool = False,
+        allow_non_empty: bool = False,
+        geometry_tolerance: float = 1e-6,
+        duplicate_node_policy: str = "offset",
+        duplicate_node_offset_meters: float = 0.25,
+        connector_epsilon_minutes: float = 1e-6,
+    ) -> VisumSQLiteReport:
+        """
+        Creates an AequilibraE private-traffic network from a VISUM SQLite export.
+
+        :Arguments:
+            **path** (:obj:`str` or :obj:`Path`): VISUM SQLite export file.
+
+            **mode_mapping** (:obj:`dict`, *Optional*): Mapping from VISUM transport systems to single-character
+            AequilibraE mode IDs. Defaults to ``{"CAR": "c", "HGV": "h"}``.
+
+            **ignored_transport_systems** (:obj:`set`, :obj:`list`, or :obj:`tuple`, *Optional*): VISUM transport
+            systems to ignore explicitly. Any transport system outside ``mode_mapping`` must be mapped or ignored.
+
+            **link_type_mapping** (:obj:`dict`, *Optional*): Mapping from VISUM link class/type values to
+            AequilibraE link type names.
+
+            **source_crs** (:obj:`str` or :obj:`int`, *Optional*): CRS to use instead of
+            ``NETWORK.PROJECTIONDEFINITION``.
+
+            **accept_default_crs** (:obj:`bool`, *Optional*): Accept the importer's default CRS when the SQLite export
+            does not provide a parseable CRS.
+
+            **allow_non_empty** (:obj:`bool`, *Optional*): Allow importing into a project that already has links.
+
+            **geometry_tolerance** (:obj:`float`, *Optional*): Maximum coordinate-unit distance allowed between VISUM
+            topology references and reconstructed line endpoints.
+
+            **duplicate_node_policy** (:obj:`str`, *Optional*): Policy for VISUM nodes with identical coordinates.
+            ``"offset"`` preserves source topology with a tiny deterministic coordinate offset. ``"error"`` rejects
+            coincident source nodes before database writes.
+
+            **duplicate_node_offset_meters** (:obj:`float`, *Optional*): Approximate offset distance used when
+            ``duplicate_node_policy="offset"``.
+
+            **connector_epsilon_minutes** (:obj:`float`, *Optional*): Positive travel-time cost used when a VISUM
+            SQLite connector explicitly stores zero private-traffic travel time.
+
+        :Returns:
+            :class:`aequilibrae.project.network.visum_sqlite_importer.VisumSQLiteReport`: Import diagnostics,
+            mapping choices, field inventory, imported row counts, and source-record references.
+        """
+
+        importer = VisumSQLiteImporter(
+            self,
+            path,
+            mode_mapping=mode_mapping,
+            ignored_transport_systems=ignored_transport_systems,
+            link_type_mapping=link_type_mapping,
+            source_crs=source_crs,
+            accept_default_crs=accept_default_crs,
+            allow_non_empty=allow_non_empty,
+            geometry_tolerance=geometry_tolerance,
+            duplicate_node_policy=duplicate_node_policy,
+            duplicate_node_offset_meters=duplicate_node_offset_meters,
+            connector_epsilon_minutes=connector_epsilon_minutes,
+        )
+        report = importer.doWork()
+
+        self.logger.info("VISUM SQLite network imported successfully")
         return report
 
     def export_to_gmns(self, path: str):

--- a/aequilibrae/project/network/visum_geojson_importer.py
+++ b/aequilibrae/project/network/visum_geojson_importer.py
@@ -1,3 +1,4 @@
+import math
 import re
 import string
 from dataclasses import dataclass, field
@@ -7,7 +8,7 @@ from typing import Mapping
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-from shapely.geometry import MultiPolygon
+from shapely.geometry import LineString, MultiPolygon, Point
 
 from aequilibrae.project.field_editor import FieldEditor
 from aequilibrae.utils.db_utils import commit_and_close
@@ -43,6 +44,18 @@ DEFERRED_COUNT_FIELDS = {
     "CARS_PROJ",
     "HVG_PROJ",
     "MOTOR_PROJ",
+}
+_DIGIT_WORDS = {
+    "0": "zero",
+    "1": "one",
+    "2": "two",
+    "3": "three",
+    "4": "four",
+    "5": "five",
+    "6": "six",
+    "7": "seven",
+    "8": "eight",
+    "9": "nine",
 }
 
 
@@ -196,6 +209,8 @@ def inventory_visum_layers(layers: Mapping[str, gpd.GeoDataFrame]) -> dict[str, 
                 role = "geometry"
             elif column.startswith("R_"):
                 role = "directional"
+            elif layer == "connector" and column == "NO":
+                role = "optional"
             elif column in {"NO", "FROMNODENO", "TONODENO", "ZONENO", "NODENO"}:
                 role = "required"
             elif column in COUNT_CANDIDATE_FIELDS:
@@ -266,31 +281,53 @@ class VisumGeoJSONImporter:
         path_or_layers: str | Path | Mapping[str, str | Path],
         *,
         mode_mapping: Mapping[str, str] | None = None,
+        ignored_transport_systems: set[str] | list[str] | tuple[str, ...] | None = None,
         link_type_mapping: Mapping[object, str] | None = None,
         source_crs: str | int | None = None,
         accept_default_crs: bool = False,
         allow_non_empty: bool = False,
         geometry_tolerance: float = 1e-6,
+        duplicate_node_policy: str = "offset",
+        duplicate_node_offset_meters: float = 0.25,
     ) -> None:
+        if duplicate_node_policy not in {"offset", "error"}:
+            raise ValueError("duplicate_node_policy must be 'offset' or 'error'")
+        if duplicate_node_policy == "offset" and duplicate_node_offset_meters <= 0:
+            raise ValueError("duplicate_node_offset_meters must be positive when duplicate_node_policy='offset'")
         self.net = net
         self.path_or_layers = path_or_layers
         self.mode_mapping = {str(k).upper(): v for k, v in (mode_mapping or DEFAULT_MODE_MAPPING).items()}
+        self.ignored_transport_systems = {str(token).upper() for token in (ignored_transport_systems or set())}
         self.link_type_mapping = dict(link_type_mapping or {})
         self.source_crs = source_crs
         self.accept_default_crs = accept_default_crs
         self.allow_non_empty = allow_non_empty
         self.geometry_tolerance = geometry_tolerance
+        self.duplicate_node_policy = duplicate_node_policy
+        self.duplicate_node_offset_meters = duplicate_node_offset_meters
         self.report = VisumGeoJSONReport(mode_mapping=dict(self.mode_mapping))
         self.layers: dict[str, gpd.GeoDataFrame] = {}
+        self.node_ids: dict[object, int] = {}
+        self.node_points: dict[object, Point] = {}
+        self.node_metadata: dict[object, dict[str, object]] = {}
+        self.zone_points: dict[object, Point] = {}
+        self.zone_metadata: dict[object, dict[str, object]] = {}
         self.source_to_link_id: dict[object, int] = {}
+        self.connector_source_keys: dict[object, str] = {}
+        self.connector_source_nos: dict[object, int | None] = {}
+        self.skipped_records: dict[str, set[object]] = {"link": set(), "connector": set()}
 
     def doWork(self) -> VisumGeoJSONReport:
         self._discover_and_read()
         self._validate_required_columns()
+        self._prepare_connector_source_keys()
         self._validate_mode_values()
         self._validate_assignment_values()
         self._validate_assignment_readiness()
         self._validate_topology()
+        self._prepare_node_geometries()
+        self._prepare_node_ids()
+        self._prepare_zone_geometries()
         self.report.raise_for_errors()
 
         if self.net.count_links() > 0 and not self.allow_non_empty:
@@ -341,7 +378,7 @@ class VisumGeoJSONImporter:
             "node": {"NO"},
             "link": {"NO", "FROMNODENO", "TONODENO", "TSYSSET"},
             "zone_centroid": {"NO"},
-            "connector": {"NO", "ZONENO", "NODENO", "TSYSSET"},
+            "connector": {"ZONENO", "NODENO", "TSYSSET"},
         }
         for layer, fields in required.items():
             if layer not in self.layers:
@@ -356,13 +393,45 @@ class VisumGeoJSONImporter:
                     field=field_name,
                 )
 
+    def _prepare_connector_source_keys(self) -> None:
+        if "connector" not in self.layers:
+            return
+
+        base_counts = {}
+        for row_index, row in self.layers["connector"].iterrows():
+            source_no = _optional_int(row.get("NO"))
+            ab_modes = self._mapped_modes(row.get("TSYSSET"), "connector", source_no)
+            ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "connector", source_no)
+            direction_code = _connector_direction_code(_direction(ab_modes, ba_modes))
+            base_key = (
+                f"connector:{_connector_key_part(row.get('ZONENO'))}:"
+                f"{_connector_key_part(row.get('NODENO'))}:{direction_code}"
+            )
+            base_counts[base_key] = base_counts.get(base_key, 0) + 1
+            suffix = "" if base_counts[base_key] == 1 else f":{base_counts[base_key]}"
+            self.connector_source_keys[row_index] = f"{base_key}{suffix}"
+            self.connector_source_nos[row_index] = source_no
+
+    def _source_id(self, layer: str, row_index, row):
+        if layer == "connector":
+            return self._connector_source_key(row_index)
+        return row.get("NO")
+
+    def _connector_source_key(self, row_index) -> str:
+        return self.connector_source_keys.get(row_index, f"connector:{row_index}")
+
+    def _connector_source_no(self, row_index) -> int | None:
+        return self.connector_source_nos.get(row_index)
+
     def _validate_topology(self) -> None:
         if not REQUIRED_LAYERS.issubset(self.layers):
             return
 
         nodes = self.layers["node"].set_index("NO")
         zones = self.layers["zone_centroid"].set_index("NO")
-        for _, row in self.layers["link"].iterrows():
+        for row_index, row in self.layers["link"].iterrows():
+            if self._skip_record("link", row_index):
+                continue
             source_id = row["NO"]
             if row["FROMNODENO"] not in nodes.index or row["TONODENO"] not in nodes.index:
                 self.report.add(
@@ -376,8 +445,10 @@ class VisumGeoJSONImporter:
             self._validate_line_endpoint(row.geometry, nodes.loc[row["FROMNODENO"]].geometry, True, "link", source_id)
             self._validate_line_endpoint(row.geometry, nodes.loc[row["TONODENO"]].geometry, False, "link", source_id)
 
-        for _, row in self.layers["connector"].iterrows():
-            source_id = row["NO"]
+        for row_index, row in self.layers["connector"].iterrows():
+            if self._skip_record("connector", row_index):
+                continue
+            source_id = self._connector_source_key(row_index)
             if row["ZONENO"] not in zones.index:
                 self.report.add(
                     "error",
@@ -400,40 +471,100 @@ class VisumGeoJSONImporter:
             self._validate_line_endpoint(row.geometry, nodes.loc[row["NODENO"]].geometry, False, "connector", source_id)
 
     def _validate_mode_values(self) -> None:
+        unmapped = {}
+        ignored = {}
         for layer in ("link", "connector"):
             if layer not in self.layers:
                 continue
-            for _, row in self.layers[layer].iterrows():
-                source_id = row.get("NO")
+            for row_index, row in self.layers[layer].iterrows():
+                source_id = self._source_id(layer, row_index, row)
                 ab_tokens = _split_tsysset(row.get("TSYSSET"))
                 ba_tokens = _split_tsysset(row.get("R_TSYSSET"))
-                if not ab_tokens and not ba_tokens:
+                tokens = ab_tokens + ba_tokens
+                mapped_tokens = [token for token in tokens if token.upper() in self.mode_mapping]
+                ignored_tokens = [token for token in tokens if token.upper() in self.ignored_transport_systems]
+                unmapped_tokens = [
+                    token
+                    for token in tokens
+                    if token.upper() not in self.mode_mapping and token.upper() not in self.ignored_transport_systems
+                ]
+
+                if not tokens:
+                    self.skipped_records[layer].add(row_index)
                     self.report.add(
-                        "error",
-                        "no-private-modes",
-                        "Record has no private transport systems in either direction",
+                        "warning",
+                        "empty-transport-systems",
+                        "Record has no declared transport systems and will not be imported",
                         layer=layer,
                         field="TSYSSET",
                         source_id=source_id,
                     )
-                for token in ab_tokens + ba_tokens:
-                    if token.upper() not in self.mode_mapping:
-                        self.report.add(
-                            "error",
-                            "unmapped-transport-system",
-                            f"Transport system '{token}' is not mapped",
-                            layer=layer,
-                            field="TSYSSET",
-                            source_id=source_id,
-                        )
+                    continue
+
+                for token in set(unmapped_tokens):
+                    self._add_transport_system_summary(unmapped, layer, token, source_id)
+                for token in set(ignored_tokens):
+                    self._add_transport_system_summary(ignored, layer, token, source_id)
+
+                if mapped_tokens:
+                    continue
+                if unmapped_tokens:
+                    continue
+
+                self.skipped_records[layer].add(row_index)
+                self.report.add(
+                    "warning",
+                    "ignored-record",
+                    "Record has only explicitly ignored transport systems and will not be imported",
+                    layer=layer,
+                    field="TSYSSET",
+                    source_id=source_id,
+                )
+
+        for (layer, token), summary in sorted(unmapped.items()):
+            source_text = ", ".join(str(source_id) for source_id in summary["sources"])
+            self.report.add(
+                "error",
+                "unmapped-transport-system",
+                (
+                    f"Transport system '{token}' appears in {summary['count']} {layer} records and requires an "
+                    f"explicit mode_mapping or ignored_transport_systems decision. Sample source IDs: {source_text}"
+                ),
+                layer=layer,
+                field="TSYSSET",
+            )
+
+        for (layer, token), summary in sorted(ignored.items()):
+            self.report.add(
+                "info",
+                "ignored-transport-system",
+                f"Transport system '{token}' is explicitly ignored in {summary['count']} {layer} records",
+                layer=layer,
+                field="TSYSSET",
+            )
+
+    def _add_transport_system_summary(self, summary: dict, layer: str, token: str, source_id) -> None:
+        key = (layer, token.upper())
+        if key not in summary:
+            summary[key] = {"count": 0, "sources": []}
+        summary[key]["count"] += 1
+        if len(summary[key]["sources"]) < 5:
+            summary[key]["sources"].append(source_id)
+
+    def _skip_record(self, layer: str, row_index) -> bool:
+        return row_index in self.skipped_records.get(layer, set())
 
     def _validate_assignment_values(self) -> None:
         for layer in ("link", "connector"):
             if layer not in self.layers:
                 continue
-            for _, row in self.layers[layer].iterrows():
-                source_id = row.get("NO")
+            for row_index, row in self.layers[layer].iterrows():
+                if self._skip_record(layer, row_index):
+                    continue
+                source_id = self._source_id(layer, row_index, row)
                 for prefix in ("", "R_"):
+                    if not self._mapped_modes(row.get(f"{prefix}TSYSSET"), layer, source_id):
+                        continue
                     for field_name, parser in (
                         (f"{prefix}LENGTH", parse_visum_length),
                         (f"{prefix}V0PRT", parse_visum_speed),
@@ -458,10 +589,12 @@ class VisumGeoJSONImporter:
         for layer in ("link", "connector"):
             if layer not in self.layers:
                 continue
-            for _, row in self.layers[layer].iterrows():
-                source_id = row.get("NO")
+            for row_index, row in self.layers[layer].iterrows():
+                if self._skip_record(layer, row_index):
+                    continue
+                source_id = self._source_id(layer, row_index, row)
                 for prefix, direction_value in (("", row.get("TSYSSET")), ("R_", row.get("R_TSYSSET"))):
-                    if not _split_tsysset(direction_value):
+                    if not self._mapped_modes(direction_value, layer, source_id):
                         continue
                     try:
                         length, speed, capacity, time = self._assignment_values(row, prefix, layer, source_id)
@@ -508,6 +641,12 @@ class VisumGeoJSONImporter:
             {
                 "visum_node_no": ("VISUM source node identifier", "INTEGER"),
                 "visum_zone_no": ("VISUM source zone identifier for centroid nodes", "INTEGER"),
+                "visum_original_lon": ("VISUM source node longitude before importer coordinate disambiguation", "REAL"),
+                "visum_original_lat": ("VISUM source node latitude before importer coordinate disambiguation", "REAL"),
+                "visum_xcoord": ("VISUM source projected X coordinate when provided", "REAL"),
+                "visum_ycoord": ("VISUM source projected Y coordinate when provided", "REAL"),
+                "visum_duplicate_coord_group": ("VISUM duplicate coordinate group identifier", "TEXT"),
+                "visum_coord_offset_m": ("Approximate coordinate offset applied during VISUM import in meters", "REAL"),
             },
         )
         self._add_fields(
@@ -515,6 +654,7 @@ class VisumGeoJSONImporter:
             {
                 "visum_link_no": ("VISUM source link identifier", "INTEGER"),
                 "visum_connector_no": ("VISUM source connector identifier", "INTEGER"),
+                "visum_connector_key": ("Deterministic VISUM connector source key", "TEXT"),
                 "visum_length_ab": ("VISUM source AB length in meters", "NUMERIC"),
                 "visum_length_ba": ("VISUM source BA length in meters", "NUMERIC"),
             },
@@ -553,7 +693,9 @@ class VisumGeoJSONImporter:
                 continue
             if layer == "connector":
                 continue
-            for _, row in self.layers[layer].iterrows():
+            for row_index, row in self.layers[layer].iterrows():
+                if self._skip_record(layer, row_index):
+                    continue
                 source_values.append(_link_type_source_value(row))
         mapping = dict(self.link_type_mapping)
         used_ids = set(self.net.link_types.all_types())
@@ -593,12 +735,31 @@ class VisumGeoJSONImporter:
     def _insert_nodes(self, conn) -> dict[object, int]:
         mapping = {}
         query = """
-            INSERT INTO nodes(node_id, is_centroid, visum_node_no, geometry)
-            VALUES(?, 0, ?, MakePoint(?, ?, 4326))
+            INSERT INTO nodes(
+                node_id, is_centroid, visum_node_no, visum_original_lon, visum_original_lat, visum_xcoord,
+                visum_ycoord, visum_duplicate_coord_group, visum_coord_offset_m, geometry
+            )
+            VALUES(?, 0, ?, ?, ?, ?, ?, ?, ?, MakePoint(?, ?, 4326))
         """
         for _, row in self.layers["node"].iterrows():
-            node_id = int(row["NO"])
-            conn.execute(query, (node_id, node_id, row.geometry.x, row.geometry.y))
+            node_id = self._node_id(row["NO"])
+            point = self._node_point(row["NO"])
+            metadata = self.node_metadata.get(row["NO"], {})
+            conn.execute(
+                query,
+                (
+                    node_id,
+                    int(row["NO"]),
+                    metadata.get("original_lon", row.geometry.x),
+                    metadata.get("original_lat", row.geometry.y),
+                    metadata.get("xcoord"),
+                    metadata.get("ycoord"),
+                    metadata.get("duplicate_group"),
+                    metadata.get("offset_m", 0.0),
+                    point.x,
+                    point.y,
+                ),
+            )
             mapping[row["NO"]] = node_id
         self.report.source_references["nodes"] = mapping
         return mapping
@@ -622,12 +783,28 @@ class VisumGeoJSONImporter:
                 """,
                 (zone_id, name, zone_id, geometry.wkt),
             )
+            point = self._zone_point(row["NO"])
+            metadata = self.zone_metadata.get(row["NO"], {})
             conn.execute(
                 """
-                INSERT INTO nodes(node_id, is_centroid, visum_zone_no, geometry)
-                VALUES(?, 1, ?, MakePoint(?, ?, 4326))
+                INSERT INTO nodes(
+                    node_id, is_centroid, visum_zone_no, visum_original_lon, visum_original_lat, visum_xcoord,
+                    visum_ycoord, visum_duplicate_coord_group, visum_coord_offset_m, geometry
+                )
+                VALUES(?, 1, ?, ?, ?, ?, ?, ?, ?, MakePoint(?, ?, 4326))
                 """,
-                (zone_id, zone_id, row.geometry.x, row.geometry.y),
+                (
+                    zone_id,
+                    zone_id,
+                    metadata.get("original_lon", row.geometry.x),
+                    metadata.get("original_lat", row.geometry.y),
+                    metadata.get("xcoord"),
+                    metadata.get("ycoord"),
+                    metadata.get("duplicate_group"),
+                    metadata.get("offset_m", 0.0),
+                    point.x,
+                    point.y,
+                ),
             )
             zones[row["NO"]] = zone_id
         self.report.source_references["zones"] = zones
@@ -642,7 +819,9 @@ class VisumGeoJSONImporter:
             )
             VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))
         """
-        for _, row in self.layers["link"].iterrows():
+        for row_index, row in self.layers["link"].iterrows():
+            if self._skip_record("link", row_index):
+                continue
             source_id = int(row["NO"])
             ab_modes = self._mapped_modes(row.get("TSYSSET"), "link", source_id)
             ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "link", source_id)
@@ -658,8 +837,8 @@ class VisumGeoJSONImporter:
                 query,
                 (
                     source_id,
-                    int(row["FROMNODENO"]),
-                    int(row["TONODENO"]),
+                    self._node_id(row["FROMNODENO"]),
+                    self._node_id(row["TONODENO"]),
                     direction,
                     "".join(sorted(ab_modes | ba_modes)),
                     link_type,
@@ -672,7 +851,7 @@ class VisumGeoJSONImporter:
                     source_id,
                     length_ab,
                     length_ba,
-                    row.geometry.wkt,
+                    self._link_geometry(row).wkt,
                 ),
             )
             mapping[row["NO"]] = source_id
@@ -686,13 +865,19 @@ class VisumGeoJSONImporter:
         query = """
             INSERT INTO links(
                 link_id, a_node, b_node, direction, modes, link_type, speed_ab, speed_ba, capacity_ab, capacity_ba,
-                travel_time_ab, travel_time_ba, visum_connector_no, visum_length_ab, visum_length_ba, geometry
+                travel_time_ab, travel_time_ba, visum_connector_no, visum_connector_key, visum_length_ab,
+                visum_length_ba, geometry
             )
-            VALUES(?, ?, ?, ?, ?, 'centroid_connector', ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))
+            VALUES(?, ?, ?, ?, ?, 'centroid_connector', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))
         """
-        for idx, (_, row) in enumerate(self.layers["connector"].iterrows(), start=1):
+        idx = 0
+        for row_index, row in self.layers["connector"].iterrows():
+            if self._skip_record("connector", row_index):
+                continue
+            idx += 1
             link_id = max_link + idx
-            source_id = int(row["NO"])
+            source_id = self._connector_source_key(row_index)
+            source_no = self._connector_source_no(row_index)
             ab_modes = self._mapped_modes(row.get("TSYSSET"), "connector", source_id)
             ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "connector", source_id)
             direction = _direction(ab_modes, ba_modes)
@@ -707,7 +892,7 @@ class VisumGeoJSONImporter:
                 (
                     link_id,
                     int(row["ZONENO"]),
-                    int(row["NODENO"]),
+                    self._node_id(row["NODENO"]),
                     direction,
                     "".join(sorted(ab_modes | ba_modes)),
                     speed_ab,
@@ -716,15 +901,192 @@ class VisumGeoJSONImporter:
                     capacity_ba,
                     time_ab,
                     time_ba,
+                    source_no,
                     source_id,
                     length_ab,
                     length_ba,
-                    row.geometry.wkt,
+                    self._connector_geometry(row).wkt,
                 ),
             )
-            mapping[row["NO"]] = link_id
+            mapping[source_id] = link_id
         self.report.source_references["connectors"] = mapping
         return mapping
+
+    def _prepare_node_geometries(self) -> None:
+        if "node" not in self.layers:
+            return
+
+        groups: dict[tuple[float, float], list[tuple[object, object, Point]]] = {}
+        for row_index, row in self.layers["node"].iterrows():
+            point = row.geometry
+            if point is None or point.is_empty:
+                continue
+            source_id = row["NO"]
+            self.node_points[source_id] = point
+            self.node_metadata[source_id] = {
+                "original_lon": point.x,
+                "original_lat": point.y,
+                "xcoord": _optional_float(row.get("XCOORD")),
+                "ycoord": _optional_float(row.get("YCOORD")),
+                "duplicate_group": None,
+                "offset_m": 0.0,
+            }
+            groups.setdefault((point.x, point.y), []).append((row_index, source_id, point))
+
+        duplicate_group_number = 0
+        for records in groups.values():
+            if len(records) < 2:
+                continue
+            duplicate_group_number += 1
+            source_ids = [record[1] for record in records]
+            if self.duplicate_node_policy == "error":
+                self.report.add(
+                    "error",
+                    "coincident-node-coordinate",
+                    "VISUM nodes share identical coordinates; use duplicate_node_policy='offset' to preserve topology",
+                    layer="node",
+                    source_id=", ".join(str(source_id) for source_id in source_ids),
+                )
+                continue
+
+            group_id = f"node-coordinate-{duplicate_group_number}"
+            for position, (_, source_id, point) in enumerate(records):
+                offset_m = 0.0
+                adjusted_point = point
+                if position > 0:
+                    offset_m = self.duplicate_node_offset_meters
+                    adjusted_point = _offset_point(point, position - 1, len(records) - 1, offset_m)
+                self.node_points[source_id] = adjusted_point
+                self.node_metadata[source_id]["duplicate_group"] = group_id
+                self.node_metadata[source_id]["offset_m"] = offset_m
+
+            self.report.add(
+                "warning",
+                "coincident-node-offset",
+                (
+                    f"{len(records)} VISUM nodes share coordinates; importer applied deterministic offsets to "
+                    "preserve source topology. Source node IDs: "
+                    f"{', '.join(str(source_id) for source_id in source_ids)}"
+                ),
+                layer="node",
+                source_id=", ".join(str(source_id) for source_id in source_ids),
+            )
+
+        self.report.source_references["node_coordinate_offsets"] = {
+            _jsonish(source_id): {
+                "original_lon": metadata["original_lon"],
+                "original_lat": metadata["original_lat"],
+                "offset_m": metadata["offset_m"],
+                "duplicate_group": metadata["duplicate_group"],
+            }
+            for source_id, metadata in self.node_metadata.items()
+            if metadata.get("duplicate_group") is not None
+        }
+
+    def _node_point(self, source_id) -> Point:
+        return self.node_points[source_id]
+
+    def _prepare_node_ids(self) -> None:
+        if "node" not in self.layers:
+            return
+
+        zone_ids = {int(row["NO"]) for _, row in self.layers.get("zone_centroid", pd.DataFrame()).iterrows()}
+        source_node_ids = [int(row["NO"]) for _, row in self.layers["node"].iterrows()]
+        used_ids = set(zone_ids)
+        next_node_id = max(used_ids | set(source_node_ids), default=0) + 1
+
+        for _, row in self.layers["node"].iterrows():
+            source_id = row["NO"]
+            preferred_id = int(source_id)
+            if preferred_id not in used_ids:
+                node_id = preferred_id
+            else:
+                while next_node_id in used_ids:
+                    next_node_id += 1
+                node_id = next_node_id
+                next_node_id += 1
+                self.report.add(
+                    "warning",
+                    "node-id-remapped",
+                    (
+                        f"VISUM node {source_id} uses an ID reserved for a zone centroid; "
+                        f"imported as AequilibraE node {node_id}"
+                    ),
+                    layer="node",
+                    field="NO",
+                    source_id=source_id,
+                )
+            self.node_ids[source_id] = node_id
+            used_ids.add(node_id)
+
+    def _node_id(self, source_id) -> int:
+        return self.node_ids[source_id]
+
+    def _prepare_zone_geometries(self) -> None:
+        if "zone_centroid" not in self.layers:
+            return
+
+        occupied = {(point.x, point.y) for point in self.node_points.values()}
+        offset_number = 0
+        for _, row in self.layers["zone_centroid"].iterrows():
+            source_id = row["NO"]
+            point = row.geometry
+            self.zone_metadata[source_id] = {
+                "original_lon": point.x,
+                "original_lat": point.y,
+                "xcoord": _optional_float(row.get("XCOORD")),
+                "ycoord": _optional_float(row.get("YCOORD")),
+                "duplicate_group": None,
+                "offset_m": 0.0,
+            }
+
+            adjusted_point = point
+            if (adjusted_point.x, adjusted_point.y) in occupied:
+                offset_number += 1
+                group_id = f"zone-coordinate-{offset_number}"
+                offset_step = 0
+                while (adjusted_point.x, adjusted_point.y) in occupied:
+                    adjusted_point = _offset_point(point, offset_step, 8, self.duplicate_node_offset_meters)
+                    offset_step += 1
+                self.zone_metadata[source_id]["duplicate_group"] = group_id
+                self.zone_metadata[source_id]["offset_m"] = self.duplicate_node_offset_meters
+                self.report.add(
+                    "warning",
+                    "coincident-centroid-offset",
+                    (
+                        f"VISUM zone centroid {source_id} shares coordinates with another imported node; "
+                        "importer applied a deterministic offset"
+                    ),
+                    layer="zone_centroid",
+                    source_id=source_id,
+                )
+
+            self.zone_points[source_id] = adjusted_point
+            occupied.add((adjusted_point.x, adjusted_point.y))
+
+        self.report.source_references["zone_coordinate_offsets"] = {
+            _jsonish(source_id): {
+                "original_lon": metadata["original_lon"],
+                "original_lat": metadata["original_lat"],
+                "offset_m": metadata["offset_m"],
+                "duplicate_group": metadata["duplicate_group"],
+            }
+            for source_id, metadata in self.zone_metadata.items()
+            if metadata.get("duplicate_group") is not None
+        }
+
+    def _zone_point(self, source_id) -> Point:
+        return self.zone_points[source_id]
+
+    def _link_geometry(self, row) -> LineString:
+        return _line_with_endpoints(
+            row.geometry,
+            self._node_point(row["FROMNODENO"]),
+            self._node_point(row["TONODENO"]),
+        )
+
+    def _connector_geometry(self, row) -> LineString:
+        return _line_with_endpoints(row.geometry, self._zone_point(row["ZONENO"]), self._node_point(row["NODENO"]))
 
     def _mapped_modes(self, value, layer: str, source_id) -> set[str]:
         modes = set()
@@ -834,6 +1196,55 @@ def _direction(ab_modes: set[str], ba_modes: set[str]) -> int:
     return 1
 
 
+def _connector_direction_code(direction: int) -> str:
+    return {0: "B", 1: "O", -1: "D"}[direction]
+
+
+def _connector_key_part(value) -> str:
+    if value is None or pd.isna(value):
+        return "unknown"
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value).strip()
+
+
+def _optional_int(value) -> int | None:
+    if value is None or pd.isna(value) or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value) -> float | None:
+    if value is None or pd.isna(value) or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _offset_point(point: Point, offset_index: int, offset_count: int, offset_meters: float) -> Point:
+    angle = 2.0 * math.pi * offset_index / max(offset_count, 1)
+    latitude_radians = math.radians(point.y)
+    meters_per_degree_latitude = 111_320.0
+    meters_per_degree_longitude = max(math.cos(latitude_radians) * meters_per_degree_latitude, 1e-9)
+    dx = math.cos(angle) * offset_meters / meters_per_degree_longitude
+    dy = math.sin(angle) * offset_meters / meters_per_degree_latitude
+    return Point(point.x + dx, point.y + dy)
+
+
+def _line_with_endpoints(geometry, start_point: Point, end_point: Point) -> LineString:
+    coords = [(coord[0], coord[1]) for coord in geometry.coords]
+    coords[0] = (start_point.x, start_point.y)
+    coords[-1] = (end_point.x, end_point.y)
+    return LineString(coords)
+
+
 def _link_type_source_value(row) -> object:
     for field_name in ("LC", "TYPENO"):
         if field_name in row and not pd.isna(row[field_name]) and row[field_name] != "":
@@ -850,7 +1261,10 @@ def _first_unused_link_type_id(source: str, used: set[str]) -> str | None:
 
 
 def _clean_name(value) -> str:
-    text = re.sub(r"[^a-zA-Z_]+", "_", str(value).strip().lower()).strip("_")
+    text = str(value).strip().lower()
+    text = re.sub(r"\d", lambda match: f"_{_DIGIT_WORDS[match.group(0)]}", text)
+    text = re.sub(r"[^a-zA-Z_]+", "_", text)
+    text = re.sub(r"_+", "_", text).strip("_")
     if not text or text[0] not in string.ascii_letters:
         text = f"visum_{text}" if text else "visum_default"
     return text

--- a/aequilibrae/project/network/visum_geojson_importer.py
+++ b/aequilibrae/project/network/visum_geojson_importer.py
@@ -8,6 +8,7 @@ from typing import Mapping
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+from pyproj import Geod
 from shapely.geometry import LineString, MultiPolygon, Point
 
 from aequilibrae.project.field_editor import FieldEditor
@@ -36,6 +37,9 @@ CONVENTIONAL_NAMES = {
     "countlocation": ("countlocation.geojson", "count_location.geojson", "count-locations.geojson"),
 }
 DEFAULT_MODE_MAPPING = {"CAR": "c", "HGV": "h"}
+CONNECTOR_FALLBACK_SPEED_KMH = 30.0
+CONNECTOR_FALLBACK_CAPACITY = 99999.0
+GEOD = Geod(ellps="WGS84")
 COUNT_CANDIDATE_FIELDS = {"CAR_ORIG", "HVG_ORIG", "MOTOR_ORIG", "DTVW"}
 DEFERRED_COUNT_FIELDS = {
     "CARS_LEFT",
@@ -697,6 +701,7 @@ class VisumGeoJSONImporter:
                 if self._skip_record(layer, row_index):
                     continue
                 source_values.append(_link_type_source_value(row))
+                source_values.append(_link_type_source_value(row, "R_"))
         mapping = dict(self.link_type_mapping)
         used_ids = set(self.net.link_types.all_types())
         existing_by_name = {
@@ -812,6 +817,7 @@ class VisumGeoJSONImporter:
 
     def _insert_links(self, conn, link_type_by_value: Mapping[object, str]) -> dict[object, int]:
         mapping = {}
+        next_link_id = self._next_link_id(conn)
         query = """
             INSERT INTO links(
                 link_id, a_node, b_node, direction, modes, link_type, speed_ab, speed_ba, capacity_ab, capacity_ba,
@@ -825,43 +831,87 @@ class VisumGeoJSONImporter:
             source_id = int(row["NO"])
             ab_modes = self._mapped_modes(row.get("TSYSSET"), "link", source_id)
             ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "link", source_id)
-            direction = _direction(ab_modes, ba_modes)
             length_ab, speed_ab, capacity_ab, time_ab = self._assignment_values(row, "", "link", source_id)
             length_ba, speed_ba, capacity_ba, time_ba = self._assignment_values(row, "R_", "link", source_id)
-            if direction == 1:
-                speed_ba = capacity_ba = time_ba = None
-            elif direction == -1:
-                speed_ab = capacity_ab = time_ab = None
-            link_type = link_type_by_value[_link_type_source_value(row)]
-            conn.execute(
-                query,
-                (
-                    source_id,
-                    self._node_id(row["FROMNODENO"]),
-                    self._node_id(row["TONODENO"]),
-                    direction,
-                    "".join(sorted(ab_modes | ba_modes)),
-                    link_type,
-                    speed_ab,
-                    speed_ba,
-                    capacity_ab,
-                    capacity_ba,
-                    time_ab,
-                    time_ba,
-                    source_id,
-                    length_ab,
-                    length_ba,
-                    self._link_geometry(row).wkt,
-                ),
-            )
-            mapping[row["NO"]] = source_id
-            self.source_to_link_id[row["NO"]] = source_id
+            if ab_modes and ba_modes and ab_modes != ba_modes:
+                records = [
+                    (1, ab_modes, speed_ab, None, capacity_ab, None, time_ab, None, length_ab, None, ""),
+                    (-1, ba_modes, None, speed_ba, None, capacity_ba, None, time_ba, None, length_ba, "R_"),
+                ]
+                self.report.add(
+                    "info",
+                    "directional-mode-split",
+                    "Link has different mode sets by direction and was imported as directional one-way records",
+                    layer="link",
+                    field="TSYSSET",
+                    source_id=source_id,
+                )
+            else:
+                direction = _direction(ab_modes, ba_modes)
+                if direction == 1:
+                    speed_ba = capacity_ba = time_ba = None
+                elif direction == -1:
+                    speed_ab = capacity_ab = time_ab = None
+                records = [
+                    (
+                        direction,
+                        ab_modes | ba_modes,
+                        speed_ab,
+                        speed_ba,
+                        capacity_ab,
+                        capacity_ba,
+                        time_ab,
+                        time_ba,
+                        length_ab,
+                        length_ba,
+                        "",
+                    )
+                ]
+            for (
+                direction,
+                modes,
+                rec_speed_ab,
+                rec_speed_ba,
+                rec_capacity_ab,
+                rec_capacity_ba,
+                rec_time_ab,
+                rec_time_ba,
+                rec_length_ab,
+                rec_length_ba,
+                type_prefix,
+            ) in records:
+                link_id = next_link_id
+                next_link_id += 1
+                link_type = link_type_by_value[_link_type_source_value(row, type_prefix)]
+                conn.execute(
+                    query,
+                    (
+                        link_id,
+                        self._node_id(row["FROMNODENO"]),
+                        self._node_id(row["TONODENO"]),
+                        direction,
+                        "".join(sorted(modes)),
+                        link_type,
+                        rec_speed_ab,
+                        rec_speed_ba,
+                        rec_capacity_ab,
+                        rec_capacity_ba,
+                        rec_time_ab,
+                        rec_time_ba,
+                        source_id,
+                        rec_length_ab,
+                        rec_length_ba,
+                        self._link_geometry(row).wkt,
+                    ),
+                )
+                mapping.setdefault(row["NO"], link_id)
+                self.source_to_link_id.setdefault(row["NO"], link_id)
         self.report.source_references["links"] = mapping
         return mapping
 
     def _insert_connectors(self, conn) -> dict[object, int]:
         mapping = {}
-        max_link = max(self.source_to_link_id.values(), default=0)
+        next_link_id = self._next_link_id(conn)
         query = """
             INSERT INTO links(
                 link_id, a_node, b_node, direction, modes, link_type, speed_ab, speed_ba, capacity_ab, capacity_ba,
@@ -870,47 +920,89 @@ class VisumGeoJSONImporter:
             )
             VALUES(?, ?, ?, ?, ?, 'centroid_connector', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))
         """
-        idx = 0
         for row_index, row in self.layers["connector"].iterrows():
             if self._skip_record("connector", row_index):
                 continue
-            idx += 1
-            link_id = max_link + idx
             source_id = self._connector_source_key(row_index)
             source_no = self._connector_source_no(row_index)
             ab_modes = self._mapped_modes(row.get("TSYSSET"), "connector", source_id)
             ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "connector", source_id)
-            direction = _direction(ab_modes, ba_modes)
             length_ab, speed_ab, capacity_ab, time_ab = self._assignment_values(row, "", "connector", source_id)
             length_ba, speed_ba, capacity_ba, time_ba = self._assignment_values(row, "R_", "connector", source_id)
-            if direction == 1:
-                speed_ba = capacity_ba = time_ba = None
-            elif direction == -1:
-                speed_ab = capacity_ab = time_ab = None
-            conn.execute(
-                query,
-                (
-                    link_id,
-                    int(row["ZONENO"]),
-                    self._node_id(row["NODENO"]),
-                    direction,
-                    "".join(sorted(ab_modes | ba_modes)),
-                    speed_ab,
-                    speed_ba,
-                    capacity_ab,
-                    capacity_ba,
-                    time_ab,
-                    time_ba,
-                    source_no,
-                    source_id,
-                    length_ab,
-                    length_ba,
-                    self._connector_geometry(row).wkt,
-                ),
-            )
-            mapping[source_id] = link_id
+            if ab_modes and ba_modes and ab_modes != ba_modes:
+                records = [
+                    (1, ab_modes, speed_ab, None, capacity_ab, None, time_ab, None, length_ab, None),
+                    (-1, ba_modes, None, speed_ba, None, capacity_ba, None, time_ba, None, length_ba),
+                ]
+                self.report.add(
+                    "info",
+                    "directional-mode-split",
+                    "Connector has different mode sets by direction and was imported as directional one-way records",
+                    layer="connector",
+                    field="TSYSSET",
+                    source_id=source_id,
+                )
+            else:
+                direction = _direction(ab_modes, ba_modes)
+                if direction == 1:
+                    speed_ba = capacity_ba = time_ba = None
+                elif direction == -1:
+                    speed_ab = capacity_ab = time_ab = None
+                records = [
+                    (
+                        direction,
+                        ab_modes | ba_modes,
+                        speed_ab,
+                        speed_ba,
+                        capacity_ab,
+                        capacity_ba,
+                        time_ab,
+                        time_ba,
+                        length_ab,
+                        length_ba,
+                    )
+                ]
+            for (
+                direction,
+                modes,
+                rec_speed_ab,
+                rec_speed_ba,
+                rec_capacity_ab,
+                rec_capacity_ba,
+                rec_time_ab,
+                rec_time_ba,
+                rec_length_ab,
+                rec_length_ba,
+            ) in records:
+                link_id = next_link_id
+                next_link_id += 1
+                conn.execute(
+                    query,
+                    (
+                        link_id,
+                        int(row["ZONENO"]),
+                        self._node_id(row["NODENO"]),
+                        direction,
+                        "".join(sorted(modes)),
+                        rec_speed_ab,
+                        rec_speed_ba,
+                        rec_capacity_ab,
+                        rec_capacity_ba,
+                        rec_time_ab,
+                        rec_time_ba,
+                        source_no,
+                        source_id,
+                        rec_length_ab,
+                        rec_length_ba,
+                        self._connector_geometry(row).wkt,
+                    ),
+                )
+                mapping.setdefault(source_id, link_id)
         self.report.source_references["connectors"] = mapping
         return mapping
+
+    def _next_link_id(self, conn) -> int:
+        return int(conn.execute("SELECT COALESCE(MAX(link_id), 0) + 1 FROM links").fetchone()[0])
 
     def _prepare_node_geometries(self) -> None:
         if "node" not in self.layers:
@@ -1103,6 +1195,43 @@ class VisumGeoJSONImporter:
         speed = parse_visum_speed(row.get(f"{prefix}V0PRT"))
         capacity = parse_visum_capacity(row.get(f"{prefix}CAPPRT"))
         time = parse_visum_time(row.get(f"{prefix}T0PRT"))
+        if layer == "connector":
+            if length is None or length <= 0:
+                geometry_length = _geodesic_length(row.geometry)
+                if geometry_length is not None and geometry_length > 0:
+                    length = geometry_length
+                    self.report.add(
+                        "warning",
+                        "connector-length-defaulted",
+                        "Connector length defaulted from geometry length",
+                        layer=layer,
+                        field=f"{prefix}LENGTH",
+                        source_id=source_id,
+                    )
+            if time is not None and time <= 0:
+                time = None
+            if speed is not None and speed <= 0:
+                speed = None
+            if time is None and speed is None and length is not None and length > 0:
+                speed = CONNECTOR_FALLBACK_SPEED_KMH
+                self.report.add(
+                    "warning",
+                    "connector-speed-defaulted",
+                    f"Connector speed defaulted to {CONNECTOR_FALLBACK_SPEED_KMH:g} km/h",
+                    layer=layer,
+                    field=f"{prefix}V0PRT",
+                    source_id=source_id,
+                )
+            if capacity is None or capacity <= 0:
+                capacity = CONNECTOR_FALLBACK_CAPACITY
+                self.report.add(
+                    "warning",
+                    "connector-capacity-defaulted",
+                    f"Connector capacity defaulted to {CONNECTOR_FALLBACK_CAPACITY:g}",
+                    layer=layer,
+                    field=f"{prefix}CAPPRT",
+                    source_id=source_id,
+                )
         if time is None and length is not None and speed is not None and speed > 0:
             time = (length / 1000.0) / speed * 60.0
         for field_name, parsed in ((f"{prefix}V0PRT", speed), (f"{prefix}CAPPRT", capacity), (f"{prefix}T0PRT", time)):
@@ -1245,8 +1374,21 @@ def _line_with_endpoints(geometry, start_point: Point, end_point: Point) -> Line
     return LineString(coords)
 
 
-def _link_type_source_value(row) -> object:
-    for field_name in ("LC", "TYPENO"):
+def _geodesic_length(geometry) -> float | None:
+    if geometry is None or geometry.is_empty or geometry.geom_type != "LineString":
+        return None
+    coords = list(geometry.coords)
+    if len(coords) < 2:
+        return None
+    length = 0.0
+    for start, end in zip(coords[:-1], coords[1:], strict=True):
+        _, _, distance = GEOD.inv(start[0], start[1], end[0], end[1])
+        length += distance
+    return length
+
+
+def _link_type_source_value(row, prefix: str = "") -> object:
+    for field_name in (f"{prefix}LC", f"{prefix}TYPENO"):
         if field_name in row and not pd.isna(row[field_name]) and row[field_name] != "":
             return row[field_name]
     return "default"

--- a/aequilibrae/project/network/visum_geojson_importer.py
+++ b/aequilibrae/project/network/visum_geojson_importer.py
@@ -1,0 +1,877 @@
+import re
+import string
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import MultiPolygon
+
+from aequilibrae.project.field_editor import FieldEditor
+from aequilibrae.utils.db_utils import commit_and_close
+
+
+REQUIRED_LAYERS = {"node", "link", "zone_centroid", "connector"}
+OPTIONAL_LAYERS = {"zone_polygon", "countlocation"}
+DEFERRED_LAYERS = {
+    "stop",
+    "stoppoint",
+    "stop_point",
+    "lineroute",
+    "line_route",
+    "ptline",
+    "pt_line",
+    "od_matrix",
+    "matrix",
+}
+CONVENTIONAL_NAMES = {
+    "node": ("node.geojson", "nodes.geojson"),
+    "link": ("link.geojson", "links.geojson"),
+    "zone_centroid": ("zone_centroid.geojson", "zonecentroid.geojson", "zone-centroid.geojson"),
+    "zone_polygon": ("zone_polygon.geojson", "zone.geojson", "zones.geojson"),
+    "connector": ("connector.geojson", "connectors.geojson"),
+    "countlocation": ("countlocation.geojson", "count_location.geojson", "count-locations.geojson"),
+}
+DEFAULT_MODE_MAPPING = {"CAR": "c", "HGV": "h"}
+COUNT_CANDIDATE_FIELDS = {"CAR_ORIG", "HVG_ORIG", "MOTOR_ORIG", "DTVW"}
+DEFERRED_COUNT_FIELDS = {
+    "CARS_LEFT",
+    "CARS_RIGHT",
+    "CARS_STRAIGHT",
+    "CARS_PROJ",
+    "HVG_PROJ",
+    "MOTOR_PROJ",
+}
+
+
+@dataclass
+class VisumGeoJSONDiagnostic:
+    """One VISUM GeoJSON import diagnostic."""
+
+    severity: str
+    code: str
+    message: str
+    layer: str | None = None
+    field: str | None = None
+    source_id: object | None = None
+
+
+@dataclass
+class VisumGeoJSONReport:
+    """Diagnostics and provenance returned by a VISUM GeoJSON import."""
+
+    diagnostics: list[VisumGeoJSONDiagnostic] = field(default_factory=list)
+    discovered_layers: dict[str, str] = field(default_factory=dict)
+    deferred_layers: list[str] = field(default_factory=list)
+    field_inventory: dict[str, dict[str, dict[str, object]]] = field(default_factory=dict)
+    imported_counts: dict[str, int] = field(default_factory=dict)
+    source_references: dict[str, object] = field(default_factory=dict)
+    mode_mapping: dict[str, str] = field(default_factory=dict)
+    link_type_mapping: dict[object, str] = field(default_factory=dict)
+    crs: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def errors(self) -> list[VisumGeoJSONDiagnostic]:
+        return [diag for diag in self.diagnostics if diag.severity == "error"]
+
+    def add(
+        self,
+        severity: str,
+        code: str,
+        message: str,
+        layer: str | None = None,
+        field: str | None = None,
+        source_id: object | None = None,
+    ) -> None:
+        self.diagnostics.append(VisumGeoJSONDiagnostic(severity, code, message, layer, field, source_id))
+
+    def raise_for_errors(self) -> None:
+        if self.errors:
+            messages = "; ".join(f"{diag.code}: {diag.message}" for diag in self.errors[:5])
+            raise ValueError(f"VISUM GeoJSON import failed validation: {messages}")
+
+
+def discover_visum_geojson_layers(path_or_layers: str | Path | Mapping[str, str | Path]) -> VisumGeoJSONReport:
+    """Discover conventional VISUM GeoJSON layers or normalize an explicit layer-path mapping."""
+
+    report = VisumGeoJSONReport()
+    if isinstance(path_or_layers, Mapping):
+        for layer, path in path_or_layers.items():
+            key = _normalize_layer_name(layer)
+            path = Path(path)
+            if key in DEFERRED_LAYERS:
+                report.deferred_layers.append(key)
+            elif key in REQUIRED_LAYERS | OPTIONAL_LAYERS:
+                report.discovered_layers[key] = str(path)
+            else:
+                report.add("warning", "unknown-layer", f"Layer '{layer}' is not recognized", layer=layer)
+            if not path.exists():
+                report.add("error", "missing-file", f"Layer file does not exist: {path}", layer=key)
+    else:
+        folder = Path(path_or_layers)
+        if not folder.exists():
+            report.add("error", "missing-input", f"VISUM GeoJSON path does not exist: {folder}")
+            return report
+        if not folder.is_dir():
+            report.add("error", "invalid-input", "VISUM GeoJSON input must be a folder or explicit layer mapping")
+            return report
+
+        files = {file.name.lower(): file for file in folder.iterdir() if file.is_file()}
+        for layer, names in CONVENTIONAL_NAMES.items():
+            for name in names:
+                if name in files:
+                    report.discovered_layers[layer] = str(files[name])
+                    break
+
+        for file in folder.iterdir():
+            stem = _normalize_layer_name(file.stem)
+            if stem in DEFERRED_LAYERS or (file.suffix.lower() in {".omx", ".aem", ".mtx"} and "matrix" in stem):
+                report.deferred_layers.append(stem)
+
+    for layer in sorted(REQUIRED_LAYERS - set(report.discovered_layers)):
+        report.add("error", "missing-layer", f"Required VISUM layer '{layer}' was not provided", layer=layer)
+
+    for layer in sorted(set(report.deferred_layers)):
+        report.add("warning", "deferred-layer", f"VISUM layer '{layer}' is recognized but deferred", layer=layer)
+
+    report.deferred_layers = sorted(set(report.deferred_layers))
+    return report
+
+
+def read_visum_geojson_layers(
+    layer_paths: Mapping[str, str | Path],
+    report: VisumGeoJSONReport | None = None,
+    *,
+    source_crs: str | int | None = None,
+    accept_default_crs: bool = False,
+    default_crs: str = "EPSG:4326",
+    target_crs: str = "EPSG:4326",
+) -> tuple[dict[str, gpd.GeoDataFrame], VisumGeoJSONReport]:
+    """Read VISUM GeoJSON layers with explicit CRS handling."""
+
+    report = report or VisumGeoJSONReport()
+    layers = {}
+    for layer, path in layer_paths.items():
+        gdf = gpd.read_file(path)
+        if gdf.crs is None:
+            if source_crs is not None:
+                gdf = gdf.set_crs(source_crs)
+                report.add("info", "source-crs-supplied", f"Using supplied CRS for layer '{layer}'", layer=layer)
+            elif accept_default_crs:
+                gdf = gdf.set_crs(default_crs)
+                report.add(
+                    "warning",
+                    "default-crs-assumed",
+                    f"Layer '{layer}' has no CRS metadata; assuming {default_crs}",
+                    layer=layer,
+                )
+            else:
+                report.add(
+                    "error",
+                    "missing-crs",
+                    f"Layer '{layer}' has no CRS metadata; supply source_crs or accept_default_crs=True",
+                    layer=layer,
+                )
+                layers[layer] = gdf
+                continue
+        if str(gdf.crs).upper() != target_crs.upper():
+            report.crs[layer] = f"{gdf.crs} -> {target_crs}"
+            gdf = gdf.to_crs(target_crs)
+        else:
+            report.crs[layer] = str(gdf.crs)
+        layers[layer] = gdf
+    return layers, report
+
+
+def inventory_visum_layers(layers: Mapping[str, gpd.GeoDataFrame]) -> dict[str, dict[str, dict[str, object]]]:
+    """Build a compact field inventory for diagnostics and reviewer workflows."""
+
+    inventory = {}
+    for layer, gdf in layers.items():
+        fields = {}
+        for column in gdf.columns:
+            if column == gdf.geometry.name:
+                role = "geometry"
+            elif column.startswith("R_"):
+                role = "directional"
+            elif column in {"NO", "FROMNODENO", "TONODENO", "ZONENO", "NODENO"}:
+                role = "required"
+            elif column in COUNT_CANDIDATE_FIELDS:
+                role = "count-candidate"
+            elif column in DEFERRED_COUNT_FIELDS:
+                role = "deferred"
+            else:
+                role = "optional"
+
+            series = gdf[column]
+            non_null = series.dropna()
+            samples = [_jsonish(value) for value in non_null.head(3).tolist()]
+            unique_values = []
+            if column != gdf.geometry.name and non_null.nunique(dropna=True) <= 10:
+                unique_values = [_jsonish(value) for value in non_null.unique().tolist()]
+            fields[column] = {
+                "dtype": str(series.dtype),
+                "null_count": int(series.isna().sum()),
+                "unique_values": unique_values,
+                "sample_values": samples,
+                "unit_pattern": _unit_pattern(non_null),
+                "role": role,
+            }
+        inventory[layer] = fields
+    return inventory
+
+
+def parse_visum_length(value) -> float | None:
+    """Parse VISUM length values into meters."""
+
+    return _parse_unit(value, {"m": 1.0, "meter": 1.0, "meters": 1.0, "km": 1000.0}, "m")
+
+
+def parse_visum_speed(value) -> float | None:
+    """Parse VISUM speed values into km/h."""
+
+    return _parse_unit(
+        value,
+        {"km/h": 1.0, "kph": 1.0, "kmh": 1.0, "m/s": 3.6, "mph": 1.609344},
+        "km/h",
+    )
+
+
+def parse_visum_time(value) -> float | None:
+    """Parse VISUM time values into minutes."""
+
+    return _parse_unit(
+        value,
+        {"min": 1.0, "mins": 1.0, "minute": 1.0, "s": 1.0 / 60.0, "sec": 1.0 / 60.0, "h": 60.0},
+        "min",
+    )
+
+
+def parse_visum_capacity(value) -> float | None:
+    """Parse VISUM capacity-like values into vehicles per hour."""
+
+    return _parse_unit(
+        value,
+        {"veh/h": 1.0, "veh/hr": 1.0, "vehph": 1.0, "pcu/h": 1.0, "pc/h": 1.0, "/h": 1.0},
+        "veh/h",
+    )
+
+
+class VisumGeoJSONImporter:
+    def __init__(
+        self,
+        net,
+        path_or_layers: str | Path | Mapping[str, str | Path],
+        *,
+        mode_mapping: Mapping[str, str] | None = None,
+        link_type_mapping: Mapping[object, str] | None = None,
+        source_crs: str | int | None = None,
+        accept_default_crs: bool = False,
+        allow_non_empty: bool = False,
+        geometry_tolerance: float = 1e-6,
+    ) -> None:
+        self.net = net
+        self.path_or_layers = path_or_layers
+        self.mode_mapping = {str(k).upper(): v for k, v in (mode_mapping or DEFAULT_MODE_MAPPING).items()}
+        self.link_type_mapping = dict(link_type_mapping or {})
+        self.source_crs = source_crs
+        self.accept_default_crs = accept_default_crs
+        self.allow_non_empty = allow_non_empty
+        self.geometry_tolerance = geometry_tolerance
+        self.report = VisumGeoJSONReport(mode_mapping=dict(self.mode_mapping))
+        self.layers: dict[str, gpd.GeoDataFrame] = {}
+        self.source_to_link_id: dict[object, int] = {}
+
+    def doWork(self) -> VisumGeoJSONReport:
+        self._discover_and_read()
+        self._validate_required_columns()
+        self._validate_mode_values()
+        self._validate_assignment_values()
+        self._validate_assignment_readiness()
+        self._validate_topology()
+        self.report.raise_for_errors()
+
+        if self.net.count_links() > 0 and not self.allow_non_empty:
+            raise FileExistsError("You can only import a VISUM GeoJSON network into an empty model file")
+
+        self._prepare_database_fields()
+        self._ensure_modes()
+        link_type_by_value = self._ensure_link_types()
+        self.report.link_type_mapping = {str(k): v for k, v in link_type_by_value.items()}
+
+        with commit_and_close(self.net.project.path_to_file, spatial=True) as conn:
+            conn.manual_transaction()
+            with conn:
+                node_ids = self._insert_nodes(conn)
+                zone_ids = self._insert_zones_and_centroids(conn)
+                link_ids = self._insert_links(conn, link_type_by_value)
+                connector_ids = self._insert_connectors(conn)
+
+        self.report.imported_counts.update(
+            {
+                "nodes": len(node_ids),
+                "zones": len(zone_ids),
+                "links": len(link_ids),
+                "connectors": len(connector_ids),
+            }
+        )
+        self._process_count_locations()
+        self.report.add("info", "import-complete", "VISUM GeoJSON import completed")
+        return self.report
+
+    def _discover_and_read(self) -> None:
+        discovery = discover_visum_geojson_layers(self.path_or_layers)
+        self.report.discovered_layers.update(discovery.discovered_layers)
+        self.report.deferred_layers.extend(discovery.deferred_layers)
+        self.report.diagnostics.extend(discovery.diagnostics)
+        self.report.raise_for_errors()
+
+        self.layers, self.report = read_visum_geojson_layers(
+            self.report.discovered_layers,
+            self.report,
+            source_crs=self.source_crs,
+            accept_default_crs=self.accept_default_crs,
+        )
+        self.report.field_inventory = inventory_visum_layers(self.layers)
+
+    def _validate_required_columns(self) -> None:
+        required = {
+            "node": {"NO"},
+            "link": {"NO", "FROMNODENO", "TONODENO", "TSYSSET"},
+            "zone_centroid": {"NO"},
+            "connector": {"NO", "ZONENO", "NODENO", "TSYSSET"},
+        }
+        for layer, fields in required.items():
+            if layer not in self.layers:
+                continue
+            missing = fields - set(self.layers[layer].columns)
+            for field_name in sorted(missing):
+                self.report.add(
+                    "error",
+                    "missing-field",
+                    f"Layer '{layer}' is missing required field '{field_name}'",
+                    layer=layer,
+                    field=field_name,
+                )
+
+    def _validate_topology(self) -> None:
+        if not REQUIRED_LAYERS.issubset(self.layers):
+            return
+
+        nodes = self.layers["node"].set_index("NO")
+        zones = self.layers["zone_centroid"].set_index("NO")
+        for _, row in self.layers["link"].iterrows():
+            source_id = row["NO"]
+            if row["FROMNODENO"] not in nodes.index or row["TONODENO"] not in nodes.index:
+                self.report.add(
+                    "error",
+                    "missing-node-reference",
+                    "Link references missing node",
+                    "link",
+                    source_id=source_id,
+                )
+                continue
+            self._validate_line_endpoint(row.geometry, nodes.loc[row["FROMNODENO"]].geometry, True, "link", source_id)
+            self._validate_line_endpoint(row.geometry, nodes.loc[row["TONODENO"]].geometry, False, "link", source_id)
+
+        for _, row in self.layers["connector"].iterrows():
+            source_id = row["NO"]
+            if row["ZONENO"] not in zones.index:
+                self.report.add(
+                    "error",
+                    "missing-zone-reference",
+                    "Connector references missing zone centroid",
+                    "connector",
+                    source_id=source_id,
+                )
+                continue
+            if row["NODENO"] not in nodes.index:
+                self.report.add(
+                    "error",
+                    "missing-node-reference",
+                    "Connector references missing network node",
+                    "connector",
+                    source_id=source_id,
+                )
+                continue
+            self._validate_line_endpoint(row.geometry, zones.loc[row["ZONENO"]].geometry, True, "connector", source_id)
+            self._validate_line_endpoint(row.geometry, nodes.loc[row["NODENO"]].geometry, False, "connector", source_id)
+
+    def _validate_mode_values(self) -> None:
+        for layer in ("link", "connector"):
+            if layer not in self.layers:
+                continue
+            for _, row in self.layers[layer].iterrows():
+                source_id = row.get("NO")
+                ab_tokens = _split_tsysset(row.get("TSYSSET"))
+                ba_tokens = _split_tsysset(row.get("R_TSYSSET"))
+                if not ab_tokens and not ba_tokens:
+                    self.report.add(
+                        "error",
+                        "no-private-modes",
+                        "Record has no private transport systems in either direction",
+                        layer=layer,
+                        field="TSYSSET",
+                        source_id=source_id,
+                    )
+                for token in ab_tokens + ba_tokens:
+                    if token.upper() not in self.mode_mapping:
+                        self.report.add(
+                            "error",
+                            "unmapped-transport-system",
+                            f"Transport system '{token}' is not mapped",
+                            layer=layer,
+                            field="TSYSSET",
+                            source_id=source_id,
+                        )
+
+    def _validate_assignment_values(self) -> None:
+        for layer in ("link", "connector"):
+            if layer not in self.layers:
+                continue
+            for _, row in self.layers[layer].iterrows():
+                source_id = row.get("NO")
+                for prefix in ("", "R_"):
+                    for field_name, parser in (
+                        (f"{prefix}LENGTH", parse_visum_length),
+                        (f"{prefix}V0PRT", parse_visum_speed),
+                        (f"{prefix}CAPPRT", parse_visum_capacity),
+                        (f"{prefix}T0PRT", parse_visum_time),
+                    ):
+                        if field_name not in row or pd.isna(row[field_name]) or row[field_name] == "":
+                            continue
+                        try:
+                            parser(row[field_name])
+                        except ValueError as exc:
+                            self.report.add(
+                                "error",
+                                "invalid-unit",
+                                str(exc),
+                                layer=layer,
+                                field=field_name,
+                                source_id=source_id,
+                            )
+
+    def _validate_assignment_readiness(self) -> None:
+        for layer in ("link", "connector"):
+            if layer not in self.layers:
+                continue
+            for _, row in self.layers[layer].iterrows():
+                source_id = row.get("NO")
+                for prefix, direction_value in (("", row.get("TSYSSET")), ("R_", row.get("R_TSYSSET"))):
+                    if not _split_tsysset(direction_value):
+                        continue
+                    try:
+                        length, speed, capacity, time = self._assignment_values(row, prefix, layer, source_id)
+                    except ValueError:
+                        continue
+                    if time is None and length is not None and speed is not None and speed > 0:
+                        time = (length / 1000.0) / speed * 60.0
+                    if capacity is None:
+                        self.report.add(
+                            "warning",
+                            "non-assignment-ready",
+                            "Capacity is missing for an available private-traffic direction",
+                            layer=layer,
+                            field=f"{prefix}CAPPRT",
+                            source_id=source_id,
+                        )
+                    if time is None:
+                        self.report.add(
+                            "warning",
+                            "non-assignment-ready",
+                            "Free-flow time cannot be parsed or derived for an available private-traffic direction",
+                            layer=layer,
+                            field=f"{prefix}T0PRT",
+                            source_id=source_id,
+                        )
+
+    def _validate_line_endpoint(self, geometry, point, first: bool, layer: str, source_id) -> None:
+        if geometry is None or geometry.is_empty or geometry.geom_type != "LineString":
+            self.report.add("error", "invalid-geometry", "Expected LineString geometry", layer, source_id=source_id)
+            return
+        endpoint = geometry.coords[0 if first else -1]
+        if point.distance(type(point)(endpoint)) > self.geometry_tolerance:
+            self.report.add(
+                "error",
+                "endpoint-mismatch",
+                "Geometry endpoint does not match referenced topology point",
+                layer,
+                source_id=source_id,
+            )
+
+    def _prepare_database_fields(self) -> None:
+        self._add_fields(
+            "nodes",
+            {
+                "visum_node_no": ("VISUM source node identifier", "INTEGER"),
+                "visum_zone_no": ("VISUM source zone identifier for centroid nodes", "INTEGER"),
+            },
+        )
+        self._add_fields(
+            "links",
+            {
+                "visum_link_no": ("VISUM source link identifier", "INTEGER"),
+                "visum_connector_no": ("VISUM source connector identifier", "INTEGER"),
+                "visum_length_ab": ("VISUM source AB length in meters", "NUMERIC"),
+                "visum_length_ba": ("VISUM source BA length in meters", "NUMERIC"),
+            },
+        )
+        self._add_fields("zones", {"visum_zone_no": ("VISUM source zone identifier", "INTEGER")})
+
+    def _add_fields(self, table_name: str, fields: Mapping[str, tuple[str, str]]) -> None:
+        editor = FieldEditor(self.net.project, table_name)
+        existing = set(editor.all_fields())
+        for field_name, (description, data_type) in fields.items():
+            if field_name not in existing:
+                editor.add(field_name, description=description, data_type=data_type)
+
+    def _ensure_modes(self) -> None:
+        for source_mode, mode_id in sorted(self.mode_mapping.items()):
+            if len(mode_id) != 1:
+                self.report.add(
+                    "error",
+                    "invalid-mode-id",
+                    f"Mode mapping for {source_mode} must be a single-character AequilibraE mode ID",
+                    field=source_mode,
+                )
+                continue
+            if mode_id not in self.net.modes.all_modes():
+                mode = self.net.modes.new(mode_id)
+                mode.mode_name = "hgv" if source_mode == "HGV" else source_mode.lower()
+                mode.description = f"VISUM transport system {source_mode}"
+                self.net.modes.add(mode)
+                mode.save()
+        self.report.raise_for_errors()
+
+    def _ensure_link_types(self) -> dict[object, str]:
+        source_values = []
+        for layer in ("link", "connector"):
+            if layer not in self.layers:
+                continue
+            if layer == "connector":
+                continue
+            for _, row in self.layers[layer].iterrows():
+                source_values.append(_link_type_source_value(row))
+        mapping = dict(self.link_type_mapping)
+        used_ids = set(self.net.link_types.all_types())
+        existing_by_name = {
+            link_type.link_type.lower(): link_type.link_type for link_type in self.net.link_types.all_types().values()
+        }
+
+        for source in sorted(set(source_values), key=str):
+            if source in mapping:
+                name = _clean_name(mapping[source])
+            else:
+                name = _clean_name(f"visum_{source}")
+                mapping[source] = name
+            if name.lower() in existing_by_name:
+                mapping[source] = existing_by_name[name.lower()]
+                continue
+
+            link_type_id = _first_unused_link_type_id(str(source), used_ids)
+            if link_type_id is None:
+                self.report.add(
+                    "error",
+                    "link-type-id-exhausted",
+                    "No available link-type IDs remain",
+                    field=str(source),
+                )
+                continue
+            link_type = self.net.link_types.new(link_type_id)
+            link_type.link_type = name
+            link_type.description = f"VISUM link type/class {source}"
+            link_type.save()
+            used_ids.add(link_type_id)
+            mapping[source] = name
+
+        self.report.raise_for_errors()
+        return mapping
+
+    def _insert_nodes(self, conn) -> dict[object, int]:
+        mapping = {}
+        query = """
+            INSERT INTO nodes(node_id, is_centroid, visum_node_no, geometry)
+            VALUES(?, 0, ?, MakePoint(?, ?, 4326))
+        """
+        for _, row in self.layers["node"].iterrows():
+            node_id = int(row["NO"])
+            conn.execute(query, (node_id, node_id, row.geometry.x, row.geometry.y))
+            mapping[row["NO"]] = node_id
+        self.report.source_references["nodes"] = mapping
+        return mapping
+
+    def _insert_zones_and_centroids(self, conn) -> dict[object, int]:
+        zones = {}
+        polygons = {}
+        if "zone_polygon" in self.layers:
+            polygons = {row["NO"]: row for _, row in self.layers["zone_polygon"].iterrows()}
+        for _, row in self.layers["zone_centroid"].iterrows():
+            zone_id = int(row["NO"])
+            name = str(row["NAME"]) if "NAME" in row and not pd.isna(row["NAME"]) else ""
+            polygon_row = polygons.get(row["NO"])
+            geometry = polygon_row.geometry if polygon_row is not None else MultiPolygon([row.geometry.buffer(1e-6)])
+            if geometry.geom_type == "Polygon":
+                geometry = MultiPolygon([geometry])
+            conn.execute(
+                """
+                INSERT INTO zones(zone_id, name, visum_zone_no, geometry)
+                VALUES(?, ?, ?, GeomFromText(?, 4326))
+                """,
+                (zone_id, name, zone_id, geometry.wkt),
+            )
+            conn.execute(
+                """
+                INSERT INTO nodes(node_id, is_centroid, visum_zone_no, geometry)
+                VALUES(?, 1, ?, MakePoint(?, ?, 4326))
+                """,
+                (zone_id, zone_id, row.geometry.x, row.geometry.y),
+            )
+            zones[row["NO"]] = zone_id
+        self.report.source_references["zones"] = zones
+        return zones
+
+    def _insert_links(self, conn, link_type_by_value: Mapping[object, str]) -> dict[object, int]:
+        mapping = {}
+        query = """
+            INSERT INTO links(
+                link_id, a_node, b_node, direction, modes, link_type, speed_ab, speed_ba, capacity_ab, capacity_ba,
+                travel_time_ab, travel_time_ba, visum_link_no, visum_length_ab, visum_length_ba, geometry
+            )
+            VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))
+        """
+        for _, row in self.layers["link"].iterrows():
+            source_id = int(row["NO"])
+            ab_modes = self._mapped_modes(row.get("TSYSSET"), "link", source_id)
+            ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "link", source_id)
+            direction = _direction(ab_modes, ba_modes)
+            length_ab, speed_ab, capacity_ab, time_ab = self._assignment_values(row, "", "link", source_id)
+            length_ba, speed_ba, capacity_ba, time_ba = self._assignment_values(row, "R_", "link", source_id)
+            if direction == 1:
+                speed_ba = capacity_ba = time_ba = None
+            elif direction == -1:
+                speed_ab = capacity_ab = time_ab = None
+            link_type = link_type_by_value[_link_type_source_value(row)]
+            conn.execute(
+                query,
+                (
+                    source_id,
+                    int(row["FROMNODENO"]),
+                    int(row["TONODENO"]),
+                    direction,
+                    "".join(sorted(ab_modes | ba_modes)),
+                    link_type,
+                    speed_ab,
+                    speed_ba,
+                    capacity_ab,
+                    capacity_ba,
+                    time_ab,
+                    time_ba,
+                    source_id,
+                    length_ab,
+                    length_ba,
+                    row.geometry.wkt,
+                ),
+            )
+            mapping[row["NO"]] = source_id
+            self.source_to_link_id[row["NO"]] = source_id
+        self.report.source_references["links"] = mapping
+        return mapping
+
+    def _insert_connectors(self, conn) -> dict[object, int]:
+        mapping = {}
+        max_link = max(self.source_to_link_id.values(), default=0)
+        query = """
+            INSERT INTO links(
+                link_id, a_node, b_node, direction, modes, link_type, speed_ab, speed_ba, capacity_ab, capacity_ba,
+                travel_time_ab, travel_time_ba, visum_connector_no, visum_length_ab, visum_length_ba, geometry
+            )
+            VALUES(?, ?, ?, ?, ?, 'centroid_connector', ?, ?, ?, ?, ?, ?, ?, ?, ?, GeomFromText(?, 4326))
+        """
+        for idx, (_, row) in enumerate(self.layers["connector"].iterrows(), start=1):
+            link_id = max_link + idx
+            source_id = int(row["NO"])
+            ab_modes = self._mapped_modes(row.get("TSYSSET"), "connector", source_id)
+            ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "connector", source_id)
+            direction = _direction(ab_modes, ba_modes)
+            length_ab, speed_ab, capacity_ab, time_ab = self._assignment_values(row, "", "connector", source_id)
+            length_ba, speed_ba, capacity_ba, time_ba = self._assignment_values(row, "R_", "connector", source_id)
+            if direction == 1:
+                speed_ba = capacity_ba = time_ba = None
+            elif direction == -1:
+                speed_ab = capacity_ab = time_ab = None
+            conn.execute(
+                query,
+                (
+                    link_id,
+                    int(row["ZONENO"]),
+                    int(row["NODENO"]),
+                    direction,
+                    "".join(sorted(ab_modes | ba_modes)),
+                    speed_ab,
+                    speed_ba,
+                    capacity_ab,
+                    capacity_ba,
+                    time_ab,
+                    time_ba,
+                    source_id,
+                    length_ab,
+                    length_ba,
+                    row.geometry.wkt,
+                ),
+            )
+            mapping[row["NO"]] = link_id
+        self.report.source_references["connectors"] = mapping
+        return mapping
+
+    def _mapped_modes(self, value, layer: str, source_id) -> set[str]:
+        modes = set()
+        for token in _split_tsysset(value):
+            mapped = self.mode_mapping.get(token.upper())
+            if mapped is not None:
+                modes.add(mapped)
+        return modes
+
+    def _assignment_values(
+        self, row, prefix: str, layer: str, source_id
+    ) -> tuple[float | None, float | None, float | None, float | None]:
+        length = parse_visum_length(row.get(f"{prefix}LENGTH"))
+        speed = parse_visum_speed(row.get(f"{prefix}V0PRT"))
+        capacity = parse_visum_capacity(row.get(f"{prefix}CAPPRT"))
+        time = parse_visum_time(row.get(f"{prefix}T0PRT"))
+        if time is None and length is not None and speed is not None and speed > 0:
+            time = (length / 1000.0) / speed * 60.0
+        for field_name, parsed in ((f"{prefix}V0PRT", speed), (f"{prefix}CAPPRT", capacity), (f"{prefix}T0PRT", time)):
+            if parsed is not None and parsed <= 0:
+                self.report.add(
+                    "warning",
+                    "non-assignment-ready",
+                    f"Field '{field_name}' is not positive for assignment",
+                    layer=layer,
+                    field=field_name,
+                    source_id=source_id,
+                )
+        return length, speed, capacity, time
+
+    def _process_count_locations(self) -> None:
+        associations = []
+        if "countlocation" not in self.layers:
+            self.report.source_references["count_locations"] = associations
+            return
+        for _, row in self.layers["countlocation"].iterrows():
+            source_link = row.get("LINKNO")
+            if source_link in self.source_to_link_id:
+                count_fields = {
+                    field_name: _jsonish(row[field_name])
+                    for field_name in COUNT_CANDIDATE_FIELDS
+                    if field_name in row and not pd.isna(row[field_name])
+                }
+                associations.append(
+                    {
+                        "source_id": _jsonish(row.get("NO")),
+                        "link_id": self.source_to_link_id[source_link],
+                        "counts": count_fields,
+                    }
+                )
+            else:
+                self.report.add(
+                    "warning",
+                    "unresolved-count-link",
+                    "Count location could not be associated with an imported link",
+                    layer="countlocation",
+                    field="LINKNO",
+                    source_id=_jsonish(row.get("NO")),
+                )
+            deferred = sorted(
+                field_name for field_name in DEFERRED_COUNT_FIELDS if field_name in row and not pd.isna(row[field_name])
+            )
+            if deferred:
+                self.report.add(
+                    "warning",
+                    "deferred-count-fields",
+                    f"Count fields deferred for future traffic-data workflows: {', '.join(deferred)}",
+                    layer="countlocation",
+                    source_id=_jsonish(row.get("NO")),
+                )
+        self.report.source_references["count_locations"] = associations
+
+
+def _parse_unit(value, multipliers: Mapping[str, float], default_unit: str) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, float) and np.isnan(value):
+        return None
+    if isinstance(value, int | float):
+        return float(value) * multipliers[default_unit]
+    text = str(value).strip().lower().replace(" ", "")
+    if text in {"", "nan", "none", "null"}:
+        return None
+    match = re.fullmatch(r"([-+]?\d+(?:\.\d+)?)([a-z/]+)?", text)
+    if match is None:
+        raise ValueError(f"Could not parse VISUM unit value '{value}'")
+    number = float(match.group(1))
+    unit = match.group(2) or default_unit
+    if unit not in multipliers:
+        raise ValueError(f"Unsupported VISUM unit '{unit}' in value '{value}'")
+    return number * multipliers[unit]
+
+
+def _split_tsysset(value) -> list[str]:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return []
+    return [token for token in re.split(r"[,;|\s]+", str(value).strip()) if token]
+
+
+def _direction(ab_modes: set[str], ba_modes: set[str]) -> int:
+    if ab_modes and ba_modes:
+        return 0
+    if ab_modes:
+        return 1
+    if ba_modes:
+        return -1
+    return 1
+
+
+def _link_type_source_value(row) -> object:
+    for field_name in ("LC", "TYPENO"):
+        if field_name in row and not pd.isna(row[field_name]) and row[field_name] != "":
+            return row[field_name]
+    return "default"
+
+
+def _first_unused_link_type_id(source: str, used: set[str]) -> str | None:
+    candidates = _clean_name(source) + string.ascii_lowercase + string.ascii_uppercase
+    for candidate in candidates:
+        if candidate in string.ascii_letters and candidate not in used:
+            return candidate
+    return None
+
+
+def _clean_name(value) -> str:
+    text = re.sub(r"[^a-zA-Z_]+", "_", str(value).strip().lower()).strip("_")
+    if not text or text[0] not in string.ascii_letters:
+        text = f"visum_{text}" if text else "visum_default"
+    return text
+
+
+def _normalize_layer_name(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def _unit_pattern(series: pd.Series) -> str | None:
+    for value in series.head(10):
+        if isinstance(value, str):
+            match = re.fullmatch(r"\s*[-+]?\d+(?:\.\d+)?\s*([a-zA-Z/]+)\s*", value)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _jsonish(value):
+    if isinstance(value, np.generic):
+        return value.item()
+    if pd.isna(value):
+        return None
+    return value

--- a/aequilibrae/project/network/visum_sqlite_importer.py
+++ b/aequilibrae/project/network/visum_sqlite_importer.py
@@ -1,0 +1,759 @@
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+import geopandas as gpd
+import pandas as pd
+from pyproj import CRS, Transformer
+from shapely.geometry import LineString, MultiPolygon, Point, Polygon
+
+from aequilibrae.project.network.visum_geojson_importer import (
+    CONNECTOR_FALLBACK_CAPACITY,
+    DEFAULT_MODE_MAPPING,
+    VisumGeoJSONImporter,
+    VisumGeoJSONReport,
+    _direction,
+    _jsonish,
+    _split_tsysset,
+)
+
+
+REQUIRED_SQLITE_TABLES = {"NETWORK", "NODE", "LINK", "CONNECTOR", "ZONE", "TSYS", "LINKTYPE"}
+OPTIONAL_SQLITE_TABLES = {
+    "MODE",
+    "COUNTLOCATION",
+    "LINKPOLY",
+    "SURFACEITEM",
+    "FACEITEM",
+    "EDGE",
+    "EDGEITEM",
+    "POINT",
+}
+DEFERRED_SQLITE_TABLES = {
+    "STOP",
+    "STOPPOINT",
+    "STOPAREA",
+    "LINE",
+    "LINEROUTE",
+    "LINEROUTEITEM",
+    "TIMEPROFILE",
+    "TIMEPROFILEITEM",
+    "VEHJOURNEY",
+    "VEHJOURNEYITEM",
+    "TURN",
+    "LANETURN",
+    "FARESYSTEM",
+    "FAREMODEL",
+}
+VISUM_SQLITE_CONNECTOR_EPSILON_MINUTES = 1e-6
+
+
+@dataclass
+class VisumSQLiteReport(VisumGeoJSONReport):
+    """Diagnostics and provenance returned by a VISUM SQLite import."""
+
+    def raise_for_errors(self) -> None:
+        if self.errors:
+            messages = "; ".join(f"{diag.code}: {diag.message}" for diag in self.errors[:5])
+            raise ValueError(f"VISUM SQLite import failed validation: {messages}")
+
+
+def discover_visum_sqlite(path: str | Path) -> VisumSQLiteReport:
+    """Validate a VISUM SQLite export and report available required, optional, and deferred tables."""
+
+    report = VisumSQLiteReport()
+    db_path = Path(path)
+    if not db_path.exists():
+        report.add("error", "missing-input", f"VISUM SQLite path does not exist: {db_path}")
+        return report
+    if not db_path.is_file():
+        report.add("error", "invalid-input", f"VISUM SQLite input must be a file: {db_path}")
+        return report
+
+    try:
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')").fetchall()
+    except sqlite3.Error as exc:
+        report.add("error", "invalid-sqlite", f"Could not read VISUM SQLite database: {exc}")
+        return report
+
+    tables = {row[0].upper(): row[0] for row in rows}
+    table_names = set(tables)
+    report.discovered_layers.update(
+        {table.lower(): tables[table] for table in sorted(table_names & REQUIRED_SQLITE_TABLES)}
+    )
+    report.source_references["sqlite_tables"] = sorted(tables)
+
+    for table in sorted(REQUIRED_SQLITE_TABLES - table_names):
+        report.add("error", "missing-table", f"Required VISUM SQLite table '{table}' was not provided", layer=table)
+
+    for table in sorted(table_names & DEFERRED_SQLITE_TABLES):
+        report.deferred_layers.append(table)
+        report.add(
+            "warning",
+            "deferred-table",
+            f"VISUM SQLite table '{table}' is recognized but deferred",
+            layer=table,
+        )
+    return report
+
+
+def visum_sqlite_source_connectivity(
+    path: str | Path,
+    *,
+    mode_mapping: Mapping[str, str] | None = None,
+    ignored_transport_systems: set[str] | list[str] | tuple[str, ...] | None = None,
+) -> dict[str, set[tuple[int, int]]]:
+    """Extract source directed link/connector connectivity by mapped AequilibraE mode."""
+
+    mapping = {str(k).upper(): v for k, v in (mode_mapping or DEFAULT_MODE_MAPPING).items()}
+    ignored = {str(token).upper() for token in (ignored_transport_systems or set())}
+    connectivity = {mode: set() for mode in sorted(set(mapping.values()))}
+
+    with sqlite3.connect(Path(path)) as conn:
+        for row in conn.execute('SELECT FROMNODENO, TONODENO, TSYSSET FROM "LINK"'):
+            from_node, to_node, tsysset = row
+            for mode in _mapped_modes_from_value(tsysset, mapping, ignored):
+                connectivity.setdefault(mode, set()).add((int(from_node), int(to_node)))
+
+        for zone_no, node_no, direction, tsysset in conn.execute(
+            'SELECT ZONENO, NODENO, DIRECTION, TSYSSET FROM "CONNECTOR"'
+        ):
+            if direction == "O":
+                arc = (int(zone_no), int(node_no))
+            elif direction == "D":
+                arc = (int(node_no), int(zone_no))
+            else:
+                continue
+            for mode in _mapped_modes_from_value(tsysset, mapping, ignored):
+                connectivity.setdefault(mode, set()).add(arc)
+    return connectivity
+
+
+class VisumSQLiteImporter(VisumGeoJSONImporter):
+    def __init__(
+        self,
+        net,
+        path: str | Path,
+        *,
+        mode_mapping: Mapping[str, str] | None = None,
+        ignored_transport_systems: set[str] | list[str] | tuple[str, ...] | None = None,
+        link_type_mapping: Mapping[object, str] | None = None,
+        source_crs: str | int | None = None,
+        accept_default_crs: bool = False,
+        default_crs: str = "EPSG:4326",
+        allow_non_empty: bool = False,
+        geometry_tolerance: float = 1e-6,
+        duplicate_node_policy: str = "offset",
+        duplicate_node_offset_meters: float = 0.25,
+        connector_epsilon_minutes: float = VISUM_SQLITE_CONNECTOR_EPSILON_MINUTES,
+        connector_capacity: float = CONNECTOR_FALLBACK_CAPACITY,
+    ) -> None:
+        super().__init__(
+            net,
+            path,
+            mode_mapping=mode_mapping,
+            ignored_transport_systems=ignored_transport_systems,
+            link_type_mapping=link_type_mapping,
+            source_crs=source_crs,
+            accept_default_crs=accept_default_crs,
+            allow_non_empty=allow_non_empty,
+            geometry_tolerance=geometry_tolerance,
+            duplicate_node_policy=duplicate_node_policy,
+            duplicate_node_offset_meters=duplicate_node_offset_meters,
+        )
+        if connector_epsilon_minutes <= 0:
+            raise ValueError("connector_epsilon_minutes must be positive")
+        self.path = Path(path)
+        self.default_crs = default_crs
+        self.connector_epsilon_minutes = connector_epsilon_minutes
+        self.connector_capacity = connector_capacity
+        self.report = VisumSQLiteReport(mode_mapping=dict(self.mode_mapping))
+
+    def doWork(self) -> VisumSQLiteReport:
+        report = super().doWork()
+        report.add("info", "import-complete", "VISUM SQLite import completed")
+        return report
+
+    def _discover_and_read(self) -> None:
+        discovery = discover_visum_sqlite(self.path)
+        self.report.discovered_layers.update(discovery.discovered_layers)
+        self.report.deferred_layers.extend(discovery.deferred_layers)
+        self.report.diagnostics.extend(discovery.diagnostics)
+        self.report.source_references.update(discovery.source_references)
+        self.report.raise_for_errors()
+
+        try:
+            self.layers = _read_sqlite_as_visum_layers(
+                self.path,
+                self.report,
+                mode_mapping=self.mode_mapping,
+                ignored_transport_systems=self.ignored_transport_systems,
+                source_crs=self.source_crs,
+                accept_default_crs=self.accept_default_crs,
+                default_crs=self.default_crs,
+                connector_epsilon_minutes=self.connector_epsilon_minutes,
+                connector_capacity=self.connector_capacity,
+            )
+        except sqlite3.Error as exc:
+            self.report.add("error", "sqlite-read-failed", f"Could not read VISUM SQLite tables: {exc}")
+        self.report.field_inventory = _inventory_sqlite_layers(self.layers)
+
+    def _validate_required_columns(self) -> None:
+        super()._validate_required_columns()
+        required = {
+            "network": {"PROJECTIONDEFINITION"},
+            "tsys": {"CODE", "TYPE"},
+            "linktype": {"NO"},
+        }
+        for layer, fields in required.items():
+            if layer not in self.layers:
+                continue
+            missing = fields - set(self.layers[layer].columns)
+            for field_name in sorted(missing):
+                self.report.add(
+                    "error",
+                    "missing-field",
+                    f"Table-derived layer '{layer}' is missing required field '{field_name}'",
+                    layer=layer,
+                    field=field_name,
+                )
+
+    def _prepare_connector_source_keys(self) -> None:
+        if "connector" not in self.layers:
+            return
+        for row_index, row in self.layers["connector"].iterrows():
+            ab_modes = self._mapped_modes(row.get("TSYSSET"), "connector", None)
+            ba_modes = self._mapped_modes(row.get("R_TSYSSET"), "connector", None)
+            direction_code = "B" if _direction(ab_modes, ba_modes) == 0 else ("O" if ab_modes else "D")
+            self.connector_source_keys[row_index] = (
+                f"connector:{int(row['ZONENO'])}:{int(row['NODENO'])}:{direction_code}"
+            )
+            self.connector_source_nos[row_index] = None
+
+
+def _read_sqlite_as_visum_layers(
+    path: Path,
+    report: VisumSQLiteReport,
+    *,
+    mode_mapping: Mapping[str, str],
+    ignored_transport_systems: set[str],
+    source_crs: str | int | None,
+    accept_default_crs: bool,
+    default_crs: str,
+    connector_epsilon_minutes: float,
+    connector_capacity: float,
+) -> dict[str, gpd.GeoDataFrame]:
+    with sqlite3.connect(path) as conn:
+        conn.row_factory = sqlite3.Row
+        network = _read_table(conn, "NETWORK")
+        transformer = _coordinate_transformer(network, report, source_crs, accept_default_crs, default_crs)
+        nodes = _read_table(conn, "NODE")
+        zones = _read_table(conn, "ZONE")
+        links = _read_table(conn, "LINK")
+        connectors = _read_table(conn, "CONNECTOR")
+        tsys = _read_table(conn, "TSYS")
+        link_types = _read_table(conn, "LINKTYPE")
+        modes = _read_optional_table(conn, "MODE")
+        count_locations = _read_optional_table(conn, "COUNTLOCATION")
+
+        point_by_node = _point_lookup(nodes, transformer)
+        point_by_zone = _point_lookup(zones, transformer, id_column="NO")
+        linkpolys = _read_linkpolys(conn, transformer)
+        zone_polygons = _read_zone_polygons(conn, zones, transformer, report)
+
+    node_layer = _node_layer(nodes, point_by_node)
+    zone_layer = _zone_layer(zones, point_by_zone)
+    link_layer = _link_layer(links, point_by_node, linkpolys, report)
+    connector_layer = _connector_layer(
+        connectors,
+        point_by_zone,
+        point_by_node,
+        report,
+        mode_mapping,
+        ignored_transport_systems,
+        connector_epsilon_minutes,
+        connector_capacity,
+    )
+    layers: dict[str, gpd.GeoDataFrame] = {
+        "network": gpd.GeoDataFrame(network),
+        "tsys": gpd.GeoDataFrame(tsys),
+        "linktype": gpd.GeoDataFrame(link_types),
+        "node": node_layer,
+        "zone_centroid": zone_layer,
+        "link": link_layer,
+        "connector": connector_layer,
+    }
+    if modes is not None:
+        layers["mode"] = gpd.GeoDataFrame(modes)
+    if count_locations is not None:
+        layers["countlocation"] = _count_location_layer(count_locations, link_layer)
+    if zone_polygons:
+        layers["zone_polygon"] = gpd.GeoDataFrame(list(zone_polygons.values()), geometry="geometry", crs="EPSG:4326")
+    return layers
+
+
+def _read_table(conn: sqlite3.Connection, table: str) -> pd.DataFrame:
+    return pd.read_sql_query(f'SELECT * FROM "{table}"', conn)
+
+
+def _read_optional_table(conn: sqlite3.Connection, table: str) -> pd.DataFrame | None:
+    exists = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND UPPER(name)=?",
+        (table.upper(),),
+    ).fetchone()
+    if exists is None:
+        return None
+    return _read_table(conn, table)
+
+
+def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND UPPER(name)=?",
+            (table.upper(),),
+        ).fetchone()
+        is not None
+    )
+
+
+def _coordinate_transformer(
+    network: pd.DataFrame,
+    report: VisumSQLiteReport,
+    source_crs: str | int | None,
+    accept_default_crs: bool,
+    default_crs: str,
+) -> Transformer:
+    crs_value = source_crs
+    if crs_value is None and "PROJECTIONDEFINITION" in network.columns and not network.empty:
+        crs_value = network.iloc[0].get("PROJECTIONDEFINITION")
+    if not crs_value:
+        if not accept_default_crs:
+            report.add(
+                "error",
+                "missing-crs",
+                "VISUM SQLite source CRS is missing; supply source_crs or accept_default_crs=True",
+            )
+            report.raise_for_errors()
+        crs_value = default_crs
+        report.add("warning", "default-crs-assumed", f"Assuming VISUM SQLite source CRS {default_crs}")
+    try:
+        crs = CRS.from_user_input(crs_value)
+    except Exception as exc:  # pyproj raises multiple exception types depending on the CRS payload
+        report.add("error", "invalid-crs", f"Could not parse VISUM SQLite source CRS: {exc}")
+        report.raise_for_errors()
+        crs = CRS.from_user_input(default_crs)
+    report.crs["sqlite"] = f"{crs.to_string()} -> EPSG:4326"
+    return Transformer.from_crs(crs, "EPSG:4326", always_xy=True)
+
+
+def _transform_point(transformer: Transformer, x, y) -> Point:
+    lon, lat = transformer.transform(float(x), float(y))
+    return Point(lon, lat)
+
+
+def _point_lookup(df: pd.DataFrame, transformer: Transformer, *, id_column: str = "NO") -> dict[int, Point]:
+    return {
+        int(row[id_column]): _transform_point(transformer, row["XCOORD"], row["YCOORD"])
+        for _, row in df.iterrows()
+        if pd.notna(row.get("XCOORD")) and pd.notna(row.get("YCOORD"))
+    }
+
+
+def _node_layer(nodes: pd.DataFrame, point_by_node: Mapping[int, Point]) -> gpd.GeoDataFrame:
+    rows = []
+    for _, row in nodes.iterrows():
+        source_id = int(row["NO"])
+        if source_id not in point_by_node:
+            continue
+        rows.append({**row.to_dict(), "NO": source_id, "geometry": point_by_node[source_id]})
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+
+
+def _zone_layer(zones: pd.DataFrame, point_by_zone: Mapping[int, Point]) -> gpd.GeoDataFrame:
+    rows = []
+    for _, row in zones.iterrows():
+        zone_id = int(row["NO"])
+        if zone_id not in point_by_zone:
+            continue
+        rows.append({**row.to_dict(), "NO": zone_id, "geometry": point_by_zone[zone_id]})
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+
+
+def _read_linkpolys(conn: sqlite3.Connection, transformer: Transformer) -> dict[tuple[int, int], list[Point]]:
+    if not _table_exists(conn, "LINKPOLY"):
+        return {}
+    rows = conn.execute(
+        'SELECT FROMNODENO, TONODENO, "INDEX", XCOORD, YCOORD FROM "LINKPOLY" ORDER BY FROMNODENO, TONODENO, "INDEX"'
+    ).fetchall()
+    linkpolys: dict[tuple[int, int], list[Point]] = {}
+    for row in rows:
+        key = (int(row["FROMNODENO"]), int(row["TONODENO"]))
+        linkpolys.setdefault(key, []).append(_transform_point(transformer, row["XCOORD"], row["YCOORD"]))
+    return linkpolys
+
+
+def _link_layer(
+    links: pd.DataFrame,
+    point_by_node: Mapping[int, Point],
+    linkpolys: Mapping[tuple[int, int], list[Point]],
+    report: VisumSQLiteReport,
+) -> gpd.GeoDataFrame:
+    rows = []
+    for source_no, group in links.groupby("NO", sort=True):
+        group = group.sort_values(["FROMNODENO", "TONODENO"])
+        ab = group.iloc[0]
+        reverse = group[
+            (group["FROMNODENO"] == ab["TONODENO"])
+            & (group["TONODENO"] == ab["FROMNODENO"])
+            & (group.index != ab.name)
+        ]
+        ba = reverse.iloc[0] if not reverse.empty else None
+        from_node = int(ab["FROMNODENO"])
+        to_node = int(ab["TONODENO"])
+        if from_node not in point_by_node or to_node not in point_by_node:
+            report.add(
+                "error",
+                "missing-node-reference",
+                "SQLite link references missing node coordinates",
+                layer="link",
+                source_id=int(source_no),
+            )
+            continue
+        geometry = _link_geometry(from_node, to_node, point_by_node, linkpolys)
+        row = _directional_link_row(source_no, ab, ba)
+        row["geometry"] = geometry
+        rows.append(row)
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+
+
+def _directional_link_row(source_no, ab: pd.Series, ba: pd.Series | None) -> dict:
+    row = {
+        "NO": int(source_no),
+        "FROMNODENO": int(ab["FROMNODENO"]),
+        "TONODENO": int(ab["TONODENO"]),
+        "TSYSSET": _string_or_empty(ab.get("TSYSSET")),
+        "LC": _string_or_empty(ab.get("LC")),
+        "TYPENO": ab.get("TYPENO"),
+        "LENGTH": _sqlite_length(ab.get("LENGTH")),
+        "V0PRT": _sqlite_speed(ab.get("V0PRT")),
+        "CAPPRT": _sqlite_capacity(ab.get("CAPPRT")),
+    }
+    if ba is not None:
+        row.update(
+            {
+                "R_TSYSSET": _string_or_empty(ba.get("TSYSSET")),
+                "R_LC": _string_or_empty(ba.get("LC")),
+                "R_TYPENO": ba.get("TYPENO"),
+                "R_LENGTH": _sqlite_length(ba.get("LENGTH")),
+                "R_V0PRT": _sqlite_speed(ba.get("V0PRT")),
+                "R_CAPPRT": _sqlite_capacity(ba.get("CAPPRT")),
+            }
+        )
+    else:
+        row.update({"R_TSYSSET": "", "R_LC": "", "R_TYPENO": None, "R_LENGTH": None, "R_V0PRT": None, "R_CAPPRT": None})
+    return row
+
+
+def _link_geometry(
+    from_node: int,
+    to_node: int,
+    point_by_node: Mapping[int, Point],
+    linkpolys: Mapping[tuple[int, int], list[Point]],
+) -> LineString:
+    if (from_node, to_node) in linkpolys:
+        vertices = linkpolys[(from_node, to_node)]
+    elif (to_node, from_node) in linkpolys:
+        vertices = list(reversed(linkpolys[(to_node, from_node)]))
+    else:
+        vertices = []
+    coords = [point_by_node[from_node], *vertices, point_by_node[to_node]]
+    return LineString([(point.x, point.y) for point in coords])
+
+
+def _connector_layer(
+    connectors: pd.DataFrame,
+    point_by_zone: Mapping[int, Point],
+    point_by_node: Mapping[int, Point],
+    report: VisumSQLiteReport,
+    mode_mapping: Mapping[str, str],
+    ignored_transport_systems: set[str],
+    connector_epsilon_minutes: float,
+    connector_capacity: float,
+) -> gpd.GeoDataFrame:
+    rows = []
+    for (zone_no, node_no), group in connectors.groupby(["ZONENO", "NODENO"], sort=True):
+        zone_no = int(zone_no)
+        node_no = int(node_no)
+        if zone_no not in point_by_zone or node_no not in point_by_node:
+            report.add(
+                "error",
+                "missing-node-reference",
+                "SQLite connector references missing zone or node coordinates",
+                layer="connector",
+                source_id=f"connector:{zone_no}:{node_no}",
+            )
+            continue
+        by_direction = {str(row["DIRECTION"]): row for _, row in group.iterrows()}
+        origin = by_direction.get("O")
+        destination = by_direction.get("D")
+        row = {
+            "ZONENO": zone_no,
+            "NODENO": node_no,
+            "TSYSSET": _string_or_empty(origin.get("TSYSSET")) if origin is not None else "",
+            "R_TSYSSET": _string_or_empty(destination.get("TSYSSET")) if destination is not None else "",
+            "TYPENO": (
+                origin.get("TYPENO")
+                if origin is not None
+                else (destination.get("TYPENO") if destination is not None else None)
+            ),
+            "LENGTH": _sqlite_length(origin.get("LENGTH")) if origin is not None else None,
+            "R_LENGTH": _sqlite_length(destination.get("LENGTH")) if destination is not None else None,
+            "V0PRT": None,
+            "R_V0PRT": None,
+            "CAPPRT": _sqlite_capacity(connector_capacity),
+            "R_CAPPRT": _sqlite_capacity(connector_capacity),
+            "T0PRT": _connector_time(
+                origin,
+                mode_mapping,
+                ignored_transport_systems,
+                report,
+                zone_no,
+                node_no,
+                "O",
+                connector_epsilon_minutes,
+            ),
+            "R_T0PRT": _connector_time(
+                destination,
+                mode_mapping,
+                ignored_transport_systems,
+                report,
+                zone_no,
+                node_no,
+                "D",
+                connector_epsilon_minutes,
+            ),
+            "geometry": LineString(
+                [
+                    (point_by_zone[zone_no].x, point_by_zone[zone_no].y),
+                    (point_by_node[node_no].x, point_by_node[node_no].y),
+                ]
+            ),
+        }
+        rows.append(row)
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+
+
+def _connector_time(
+    row: pd.Series | None,
+    mode_mapping: Mapping[str, str],
+    ignored_transport_systems: set[str],
+    report: VisumSQLiteReport,
+    zone_no: int,
+    node_no: int,
+    direction: str,
+    connector_epsilon_minutes: float,
+) -> str | None:
+    if row is None:
+        return None
+    values = []
+    for token in _split_tsysset(row.get("TSYSSET")):
+        token = token.upper()
+        if token not in mode_mapping or token in ignored_transport_systems:
+            continue
+        field_name = f"T0_TSYS({token})"
+        if field_name not in row or pd.isna(row[field_name]):
+            continue
+        seconds = float(row[field_name])
+        if seconds == 0:
+            report.add(
+                "warning",
+                "sqlite-zero-connector-time",
+                "SQLite connector has explicit zero travel time; importing positive epsilon cost",
+                layer="connector",
+                field=field_name,
+                source_id=f"connector:{zone_no}:{node_no}:{direction}",
+            )
+            values.append(connector_epsilon_minutes)
+        elif seconds > 0:
+            values.append(seconds / 60.0)
+    if not values:
+        return None
+    return f"{max(values):.12f}".rstrip("0").rstrip(".") + "min"
+
+
+def _count_location_layer(count_locations: pd.DataFrame, link_layer: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    link_points = {}
+    for _, row in link_layer.iterrows():
+        line = row.geometry
+        link_points[int(row["NO"])] = line.interpolate(0.5, normalized=True)
+    rows = []
+    for _, row in count_locations.iterrows():
+        source_link = row.get("LINKNO")
+        geometry = (
+            link_points.get(int(source_link))
+            if pd.notna(source_link) and int(source_link) in link_points
+            else Point(0, 0)
+        )
+        rows.append({**row.to_dict(), "geometry": geometry})
+    return gpd.GeoDataFrame(rows, geometry="geometry", crs="EPSG:4326")
+
+
+def _read_zone_polygons(
+    conn: sqlite3.Connection,
+    zones: pd.DataFrame,
+    transformer: Transformer,
+    report: VisumSQLiteReport,
+) -> dict[int, dict]:
+    required = {"SURFACEITEM", "FACEITEM", "EDGE", "POINT"}
+    available = {
+        row[0].upper()
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type IN ('table', 'view')").fetchall()
+    }
+    if not required.issubset(available):
+        return {}
+    points = {
+        int(row["ID"]): _transform_point(transformer, row["XCOORD"], row["YCOORD"])
+        for row in conn.execute('SELECT ID, XCOORD, YCOORD FROM "POINT"')
+    }
+    edges = {
+        int(row["ID"]): (int(row["FROMPOINTID"]), int(row["TOPOINTID"]))
+        for row in conn.execute('SELECT ID, FROMPOINTID, TOPOINTID FROM "EDGE"')
+    }
+    edge_items: dict[int, list[Point]] = {}
+    if "EDGEITEM" in available:
+        for row in conn.execute('SELECT EDGEID, "INDEX", XCOORD, YCOORD FROM "EDGEITEM" ORDER BY EDGEID, "INDEX"'):
+            edge_items.setdefault(int(row["EDGEID"]), []).append(
+                _transform_point(transformer, row["XCOORD"], row["YCOORD"])
+            )
+    face_items: dict[int, list[tuple[int, int]]] = {}
+    for row in conn.execute('SELECT FACEID, "INDEX", EDGEID, DIRECTION FROM "FACEITEM" ORDER BY FACEID, "INDEX"'):
+        face_items.setdefault(int(row["FACEID"]), []).append((int(row["EDGEID"]), int(row["DIRECTION"] or 0)))
+    surface_faces: dict[int, list[tuple[int, int]]] = {}
+    for row in conn.execute('SELECT SURFACEID, FACEID, ENCLAVE FROM "SURFACEITEM"'):
+        surface_faces.setdefault(int(row["SURFACEID"]), []).append((int(row["FACEID"]), int(row["ENCLAVE"] or 0)))
+
+    polygons = {}
+    for _, zone in zones.iterrows():
+        zone_id = int(zone["NO"])
+        surface_id = zone.get("SURFACEID")
+        if pd.isna(surface_id) or int(surface_id) not in surface_faces:
+            continue
+        shells = []
+        holes = []
+        for face_id, enclave in surface_faces[int(surface_id)]:
+            coords = _face_coordinates(face_id, face_items, edges, edge_items, points)
+            if len(coords) < 4:
+                report.add(
+                    "warning",
+                    "invalid-zone-surface",
+                    "Zone surface could not be reconstructed",
+                    layer="zone",
+                    source_id=zone_id,
+                )
+                continue
+            if enclave:
+                holes.append(coords)
+            else:
+                shells.append(coords)
+        if not shells:
+            continue
+        zone_polygons = [Polygon(shell, holes if idx == 0 else None) for idx, shell in enumerate(shells)]
+        geometry = MultiPolygon(zone_polygons)
+        if not geometry.is_valid:
+            geometry = geometry.buffer(0)
+        polygons[zone_id] = {"NO": zone_id, "NAME": _string_or_empty(zone.get("NAME")), "geometry": geometry}
+    return polygons
+
+
+def _face_coordinates(
+    face_id: int,
+    face_items: Mapping[int, list[tuple[int, int]]],
+    edges: Mapping[int, tuple[int, int]],
+    edge_items: Mapping[int, list[Point]],
+    points: Mapping[int, Point],
+) -> list[tuple[float, float]]:
+    coords: list[tuple[float, float]] = []
+    for edge_id, direction in face_items.get(face_id, []):
+        if edge_id not in edges:
+            continue
+        from_point, to_point = edges[edge_id]
+        edge_points = [points[from_point], *edge_items.get(edge_id, []), points[to_point]]
+        if direction:
+            edge_points = list(reversed(edge_points))
+        edge_coords = [(point.x, point.y) for point in edge_points]
+        if coords and edge_coords and coords[-1] == edge_coords[0]:
+            coords.extend(edge_coords[1:])
+        else:
+            coords.extend(edge_coords)
+    if coords and coords[0] != coords[-1]:
+        coords.append(coords[0])
+    return coords
+
+
+def _mapped_modes_from_value(value, mode_mapping: Mapping[str, str], ignored_transport_systems: set[str]) -> set[str]:
+    modes = set()
+    for token in _split_tsysset(value):
+        token = token.upper()
+        if token in ignored_transport_systems:
+            continue
+        mapped = mode_mapping.get(token)
+        if mapped is not None:
+            modes.add(mapped)
+    return modes
+
+
+def _string_or_empty(value) -> str:
+    if value is None or pd.isna(value):
+        return ""
+    return str(value)
+
+
+def _sqlite_length(value) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    return f"{float(value):.12g}km"
+
+
+def _sqlite_speed(value) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    return f"{float(value):.12g}km/h"
+
+
+def _sqlite_capacity(value) -> str | None:
+    if value is None or pd.isna(value):
+        return None
+    return f"{float(value):.12g}veh/h"
+
+
+def _inventory_sqlite_layers(layers: Mapping[str, pd.DataFrame]) -> dict[str, dict[str, dict[str, object]]]:
+    inventory = {}
+    for layer, df in layers.items():
+        fields = {}
+        for column in df.columns:
+            series = df[column]
+            if column == "geometry":
+                role = "geometry"
+            elif column.startswith("R_"):
+                role = "directional"
+            elif column in {"NO", "FROMNODENO", "TONODENO", "ZONENO", "NODENO"}:
+                role = "required"
+            else:
+                role = "optional"
+            non_null = series.dropna()
+            samples = [_jsonish(value) for value in non_null.head(3).tolist()]
+            unique_values = []
+            if column != "geometry" and non_null.nunique(dropna=True) <= 10:
+                unique_values = [_jsonish(value) for value in non_null.unique().tolist()]
+            fields[column] = {
+                "dtype": str(series.dtype),
+                "null_count": int(series.isna().sum()),
+                "unique_values": unique_values,
+                "sample_values": samples,
+                "unit_pattern": None,
+                "role": role,
+            }
+        inventory[layer] = fields
+    return inventory

--- a/docs/source/aequilibrae_project/project_components/components.rst
+++ b/docs/source/aequilibrae_project/project_components/components.rst
@@ -348,8 +348,11 @@ records in the 'matrices' table. Each item in the 'matrices' table  is a ``Matri
     # One can also check all the project matrices as a Pandas' DataFrame
     >>> matrices.list() # doctest: +SKIP
 
-    # We can add a naw matrix
+    # We can add a new matrix
     >>> matrices.new_record() # doctest: +SKIP
+
+    # Or import an existing OMX/AEM file into the project's matrices folder
+    >>> matrices.import_file("/tmp/my_demand.omx", name="my_demand") # doctest: +SKIP
     
     # To delete a matrix from the 'matrices' table, we can delete the record directly
     >>> matrices.delete_record("demand_mc")

--- a/docs/source/examples/network_manipulation/plot_create_from_visum_geojson.py
+++ b/docs/source/examples/network_manipulation/plot_create_from_visum_geojson.py
@@ -1,0 +1,137 @@
+"""
+.. _import_from_visum_geojson:
+
+Importing a network from VISUM GeoJSON
+======================================
+
+This example creates a tiny VISUM-like GeoJSON export locally and imports it as an
+AequilibraE private-traffic network.
+"""
+
+from tempfile import TemporaryDirectory
+from pathlib import Path
+
+import geopandas as gpd
+from shapely.geometry import LineString, Point, Polygon
+
+from aequilibrae import Project
+
+
+def write_layer(path, records):
+    gdf = gpd.GeoDataFrame(records, crs="EPSG:4326")
+    gdf.to_file(path, driver="GeoJSON")
+
+
+with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    project = Project()
+    project.new(Path(temp_dir) / "visum_project")
+
+    visum_dir = project.project_base_path / "visum_geojson"
+    visum_dir.mkdir()
+
+    write_layer(
+        visum_dir / "node.geojson",
+        [
+            {"NO": 1, "NAME": "A", "geometry": Point(0.0, 0.0)},
+            {"NO": 2, "NAME": "B", "geometry": Point(0.01, 0.0)},
+        ],
+    )
+    write_layer(
+        visum_dir / "link.geojson",
+        [
+            {
+                "NO": 100,
+                "FROMNODENO": 1,
+                "TONODENO": 2,
+                "TSYSSET": "CAR,HGV",
+                "R_TSYSSET": "CAR",
+                "LC": "ARTERIAL",
+                "LENGTH": "1km",
+                "R_LENGTH": "1.1km",
+                "V0PRT": "60km/h",
+                "R_V0PRT": "55km/h",
+                "CAPPRT": "1200veh/h",
+                "R_CAPPRT": "1100veh/h",
+                "geometry": LineString([(0.0, 0.0), (0.01, 0.0)]),
+            }
+        ],
+    )
+    write_layer(
+        visum_dir / "zone_centroid.geojson",
+        [
+            {"NO": 1001, "NAME": "Z1", "geometry": Point(-0.01, 0.0)},
+            {"NO": 1002, "NAME": "Z2", "geometry": Point(0.02, 0.0)},
+        ],
+    )
+    write_layer(
+        visum_dir / "zone_polygon.geojson",
+        [
+            {
+                "NO": 1001,
+                "NAME": "Z1",
+                "geometry": Polygon([(-0.02, -0.01), (-0.005, -0.01), (-0.005, 0.01), (-0.02, 0.01)]),
+            },
+            {
+                "NO": 1002,
+                "NAME": "Z2",
+                "geometry": Polygon([(0.015, -0.01), (0.03, -0.01), (0.03, 0.01), (0.015, 0.01)]),
+            },
+        ],
+    )
+    write_layer(
+        visum_dir / "connector.geojson",
+        [
+            {
+                "NO": 9001,
+                "ZONENO": 1001,
+                "NODENO": 1,
+                "TSYSSET": "CAR,HGV",
+                "R_TSYSSET": "CAR,HGV",
+                "LENGTH": "100m",
+                "R_LENGTH": "100m",
+                "V0PRT": "30km/h",
+                "R_V0PRT": "30km/h",
+                "CAPPRT": "9999veh/h",
+                "R_CAPPRT": "9999veh/h",
+                "geometry": LineString([(-0.01, 0.0), (0.0, 0.0)]),
+            },
+            {
+                "NO": 9002,
+                "ZONENO": 1002,
+                "NODENO": 2,
+                "TSYSSET": "CAR,HGV",
+                "R_TSYSSET": "CAR,HGV",
+                "LENGTH": "100m",
+                "R_LENGTH": "100m",
+                "V0PRT": "30km/h",
+                "R_V0PRT": "30km/h",
+                "CAPPRT": "9999veh/h",
+                "R_CAPPRT": "9999veh/h",
+                "geometry": LineString([(0.02, 0.0), (0.01, 0.0)]),
+            },
+        ],
+    )
+    write_layer(
+        visum_dir / "countlocation.geojson",
+        [
+            {
+                "NO": 5001,
+                "LINKNO": 100,
+                "FROMNODENO": 1,
+                "TONODENO": 2,
+                "CAR_ORIG": 950,
+                "HVG_ORIG": 120,
+                "geometry": Point(0.005, 0.0),
+            }
+        ],
+    )
+
+    report = project.network.create_from_visum_geojson(visum_dir)
+    project.network.build_graphs(
+        fields=["distance", "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"], modes=["c"]
+    )
+    project.network.set_time_field("travel_time")
+
+    print(report.imported_counts)
+
+    project.close()

--- a/docs/source/examples/network_manipulation/plot_create_from_visum_sqlite.py
+++ b/docs/source/examples/network_manipulation/plot_create_from_visum_sqlite.py
@@ -1,0 +1,123 @@
+"""
+.. _import_from_visum_sqlite:
+
+Importing a network from VISUM SQLite
+=====================================
+
+This example creates a tiny VISUM-like SQLite export locally and imports it as
+an AequilibraE private-traffic network.
+"""
+
+from pathlib import Path
+import sqlite3
+from tempfile import TemporaryDirectory
+
+from aequilibrae import Project
+from aequilibrae.project.network.visum_sqlite_importer import visum_sqlite_source_connectivity
+
+
+def create_visum_sqlite(path):
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE NETWORK(PROJECTIONDEFINITION TEXT);
+            CREATE TABLE NODE(NO INTEGER PRIMARY KEY, NAME TEXT, TYPENO INTEGER, XCOORD REAL, YCOORD REAL);
+            CREATE TABLE ZONE(NO INTEGER PRIMARY KEY, NAME TEXT, TYPENO INTEGER, XCOORD REAL, YCOORD REAL);
+            CREATE TABLE TSYS(CODE TEXT PRIMARY KEY, NAME TEXT, TYPE TEXT, PCU REAL);
+            CREATE TABLE MODE(CODE TEXT PRIMARY KEY, NAME TEXT, TSYSSET TEXT);
+            CREATE TABLE LINKTYPE(NO INTEGER PRIMARY KEY, NAME TEXT, TSYSSET TEXT, CAPPRT INTEGER, V0PRT REAL);
+            CREATE TABLE LINK(
+                NO INTEGER,
+                FROMNODENO INTEGER,
+                TONODENO INTEGER,
+                NAME TEXT,
+                TYPENO INTEGER,
+                TSYSSET TEXT,
+                LENGTH REAL,
+                CAPPRT INTEGER,
+                V0PRT REAL,
+                LC TEXT
+            );
+            CREATE TABLE CONNECTOR(
+                ZONENO INTEGER,
+                NODENO INTEGER,
+                DIRECTION TEXT,
+                TYPENO INTEGER,
+                TSYSSET TEXT,
+                LENGTH REAL,
+                "T0_TSYS(CAR)" REAL,
+                "T0_TSYS(HGV)" REAL,
+                WEIGHTPRT REAL
+            );
+            CREATE TABLE COUNTLOCATION(
+                NO INTEGER PRIMARY KEY,
+                LINKNO INTEGER,
+                FROMNODENO INTEGER,
+                TONODENO INTEGER,
+                CAR_ORIG REAL
+            );
+            CREATE TABLE LINKPOLY(FROMNODENO INTEGER, TONODENO INTEGER, "INDEX" INTEGER, XCOORD REAL, YCOORD REAL);
+            """
+        )
+        conn.execute("INSERT INTO NETWORK VALUES('EPSG:4326')")
+        conn.executemany(
+            "INSERT INTO TSYS VALUES(?, ?, ?, ?)",
+            [("CAR", "Car", "PrT", 1.0), ("HGV", "HGV", "PrT", 2.0)],
+        )
+        conn.execute("INSERT INTO MODE VALUES('CAR', 'Car', 'CAR,HGV')")
+        conn.execute("INSERT INTO LINKTYPE VALUES(1, 'arterial', 'CAR,HGV', 1200, 60)")
+        conn.executemany(
+            "INSERT INTO NODE VALUES(?, ?, ?, ?, ?)",
+            [(1, "A", 1, 0.0, 0.0), (2, "B", 1, 0.01, 0.0)],
+        )
+        conn.executemany(
+            "INSERT INTO ZONE VALUES(?, ?, ?, ?, ?)",
+            [(1001, "Z1", 1, -0.01, 0.0), (1002, "Z2", 1, 0.02, 0.0)],
+        )
+        conn.executemany(
+            "INSERT INTO LINK VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (100, 1, 2, "AB", 1, "CAR,HGV", 1.0, 1200, 60, "ARTERIAL"),
+                (100, 2, 1, "BA", 1, "CAR", 1.1, 1100, 55, "ARTERIAL"),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO LINKPOLY VALUES(?, ?, ?, ?, ?)",
+            [(1, 2, 1, 0.0, 0.0), (1, 2, 2, 0.005, 0.001), (1, 2, 3, 0.01, 0.0)],
+        )
+        conn.executemany(
+            'INSERT INTO CONNECTOR VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                (1001, 1, "O", 1, "CAR,HGV", 0.1, 0.0, 0.0, 100),
+                (1001, 1, "D", 1, "CAR,HGV", 0.1, 0.0, 0.0, 100),
+                (1002, 2, "O", 1, "CAR,HGV", 0.1, 30.0, 30.0, 100),
+                (1002, 2, "D", 1, "CAR,HGV", 0.1, 30.0, 30.0, 100),
+            ],
+        )
+        conn.execute("INSERT INTO COUNTLOCATION VALUES(1, 100, 1, 2, 950)")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+with TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+    temp_dir = Path(temp_dir)
+    sqlite_path = temp_dir / "visum.sqlite"
+    create_visum_sqlite(sqlite_path)
+
+    project = Project()
+    project.new(temp_dir / "visum_project")
+
+    report = project.network.create_from_visum_sqlite(sqlite_path)
+    project.network.build_graphs(
+        fields=["distance", "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"], modes=["c"]
+    )
+    project.network.set_time_field("travel_time")
+
+    source_graph = visum_sqlite_source_connectivity(sqlite_path)
+
+    print(report.imported_counts)
+    print({mode: len(arcs) for mode, arcs in source_graph.items()})
+
+    project.close()

--- a/docs/source/network_manipulation/import_and_export_network.rst
+++ b/docs/source/network_manipulation/import_and_export_network.rst
@@ -102,6 +102,50 @@ specification.
     * :ref:`import_from_gmns`
         Usage example
 
+.. _importing_from_visum_geojson_file:
+
+Importing from VISUM GeoJSON
+----------------------------
+
+VISUM GeoJSON private-traffic exports can be imported with
+``Project.network.create_from_visum_geojson()``. The importer reads GeoJSON
+layers through GeoPandas, validates VISUM source topology from identifiers such
+as ``FROMNODENO``, ``TONODENO``, ``ZONENO``, and ``NODENO``, and creates
+AequilibraE nodes, links, zones, centroids, and centroid connectors.
+
+Folder-based import recognizes conventional files named ``node.geojson``,
+``link.geojson``, ``zone_centroid.geojson``, ``connector.geojson``, optional
+``zone_polygon.geojson``, and optional ``countlocation.geojson``. Custom file
+names can be supplied with an explicit layer-to-path mapping.
+
+By default, VISUM ``CAR`` maps to AequilibraE mode ``c`` and ``HGV`` maps to
+mode ``h``. Users can override this mapping, for example to merge ``HGV`` into
+``c``. Link classes use deterministic link-type creation, and users can provide
+their own link-type mapping when model classes need specific AequilibraE names.
+
+VISUM length, speed, time, and capacity-like fields are parsed into assignment
+fields where possible. AequilibraE trigger-derived ``distance`` remains based on
+stored geometry, while source VISUM lengths are preserved separately in
+``visum_length_ab`` and ``visum_length_ba`` when present. Missing CRS metadata
+must be resolved by supplying ``source_crs`` or explicitly accepting the default
+``EPSG:4326`` assumption.
+
+Count locations are imported only as supported link-count associations in the
+returned report. They are not used to adjust OD matrices, calibrate demand, or
+run ODME. Public transport layers, OD matrix files, turn counts, detector/lane
+counts, screenlines, speeds, routes, and travel-time observations are recognized
+as deferred workflows for later import pipelines.
+
+Interactive UI wiring for VISUM import belongs in the adjacent frontend or
+plugin repository. This Python package exposes the import API and documentation.
+
+.. seealso::
+
+    * :func:`aequilibrae.project.network.network.Network.create_from_visum_geojson`
+        Function documentation
+    * :ref:`import_from_visum_geojson`
+        Usage example
+
 .. _aequilibrae_to_gmns:
 
 Exporting AequilibraE model to GMNS format

--- a/docs/source/network_manipulation/import_and_export_network.rst
+++ b/docs/source/network_manipulation/import_and_export_network.rst
@@ -120,7 +120,11 @@ names can be supplied with an explicit layer-to-path mapping.
 
 By default, VISUM ``CAR`` maps to AequilibraE mode ``c`` and ``HGV`` maps to
 mode ``h``. Users can override this mapping, for example to merge ``HGV`` into
-``c``. Link classes use deterministic link-type creation, and users can provide
+``c``. Any additional VISUM transport system must be explicitly mapped or
+explicitly ignored with ``ignored_transport_systems`` before the importer writes
+to the project database. This allows users to decide whether systems such as
+``BUS`` should become assignable road-vehicle modes or remain outside the import
+scope. Link classes use deterministic link-type creation, and users can provide
 their own link-type mapping when model classes need specific AequilibraE names.
 
 VISUM length, speed, time, and capacity-like fields are parsed into assignment
@@ -129,6 +133,27 @@ stored geometry, while source VISUM lengths are preserved separately in
 ``visum_length_ab`` and ``visum_length_ba`` when present. Missing CRS metadata
 must be resolved by supplying ``source_crs`` or explicitly accepting the default
 ``EPSG:4326`` assumption.
+
+Connector imports do not require a numeric VISUM connector ``NO`` field.
+AequilibraE stores numeric ``visum_connector_no`` values when present and always
+stores a deterministic ``visum_connector_key`` derived from the connector zone,
+node, and usable direction.
+
+Some VISUM models use multiple node records at the same physical coordinate to
+represent separate modal or topological layers. By default, the importer preserves
+these nodes separately with ``duplicate_node_policy="offset"``. It applies a tiny
+deterministic coordinate offset to satisfy AequilibraE's node uniqueness rules,
+adjusts imported link and connector endpoints consistently, and stores original
+VISUM coordinates in ``visum_original_lon``, ``visum_original_lat``,
+``visum_xcoord``, and ``visum_ycoord`` when available. Use
+``duplicate_node_policy="error"`` to reject coincident source nodes before import.
+If a VISUM regular node number collides with a VISUM zone number, the importer
+keeps the zone number as the centroid node ID and imports the regular node with a
+deterministic free node ID. The original value remains in ``visum_node_no`` and
+the returned report records the source-to-imported node mapping.
+If a VISUM zone centroid shares coordinates with an imported node, the importer
+keeps the zone number as the centroid node ID, applies a tiny deterministic
+centroid coordinate offset, and adjusts connector starts consistently.
 
 Count locations are imported only as supported link-count associations in the
 returned report. They are not used to adjust OD matrices, calibrate demand, or

--- a/docs/source/network_manipulation/import_and_export_network.rst
+++ b/docs/source/network_manipulation/import_and_export_network.rst
@@ -171,6 +171,60 @@ plugin repository. This Python package exposes the import API and documentation.
     * :ref:`import_from_visum_geojson`
         Usage example
 
+.. _importing_from_visum_sqlite_file:
+
+Importing from VISUM SQLite
+---------------------------
+
+VISUM SQLite private-traffic exports can be imported with
+``Project.network.create_from_visum_sqlite()``. The importer reads relational
+VISUM tables, reconstructs geometry, and then uses the same network-writing
+rules as the VISUM GeoJSON importer.
+
+The required source tables are ``NETWORK``, ``NODE``, ``ZONE``, ``TSYS``,
+``MODE``, ``LINKTYPE``, ``LINK``, ``CONNECTOR``, and ``COUNTLOCATION``.
+``LINKPOLY`` is used when present to preserve shaped link geometry; otherwise
+links are built as straight lines between source endpoints. Zone polygons are
+reconstructed when the export contains compatible ``SURFACEITEM``,
+``FACEITEM``, ``EDGE``, ``EDGEITEM``, and ``POINT`` tables. Connectors use
+straight VISUM centroid-to-node geometry.
+
+The importer reads ``NETWORK.PROJECTIONDEFINITION`` for the source CRS and
+stores project geometry in the usual AequilibraE CRS. If the SQLite export does
+not contain parseable CRS metadata, provide ``source_crs`` or explicitly accept
+the default CRS assumption.
+
+VISUM SQLite stores links and connectors as directed source rows. AequilibraE
+link rows use one modal set per row, so source links with different AB and BA
+transport-system sets are imported as two one-way rows. This preserves modal
+connectivity and avoids allowing, for example, private vehicles to use a public
+transport-only reverse direction.
+
+SQLite connector assignment fields use source ``T0_TSYS(...)`` values for the
+mapped transport systems. When VISUM stores an explicit zero connector time, the
+importer writes a positive epsilon cost and reports a diagnostic. This keeps
+instant centroid transfers usable in VISUM while avoiding zero-cost edges in
+AequilibraE graph construction.
+
+Use ``visum_sqlite_source_connectivity()`` to extract directed source arcs by
+mapped AequilibraE mode. This is useful when validating that a SQLite import, or
+an equivalent GeoJSON import, preserved the source modal graph. The helper
+compares connectivity only; impedance differences from GeoJSON fallback values
+or SQLite epsilon connector costs should be checked separately.
+
+Public-transport service tables, turn restrictions, detector data, and other
+recognized VISUM tables are reported as deferred scope. They are not imported by
+this private-traffic network endpoint.
+
+.. seealso::
+
+    * :func:`aequilibrae.project.network.network.Network.create_from_visum_sqlite`
+        Function documentation
+    * :func:`aequilibrae.project.network.visum_sqlite_importer.visum_sqlite_source_connectivity`
+        Source graph validation helper
+    * :ref:`import_from_visum_sqlite`
+        Usage example
+
 .. _aequilibrae_to_gmns:
 
 Exporting AequilibraE model to GMNS format

--- a/openspec/changes/add-assignment-demand-connectivity-warning/.openspec.yaml
+++ b/openspec/changes/add-assignment-demand-connectivity-warning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/add-assignment-demand-connectivity-warning/design.md
+++ b/openspec/changes/add-assignment-demand-connectivity-warning/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Traffic assignment currently validates matrix/graph centroid compatibility and graph fields, but it does not summarize
+how much positive demand cannot be loaded because the selected mode graph lacks a usable path. Imported multimodal
+projects can legitimately contain zones that are irrelevant for one mode, but they can also contain inconsistent OD
+demand and connectors that should be surfaced before users trust assignment results.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Warn assignment users when positive class demand is attached to centroids absent from the selected mode graph.
+- Warn assignment users when positive OD demand has no path through the selected mode graph.
+- Include aggregate demand totals, demand percentages, affected OD-pair counts, and bounded samples.
+- Keep default assignment execution non-blocking.
+
+**Non-Goals:**
+
+- Do not change VISUM, OSM, GMNS, or manual network import behavior.
+- Do not add a new project database table.
+- Do not make assignments fail by default.
+- Do not solve disconnected networks automatically by creating connectors or synthetic paths.
+
+## Decisions
+
+1. **Validate at assignment time**
+
+   The check belongs to `TrafficAssignment`/`TrafficClass`, because reachability depends on the selected graph mode,
+   matrix core, centroid blocking option, and current graph preparation. Importers cannot know which demand core and
+   mode will be assigned.
+
+2. **Warn by default, report structured details**
+
+   The default behavior should log warnings and expose structured validation details for programmatic access. This avoids
+   breaking existing partial-network workflows while making lost demand visible.
+
+3. **Separate missing-centroid demand from unreachable OD demand**
+
+   Missing graph centroids usually point to mode-disabled connectors or absent zones. Unreachable OD pairs indicate graph
+   disconnection, directionality, blocked centroid-through-flow behavior, or cost-field filtering. Reporting them
+   separately makes diagnostics actionable.
+
+4. **Bound expensive diagnostics**
+
+   The implementation should aggregate totals for all positive demand, but cap detailed OD samples. Large dense matrices
+   should not produce massive warning strings or result objects.
+
+## Risks / Trade-offs
+
+- **Large matrices can make full reachability checks expensive** -> Reuse graph/path connectivity primitives where
+  possible, skip zero-demand cells, and cap samples.
+- **Warnings may surprise users with intentionally partial assignments** -> Keep execution non-blocking and report
+  fractions so users can judge severity.
+- **Multiple classes and cores need clear attribution** -> Report results per traffic class and matrix core/computational
+  view.
+- **Centroid-through-flow settings affect reachability** -> Run validation against the graph as configured for the
+  assignment, including connector and centroid blocking behavior.

--- a/openspec/changes/add-assignment-demand-connectivity-warning/proposal.md
+++ b/openspec/changes/add-assignment-demand-connectivity-warning/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Traffic assignment can silently leave positive OD demand unloaded when centroids are missing from the selected mode graph
+or when no path exists between an origin and destination. This is easy to miss in large imported models, especially when
+the network and matrix contain zones for multiple modes.
+
+## What Changes
+
+- Add a warning-oriented demand/connectivity validation step for traffic assignment.
+- Detect positive demand attached to centroids that are absent from the selected graph, including missing mode-enabled
+  connector cases.
+- Detect positive OD demand for pairs with no path in the selected graph.
+- Report affected demand totals, percentage of class demand, affected OD-pair counts, and small origin/destination
+  samples.
+- Keep assignment execution warning-only by default; no breaking behavior change is proposed.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `traffic-assignment`: traffic assignment SHALL warn when configured demand cannot be assigned because of missing
+  graph centroids, connectors, or unreachable OD pairs.
+
+## Impact
+
+- Affected code: `aequilibrae/paths/traffic_assignment.py`, traffic-class execution setup, graph/path connectivity
+  utilities, and assignment tests.
+- Affected APIs: likely a public validation helper such as `TrafficAssignment.validate_demand_connectivity()` plus
+  automatic invocation before `execute()`.
+- No database schema changes are expected.
+- No Cython changes are required unless implementation chooses to reuse low-level path results for performance.

--- a/openspec/changes/add-assignment-demand-connectivity-warning/specs/traffic-assignment/spec.md
+++ b/openspec/changes/add-assignment-demand-connectivity-warning/specs/traffic-assignment/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Assignment warns about unassignable demand
+
+The system SHALL detect and warn when positive traffic-assignment demand cannot be assigned on the selected class graph
+because required centroids are absent from the graph or because no path exists for positive OD pairs.
+
+#### Scenario: Positive demand references centroids absent from the graph
+
+- **WHEN** a traffic class has positive productions or attractions for centroids that are not present in its selected graph
+- **THEN** the assignment validation SHALL report those centroids as missing from the graph
+- **AND** the report SHALL include the positive demand attached to those centroids
+- **AND** assignment execution SHALL warn by default without failing
+
+#### Scenario: Positive OD demand has no path
+
+- **WHEN** a traffic class has positive OD demand between centroids that are present in the graph but not mutually reachable
+- **THEN** the assignment validation SHALL report the unassignable OD demand
+- **AND** the report SHALL include total unassignable demand, percentage of class demand, affected OD-pair count, and bounded OD samples
+- **AND** assignment execution SHALL warn by default without failing
+
+#### Scenario: Missing graph centroids have zero demand
+
+- **WHEN** a graph contains configured centroids that are absent from the selected mode graph
+- **AND** the traffic class has zero production and attraction for those centroids
+- **THEN** the assignment validation SHALL NOT report demand loss for those centroids
+
+#### Scenario: Multiple traffic classes are validated independently
+
+- **WHEN** a traffic assignment contains multiple traffic classes
+- **THEN** demand-connectivity validation SHALL produce class-specific warnings and summaries
+- **AND** one class with unassignable demand SHALL NOT mask another class with fully assignable demand

--- a/openspec/changes/add-assignment-demand-connectivity-warning/tasks.md
+++ b/openspec/changes/add-assignment-demand-connectivity-warning/tasks.md
@@ -1,0 +1,36 @@
+## 1. Validation Report Shape
+
+- [ ] 1.1 Define the demand-connectivity validation return structure for per-class summaries.
+- [ ] 1.2 Include class name, matrix core names, total demand, unassignable demand, percentage, OD-pair count, and bounded samples.
+- [ ] 1.3 Distinguish missing-centroid demand from present-but-unreachable OD demand.
+
+## 2. Missing Centroid Demand Checks
+
+- [ ] 2.1 Detect centroids that are present in the matrix index but absent from the selected graph.
+- [ ] 2.2 Aggregate positive productions and attractions attached to missing graph centroids.
+- [ ] 2.3 Suppress demand-loss warnings for missing graph centroids with zero productions and attractions.
+- [ ] 2.4 Add tests for mode-disabled connector cases with and without positive demand.
+
+## 3. Reachability Checks
+
+- [ ] 3.1 Reuse existing graph/path connectivity primitives to test reachable destinations for positive-demand origins.
+- [ ] 3.2 Aggregate positive OD demand for OD pairs with no path.
+- [ ] 3.3 Respect the configured graph mode, time field, centroid-through-flow blocking, and connector availability.
+- [ ] 3.4 Add tests for disconnected components, one-way directionality, and connector-only failures.
+
+## 4. Assignment Integration
+
+- [ ] 4.1 Add a public validation helper, such as `TrafficAssignment.validate_demand_connectivity()`.
+- [ ] 4.2 Invoke validation automatically before assignment execution.
+- [ ] 4.3 Log warnings when any class has positive unassignable demand.
+- [ ] 4.4 Keep default behavior warning-only and preserve existing assignment execution behavior.
+- [ ] 4.5 Ensure multi-class assignments report class-specific validation summaries.
+
+## 5. Documentation And Verification
+
+- [ ] 5.1 Document the warning behavior in traffic assignment documentation.
+- [ ] 5.2 Add examples or notes explaining zero-demand missing centroids versus real demand loss.
+- [ ] 5.3 Run focused traffic assignment validation tests.
+- [ ] 5.4 Run existing traffic assignment tests.
+- [ ] 5.5 Run ruff on touched files.
+- [ ] 5.6 Run `openspec.cmd status --change add-assignment-demand-connectivity-warning` and resolve incomplete artifacts.

--- a/openspec/changes/add-project-matrix-file-import/.openspec.yaml
+++ b/openspec/changes/add-project-matrix-file-import/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/add-project-matrix-file-import/design.md
+++ b/openspec/changes/add-project-matrix-file-import/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`AequilibraeMatrix` already reads and writes OMX files through `openmatrix`, and `Matrices.new_record(...)` can register `.omx` or `.aem` files that already exist in a project's `matrices` folder. `Matrices.update_database()` can also discover unregistered files in that folder. Users with an external demand file currently need to manually copy it into the project folder and then call lower-level registration or discovery methods.
+
+The new endpoint belongs on the existing `Project.matrices` gateway because that gateway owns the project matrix folder, uniqueness checks, record creation, and matrix loading helpers.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide one public method to import a supported matrix file from outside the project into the project `matrices` folder.
+- Validate the source file and destination record before registration.
+- Reuse existing matrix loading and record creation behavior for core counting and database writes.
+- Keep behavior deterministic for default destination file names and matrix record names.
+
+**Non-Goals:**
+
+- Add a new OMX parser or change `AequilibraeMatrix` OMX semantics.
+- Convert imported OMX files to `.aem` by default.
+- Match matrix indices to project zones or assignment graphs during import.
+- Import VISUM proprietary matrix formats or automate assignment setup.
+
+## Decisions
+
+- Add `Matrices.import_file(path, name=None, file_name=None)` as the project-level endpoint. This keeps the API discoverable alongside `get_matrix`, `new_record`, and `update_database`.
+- Copy the source file into the project `matrices` folder and register the copied file. Registering external paths directly would break scenario copying and the existing project folder contract.
+- Accept only `.omx` and `.aem` files. This mirrors existing project registry behavior and avoids pretending CSV/trip-list import is the same capability.
+- Derive defaults from the source filename. If `name` is omitted, use the destination stem normalized with the same dot/space-to-underscore convention used by `update_database`; if `file_name` is omitted, use the source filename.
+- Validate the matrix by loading it before copying and again through `new_record` after copying. This reuses existing core-count behavior and catches unreadable files before committing a registry record.
+
+## Risks / Trade-offs
+
+- Duplicate large files increase disk usage -> importing into the project folder keeps scenarios and project archives self-contained.
+- The endpoint does not verify matrix indices against project zones -> assignment compatibility remains the caller's responsibility, consistent with existing matrix registration.
+- A failed registration after copying could leave an unregistered copied file -> remove the copied file on registration failure when the copied file was created by this endpoint.

--- a/openspec/changes/add-project-matrix-file-import/proposal.md
+++ b/openspec/changes/add-project-matrix-file-import/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Project users can load OMX files through `AequilibraeMatrix` and can register matrix files that are already inside the project `matrices` folder, but there is no direct project-level endpoint for importing an external matrix file. The VISUM GeoJSON workflow now produces project networks separately from demand, so users need a simple way to bring a matching OMX demand file into the project registry.
+
+## What Changes
+
+- Add a project matrix gateway endpoint for importing an existing external `.omx` or `.aem` file into a project's `matrices` folder.
+- Register the imported file in the project `matrices` table and return the resulting `MatrixRecord`.
+- Validate file type, source existence, destination/name uniqueness, and matrix readability before registration.
+- Preserve existing low-level `AequilibraeMatrix` OMX support and existing `new_record` / `update_database` behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `matrix-io`: add project-level matrix file import behavior for supported matrix files.
+
+## Impact
+
+- Affected API: `Project.matrices` gateway.
+- Affected code: `aequilibrae/project/data/matrices.py` and focused project matrix tests.
+- Affected docs/specs: matrix I/O OpenSpec delta and user-facing project component documentation if the endpoint is exposed publicly.
+- Dependencies: no new dependency; existing `openmatrix` support remains the OMX reader.

--- a/openspec/changes/add-project-matrix-file-import/specs/matrix-io/spec.md
+++ b/openspec/changes/add-project-matrix-file-import/specs/matrix-io/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Project matrix files can be imported
+The system SHALL provide a project matrix gateway endpoint that imports supported matrix files into the active project's matrix folder and registers them in the project matrix registry.
+
+#### Scenario: Importing an external OMX file
+- **WHEN** a user imports an existing external `.omx` matrix file through the project matrix gateway
+- **THEN** the system SHALL copy the file into the project's `matrices` folder
+- **AND** register a matrix record for the copied file
+- **AND** make the imported matrix available through the project matrices gateway
+
+#### Scenario: Importing an external native matrix file
+- **WHEN** a user imports an existing external `.aem` matrix file through the project matrix gateway
+- **THEN** the system SHALL copy the file into the project's `matrices` folder
+- **AND** register a matrix record for the copied file
+- **AND** make the imported matrix available through the project matrices gateway
+
+#### Scenario: Rejecting unsupported matrix file types
+- **WHEN** a user imports a file whose extension is not a supported project matrix format
+- **THEN** the system SHALL reject the import before copying or registering the file
+
+#### Scenario: Rejecting duplicate destination records
+- **WHEN** the requested matrix record name or destination file name conflicts with an existing project matrix
+- **THEN** the system SHALL reject the import before overwriting existing project matrix data

--- a/openspec/changes/add-project-matrix-file-import/tasks.md
+++ b/openspec/changes/add-project-matrix-file-import/tasks.md
@@ -1,0 +1,12 @@
+## 1. API Implementation
+
+- [x] 1.1 Add `Matrices.import_file(...)` to copy supported external `.omx` and `.aem` files into the project matrix folder.
+- [x] 1.2 Reuse existing matrix loading and `new_record(...)` registration to validate cores and create the project record.
+- [x] 1.3 Guard against unsupported extensions, missing sources, same-path imports, duplicate names, and duplicate destination file names.
+
+## 2. Tests And Documentation
+
+- [x] 2.1 Add focused project matrix tests for successful OMX import and registry access.
+- [x] 2.2 Add focused tests for duplicate/unsupported import failures.
+- [x] 2.3 Update project matrix documentation for the new import endpoint.
+- [x] 2.4 Run focused matrix project tests and OpenSpec status validation.

--- a/openspec/changes/add-visum-geojson-import-pipeline/.openspec.yaml
+++ b/openspec/changes/add-visum-geojson-import-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-27

--- a/openspec/changes/add-visum-geojson-import-pipeline/design.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/design.md
@@ -45,6 +45,41 @@ VISUM link layers include `FROMNODENO` and `TONODENO`, and connectors include `Z
 
 Alternative considered: spatially match endpoints to nearby nodes. This can hide model errors and would require tolerance decisions that vary by CRS and simulator export settings.
 
+### Preserve coincident VISUM nodes by offsetting, not merging
+
+Real VISUM models can contain multiple node records at the same physical coordinates when the records represent distinct
+modal or topological layers. For example, one coincident node can serve bus/train/tram links while another serves only
+rail-like links. AequilibraE's network triggers reject inserting two nodes at the same coordinates and AequilibraE does
+not currently model turn restrictions that would make an automatic merge safe in all cases.
+
+The importer will therefore preserve separate VISUM node IDs by default and apply a tiny deterministic coordinate offset
+to all but one node in each duplicate coordinate group. The original VISUM longitude/latitude and optional projected
+`XCOORD`/`YCOORD` values are preserved on the imported node, and diagnostics identify the duplicate group and offset.
+Imported link and connector geometries are rewritten at their endpoints to match the adjusted node geometry so the
+AequilibraE spatial triggers keep the intended source topology. Strict callers can request an error policy instead.
+
+Alternative considered: automatically merge coincident nodes. This was rejected as the default because it can create
+artificial connectivity across modal layers, especially while turn restrictions are outside the importer scope.
+
+### Preserve centroid node IDs when source node and zone IDs collide
+
+AequilibraE zoning and connector helpers commonly assume a zone centroid's `node_id` matches the corresponding
+`zone_id`. Real VISUM exports may still contain a regular node whose `NO` equals a zone centroid `NO`. In that case, the
+importer will keep the zone/centroid ID unchanged and remap the regular source node to a deterministic free AequilibraE
+node ID. Links and connectors are inserted through the source-to-imported node mapping, and `nodes.visum_node_no`
+preserves the original VISUM number.
+
+Alternative considered: remap centroid node IDs. This was rejected because it would break more existing AequilibraE
+assumptions around zone-centroid identity than remapping regular imported nodes.
+
+### Offset zone centroids when their coordinates collide
+
+VISUM zone centroids can share coordinates with regular network nodes. Because AequilibraE stores centroids in the same
+`nodes` table and rejects duplicate node geometries, the importer will offset the centroid node geometry when needed
+while keeping the zone ID as the centroid node ID. Connector geometries are rewritten to start from the adjusted centroid
+coordinate. Original VISUM centroid coordinates remain preserved on the centroid node for traceability and future
+geolocation/audit uses.
+
 ### Private-traffic first
 
 The first version will focus on private-traffic network import and assignment-ready fields. VISUM public transport concepts overlap only partially with AequilibraE's current GTFS/transit import model, so public transport should be studied and specified separately.

--- a/openspec/changes/add-visum-geojson-import-pipeline/design.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/design.md
@@ -1,0 +1,128 @@
+## Context
+
+AequilibraE currently supports OSM and GMNS network import, plus lower-level APIs that can populate links, nodes, zones, modes, and link types from custom layer-processing scripts. VISUM can export rich GeoJSON layer sets with explicit node IDs, link endpoint references, zone centroids, zone polygons, connectors, count locations, and simulator-specific fields. The sample VISUM GeoJSON files inspected during discovery contain exact link-to-node and connector-to-centroid topology, which means the importer can preserve simulator IDs instead of inferring topology spatially.
+
+The first version targets private-traffic model construction and assignment readiness from VISUM GeoJSON layers. OD matrix import is the next stage after the network importer is stable. Public transport layers, count-data calibration, and count-based OD adjustment are important but separate workflows.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a first-class VISUM GeoJSON import entry point under the project network API.
+- Read VISUM GeoJSON layers through GeoPandas/Shapely so geometry, CRS, tabular fields, and future GIS formats can be handled consistently.
+- Import private-traffic nodes, links, zone centroids, connectors, optional zone polygons, and VISUM link-count associations that can be connected to imported links.
+- Preserve VISUM source identifiers and selected metadata for traceability.
+- Use deterministic default mappings with user-overridable configuration for transport systems, link types, and assignment fields.
+- Produce validation diagnostics before and during import so users can resolve missing layers, unmapped values, invalid geometry, or non-assignment-ready attributes.
+- Keep imported private-traffic networks suitable for `Network.build_graphs()` and `TrafficAssignment` when required fields are present or derivable.
+
+**Non-Goals:**
+
+- Public transport import from VISUM routes, stops, stop points, or line routes.
+- GTFS conversion or integration.
+- OD matrix import in this change; it is the next planned stage after network import.
+- Count-based OD matrix estimation or correction.
+- Runtime GenAI-based field mapping in the importer.
+- Fuzzy topology construction by snapping nearby link endpoints.
+
+## Decisions
+
+### Use GeoPandas for ingestion, not a hand-rolled GeoJSON parser
+
+The importer will treat GeoJSON as the initial supported exchange format but should read layers through GeoPandas. GeoPandas is already a dependency and gives consistent access to Shapely geometry, CRS metadata, tabular fields, and reprojection. This also leaves room for future simulator exports in GeoPackage or similar GIS formats without redesigning the importer core.
+
+Alternative considered: parse GeoJSON directly with `json`. This is simpler for one file but would duplicate geometry, CRS, and data-frame logic already provided by the project stack.
+
+### Keep mapping deterministic and configurable
+
+The importer will ship deterministic VISUM defaults and accept a user-provided mapping configuration. Unknown transport systems, link classes, or required fields will produce validation errors or warnings according to the configured strictness. GenAI can be useful outside the core library to suggest a mapping file, but the importer itself must be reproducible, testable, offline, and auditable.
+
+Alternative considered: consult a GenAI service at import time. This was rejected for core behavior because it introduces network dependence, privacy concerns for proprietary models, and non-reproducible mappings.
+
+### Preserve source topology instead of snapping
+
+VISUM link layers include `FROMNODENO` and `TONODENO`, and connectors include `ZONENO` and `NODENO`. The importer will validate that referenced nodes and centroids exist and that geometries match their referenced endpoints where required. It will not create topology by snapping nearby endpoints in the first version.
+
+Alternative considered: spatially match endpoints to nearby nodes. This can hide model errors and would require tolerance decisions that vary by CRS and simulator export settings.
+
+### Private-traffic first
+
+The first version will focus on private-traffic network import and assignment-ready fields. VISUM public transport concepts overlap only partially with AequilibraE's current GTFS/transit import model, so public transport should be studied and specified separately.
+
+Alternative considered: import all VISUM layers in one change. This would mix private assignment, transit data modeling, and demand workflows into one large change with high schema and documentation risk.
+
+### HGV is preserved as a separate private mode by default
+
+VISUM `HGV` represents heavy goods vehicles. The default mapping will preserve it as a separate AequilibraE mode, expected to be `h`, rather than silently merging it into car mode `c`. Users may override the mapping to merge `HGV` into `c` when they want a single private-traffic class.
+
+Because AequilibraE link records can only reference existing single-character records in the `modes` table, the importer must create or validate the target mode before inserting any link that uses it. For the default HGV mapping, this means creating or validating mode `h` through the existing project network modes API, with a clear name such as `hgv` or `heavy_goods_vehicle`, before importing links or connectors containing `h`.
+
+Alternative considered: merge `HGV` into `c` by default. This was rejected because it loses truck-specific restrictions, PCE, costs, and future class behavior.
+
+### Zone centroids are operational; zone polygons are optional context
+
+Zone centroids are required for assignment because they become centroid nodes where demand enters and exits the network. Zone polygons provide spatial context, aggregation geometry, and support for connector generation, but they are not strictly required when centroids and connectors are already supplied. If connectors are missing, polygons become more valuable but still do not replace the need to connect centroids to the network.
+
+Alternative considered: require both zone centroid and zone polygon layers. This was rejected because VISUM exports can provide enough assignment topology through centroids plus connectors.
+
+### Link counts are the first supported traffic-data object
+
+VISUM count locations should not be modeled as source-shaped geometry tables. For the first private-traffic assignment workflow, the supported traffic-data object is a link count associated with an imported link. The sample VISUM `countlocation` layer contains link association fields (`LINKNO`, `FROMNODENO`, `TONODENO`), location fields (`XCOORD`, `YCOORD`), identity/classification fields (`NO`, `CODE`, `NAME`, `TYPE`, `TYPENO`), time-window fields (`DATE`, `FROM`, `TO`, `LENGTH`), and count-value candidates such as `CAR_ORIG`, `HVG_ORIG`, `MOTOR_ORIG`, and `DTVW`.
+
+The importer should treat observed link-count fields as candidates for validation and future calibration workflows, but it must not perform demand calibration or OD adjustment in this change. Turn-count-like fields in the sample (`CARS_LEFT`, `CARS_RIGHT`, `CARS_STRAIGHT`) and projected fields (`CARS_PROJ`, `HVG_PROJ`, `MOTOR_PROJ`) should be inventoried and reported, but durable support for turn counts, lane/detector counts, screenlines, speeds, routes, and travel-time observations is deferred.
+
+Alternative considered: add a generic VISUM count-location table immediately. This was rejected because count data sources vary widely and a source-shaped table could make future traffic-data workflows harder to generalize.
+
+### Support conventional folder input and explicit file mapping
+
+The public API should support folder-based import for conventional VISUM GeoJSON exports and explicit file mapping for custom names or partial exports. Folder mode should discover common names such as `node.geojson`, `link.geojson`, `connector.geojson`, and `zone_centroid.geojson`. Explicit mode should let users match arbitrary file paths to the layer type they provide.
+
+Alternative considered: require a fixed media folder or copy source files into the project by default. This is not needed for v1; diagnostics and source paths are enough unless later reproducibility requirements justify optional source-file archiving.
+
+Source-file paths will be used in diagnostics during import, but they will not be recorded durably or copied into a project media folder in v1.
+
+## Implementation Review Model
+
+Implementation should use focused reviewer roles before coding the importer body and again before marking the change complete. Draft reviewer charters live in `reviewers.md`.
+
+### VISUM semantics review
+
+The VISUM reviewer confirms the source-layer contract: required layers, field meanings, directional `R_*` semantics, transport-system values, link classifications, connector semantics, count-location references, and deferred public-transport layers. This review must produce or approve a field inventory and a mapping table before implementation depends on those assumptions.
+
+### AequilibraE integration review
+
+The AequilibraE reviewer confirms that API shape, schema choices, import ordering, source-ID preservation, triggers, modes, link types, zones, centroids, connectors, graph building, and assignment-ready fields remain compatible with existing project behavior. This review is mandatory before schema/migration work and before the importer writes records into the project database.
+
+### Traffic data and counts review
+
+The traffic-data reviewer confirms private-traffic assumptions, HGV/CAR handling, capacity source, speed and free-flow time derivation, directional missing-value behavior, connector mode policy, traffic-data object scope, count-location associations, and explicit deferral of ODME/count-based demand adjustment.
+
+### Review checkpoints
+
+- Checkpoint A: field inventory, mapping table, and open decisions are complete before importer behavior is implemented.
+- Checkpoint B: schema and link-count storage decisions are approved before SQL or migration changes are made.
+- Checkpoint C: importer diagnostics and validation severity levels are approved before public API behavior is stabilized.
+- Checkpoint D: graph-building and assignment-readiness tests pass before docs present the workflow as assignment-ready.
+- Checkpoint E: deferred public transport, OD matrix import, and count-based OD adjustment are documented and tested as out of scope.
+
+## Risks / Trade-offs
+
+- CRS ambiguity in VISUM GeoJSON exports -> require CRS configuration or explicit user acceptance when CRS metadata is absent; validate coordinate ranges where practical.
+- VISUM fields encode units in strings such as `0.548km` and `110km/h` -> centralize parsers for supported units and fail clearly on unknown unit formats.
+- Transport-system mapping can be agency/model specific -> provide deterministic defaults and require explicit overrides for ambiguous values.
+- HGV may be merged with car in some modeling practice -> preserve `HGV` as mode `h` by default, keep the mapping configurable, and document any merge override clearly in diagnostics.
+- Count locations may not fit an existing database table cleanly -> support only link-count associations in v1, report/defer other traffic-data objects, and avoid source-shaped VISUM tables.
+- Existing network triggers compute distances from geometry -> avoid fighting trigger-derived fields; preserve source lengths in separate fields when source values differ from geodesic length.
+- Large VISUM exports can be slow if inserted row-by-row -> prefer batch database operations where they preserve trigger behavior and transaction integrity.
+
+## Migration Plan
+
+No migration is required for existing projects unless implementation introduces new durable link-count or source-mapping tables. If schema is extended, add SQL specification, migration logic, and tests so older projects can be upgraded safely.
+
+The importer should only populate empty or explicitly targeted projects by default. Rollback for a failed import should be transaction-based where feasible; otherwise the importer must document partial-import behavior and provide enough diagnostics for cleanup.
+
+## Deferred Questions
+
+- Which non-required VISUM source fields should be preserved by default versus available only through optional field mapping?
+- Which traffic-data objects after link counts should be supported first: turn counts, detector/lane counts, screenlines, speeds, routes, travel times, or another observation type?
+- Which count-data fields and formats should be supported when the later count-data import/calibration stage is specified?

--- a/openspec/changes/add-visum-geojson-import-pipeline/field_inventory.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/field_inventory.md
@@ -1,0 +1,107 @@
+# VISUM GeoJSON Field Inventory
+
+No production VISUM sample files are currently checked into this repository. The inventory below is therefore based on
+the compact VISUM-like fixture contract used by this change and the field semantics captured in `design.md` and
+`reviewers.md`. If real agency VISUM exports are added later, this document should be refreshed from those files before
+changing importer defaults.
+
+## Layer Inventory
+
+### `node`
+
+| Field | Type | Nulls | Example values | Role |
+| --- | --- | --- | --- | --- |
+| `NO` | integer | 0 | `1`, `2` | Required source node ID |
+| `NAME` | text | optional | `Main`, `West` | Preserved-only metadata |
+| `geometry` | point | 0 | `POINT (-46.38 -23.55)` | Required node geometry |
+
+### `link`
+
+| Field | Type | Nulls | Example values | Role |
+| --- | --- | --- | --- | --- |
+| `NO` | integer | 0 | `100` | Required source link ID |
+| `FROMNODENO` | integer | 0 | `1` | Required AB endpoint reference |
+| `TONODENO` | integer | 0 | `2` | Required AB endpoint reference |
+| `TSYSSET` | text/list | directional | `CAR,HGV`, `CAR`, empty | Required AB transport systems when AB is available |
+| `R_TSYSSET` | text/list | directional | `CAR`, empty | Required BA transport systems when BA is available |
+| `TYPENO` | integer/text | optional | `1`, `10` | AB link-type mapping candidate |
+| `R_TYPENO` | integer/text | optional | `1`, `20` | BA link-type mapping candidate or diagnostic metadata |
+| `LC` | text/integer | optional | `ARTERIAL` | AB link class; primary default link-type mapping field |
+| `R_LC` | text/integer | optional | `LOCAL` | BA link class; diagnostic metadata unless split in a later version |
+| `LENGTH` | unit string/number | optional | `0.548km`, `548m` | AB source length |
+| `R_LENGTH` | unit string/number | optional | `0.550km` | BA source length |
+| `V0PRT` | unit string/number | optional | `50km/h` | AB free-flow speed |
+| `R_V0PRT` | unit string/number | optional | `45km/h` | BA free-flow speed |
+| `CAPPRT` | unit string/number | optional | `1200veh/h` | AB assignment capacity |
+| `R_CAPPRT` | unit string/number | optional | `1100veh/h` | BA assignment capacity |
+| `T0PRT` | unit string/number | optional | `0.75min` | AB free-flow travel time override |
+| `R_T0PRT` | unit string/number | optional | `0.8min` | BA free-flow travel time override |
+| `geometry` | linestring | 0 | `LINESTRING (...)` | Required link geometry |
+
+### `zone_centroid`
+
+| Field | Type | Nulls | Example values | Role |
+| --- | --- | --- | --- | --- |
+| `NO` | integer | 0 | `1001` | Required source zone/centroid ID |
+| `NAME` | text | optional | `CBD` | Zone name |
+| `geometry` | point | 0 | `POINT (...)` | Required centroid geometry |
+
+### `zone_polygon`
+
+| Field | Type | Nulls | Example values | Role |
+| --- | --- | --- | --- | --- |
+| `NO` | integer | 0 | `1001` | Optional zone ID matching `zone_centroid.NO` |
+| `NAME` | text | optional | `CBD` | Zone name |
+| `geometry` | polygon/multipolygon | optional | `POLYGON (...)` | Optional context zone geometry |
+
+### `connector`
+
+| Field | Type | Nulls | Example values | Role |
+| --- | --- | --- | --- | --- |
+| `NO` | integer | 0 | `9001` | Required source connector ID |
+| `ZONENO` | integer | 0 | `1001` | Required zone centroid reference |
+| `NODENO` | integer | 0 | `1` | Required network node reference |
+| `TSYSSET` | text/list | directional | `CAR,HGV` | Connector private modes |
+| `R_TSYSSET` | text/list | optional | `CAR,HGV`, empty | Reverse connector modes |
+| `LENGTH` | unit string/number | optional | `120m` | Source connector length |
+| `V0PRT` | unit string/number | optional | `30km/h` | Source connector speed |
+| `CAPPRT` | unit string/number | optional | `9999veh/h` | Source connector capacity |
+| `geometry` | linestring | 0 | `LINESTRING (...)` | Required centroid-to-node geometry |
+
+### `countlocation`
+
+| Field | Type | Nulls | Example values | Role |
+| --- | --- | --- | --- | --- |
+| `NO` | integer | 0 | `5001` | Count-location source ID |
+| `LINKNO` | integer | optional | `100` | Supported link-count association |
+| `FROMNODENO` | integer | optional | `1` | Direction/reference validation |
+| `TONODENO` | integer | optional | `2` | Direction/reference validation |
+| `CAR_ORIG` | numeric | optional | `950` | Observed car count candidate |
+| `HVG_ORIG` | numeric | optional | `120` | Observed heavy-vehicle count candidate |
+| `MOTOR_ORIG` | numeric | optional | `1070` | Observed motorized count candidate |
+| `DTVW` | numeric | optional | `1300` | Daily/period count candidate |
+| `CARS_LEFT`, `CARS_RIGHT`, `CARS_STRAIGHT` | numeric | optional | `10` | Deferred turn-count candidates |
+| `CARS_PROJ`, `HVG_PROJ`, `MOTOR_PROJ` | numeric | optional | `1000` | Deferred projected count values |
+| `geometry` | point | optional | `POINT (...)` | Diagnostic location |
+
+## Directional Semantics
+
+`TSYSSET`, `TYPENO`, `LC`, `LENGTH`, `V0PRT`, `CAPPRT`, and `T0PRT` describe the AB direction from
+`FROMNODENO` to `TONODENO`. Their `R_*` counterparts describe the BA direction and SHALL NOT be copied from the AB
+fields when missing. Empty `TSYSSET` or `R_TSYSSET` means that direction is unavailable for private-traffic import.
+
+`TYPENO` and `LC` are mapping candidates. The default mapping uses `LC` first, then `TYPENO`, and preserves the original
+values in diagnostics. `R_TYPENO` and `R_LC` are recognized as reverse-direction metadata; v1 does not split one VISUM
+link into two AequilibraE links solely because the reverse class differs.
+
+## Deferred Layers
+
+Known public-transport and context layers such as `stop`, `stoppoint`, `stop_point`, `lineroute`, `line_route`,
+`ptline`, and OD matrix files are recognized and reported as deferred. They are not imported into private-traffic
+network tables in v1.
+
+## Checkpoint A, VISUM Semantics
+
+Checkpoint A is approved for implementation against the compact fixture contract above. The main implementation risk is
+that real VISUM exports may include agency-specific field aliases or units; those should be handled through explicit
+mapping overrides rather than runtime inference.

--- a/openspec/changes/add-visum-geojson-import-pipeline/field_inventory.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/field_inventory.md
@@ -58,9 +58,11 @@ changing importer defaults.
 
 | Field | Type | Nulls | Example values | Role |
 | --- | --- | --- | --- | --- |
-| `NO` | integer | 0 | `9001` | Required source connector ID |
+| `NO` | integer | optional | `9001` | Optional source connector ID |
 | `ZONENO` | integer | 0 | `1001` | Required zone centroid reference |
 | `NODENO` | integer | 0 | `1` | Required network node reference |
+| `DIRECTION` | text | optional | `O` | Forward connector direction marker |
+| `R_DIRECTION` | text | optional | `D` | Reverse connector direction marker |
 | `TSYSSET` | text/list | directional | `CAR,HGV` | Connector private modes |
 | `R_TSYSSET` | text/list | optional | `CAR,HGV`, empty | Reverse connector modes |
 | `LENGTH` | unit string/number | optional | `120m` | Source connector length |

--- a/openspec/changes/add-visum-geojson-import-pipeline/implementation_notes.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/implementation_notes.md
@@ -137,3 +137,49 @@ zone IDs as centroid node IDs, remaps only the conflicting regular node IDs, pre
 The following Karlsruhe smoke check then exposed zone centroid coordinates that collide with regular network node
 coordinates. The importer now offsets such centroid node geometries, preserves original VISUM centroid coordinates, and
 rewrites connector starts to the adjusted centroid coordinates.
+
+## Compact Imported Link IDs
+
+VISUM source link numbers in the Karlsruhe export are sparse and high-valued, with source IDs above two billion. The
+graph compression path allocates by maximum `link_id`, so the importer now assigns compact AequilibraE `links.link_id`
+values and preserves source IDs in `links.visum_link_no`, `links.visum_connector_no`, `links.visum_connector_key`, and
+`report.source_references`.
+
+The Karlsruhe project was regenerated from the local Downloads VISUM folder with explicit mappings
+`CAR -> c`, `HGV -> h`, `BIKE -> b`, `WALK -> w`, and `BUS`/`PUTW`/`TRAIN`/`TRAM -> t`, then
+`Visum_3_modes.omx` was imported as `visum_3_modes`.
+
+Verification:
+
+- `python -m pytest tests/aeq/project/test_network_visum_geojson.py -q --basetemp C:/tmp/aequilibrae/.pytest-tmp-visum`
+  passed with 26 tests and one opt-in external test skipped.
+- `python -m pytest tests/aeq/project/test_matrices.py -q` passed with 13 tests.
+- `ruff check aequilibrae/project/network/visum_geojson_importer.py tests/aeq/project/test_network_visum_geojson.py aequilibrae/project/data/matrices.py tests/aeq/project/test_matrices.py` passed.
+- Regenerated Karlsruhe `links.link_id` values are compact from 1 through 13,723 while `visum_link_no` still preserves
+  source IDs up to 2,030,064,882.
+- `Visum_3_modes.omx` contains cores `Car`, `HVG`, and `PUT`; its `NO` mapping matches all 726 zones and centroid nodes.
+
+## Connector Assignment Defaults
+
+The Karlsruhe GeoJSON and Shapefile connector exports omit connector travel-time fields. A VISUM SQLite export inspected
+later showed richer connector columns such as `T0_TSYS(CAR)`, so a future SQLite importer should prefer those source
+values when available. For GeoJSON, the importer now defaults connector assignment values only when a connector has
+usable imported modes but lacks positive assignment fields: connector travel time is derived from connector length using
+a deterministic 30 km/h fallback speed, missing/zero length can be derived from connector geometry, and capacity defaults
+to 99,999. Each default emits structured diagnostics.
+
+The graph builder also now prevents links excluded from a requested mode from poisoning that mode's compressed graph with
+missing numeric fields while those excluded rows are being converted to self-loops.
+
+Post-default verification:
+
+- `python -m pytest tests/aeq/project/test_network_visum_geojson.py::test_connector_assignment_fields_default_when_not_exported tests/aeq/project/test_network_visum_geojson.py::test_mode_excluded_missing_fields_do_not_poison_car_graph -q --basetemp C:/tmp/aequilibrae/.pytest-tmp-visum-new` passed.
+- `ruff check aequilibrae/project/network/visum_geojson_importer.py aequilibrae/project/network/network.py tests/aeq/project/test_network_visum_geojson.py` passed.
+- Regenerated Karlsruhe from `C:\Users\Pablo Barceló\Downloads\Karlsruhe`, imported 8,432 nodes, 726 zones, 10,902 links,
+  2,821 connectors, and imported `Visum_3_modes.omx` as `visum_3_modes`.
+- The regenerated car graph has 8,367 compressed nodes, 726 zones, 25,041 directed graph rows, zero NaN `travel_time`
+  values, zero NaN `capacity` values, minimum travel time 0.0013561301794359395, and minimum capacity 1.0.
+- A 5-iteration MSA traffic assignment using the `Car` matrix core completed and returned 13,723 result rows with
+  `Car_tot` sum 35,805,710.82760005.
+- The car graph still warns that 28 centroids (`2000115` through `2000142`) are not present in the compressed graph.
+  Assignment completes, but those zones should be reviewed against VISUM connectivity if exact demand coverage is needed.

--- a/openspec/changes/add-visum-geojson-import-pipeline/implementation_notes.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/implementation_notes.md
@@ -1,0 +1,68 @@
+# Implementation Notes
+
+## Reviewer Assignments
+
+The reviewer charters in `reviewers.md` are sufficient for this change. They cover the three review areas needed before
+and during implementation:
+
+- VISUM semantics: source-layer fields, directional values, topology references, mappings, and deferred VISUM scope.
+- AequilibraE integration: public API shape, network tables, triggers, zones, centroids, graph building, assignment
+  readiness, and schema/migration risk.
+- Traffic data and counts: private-traffic assumptions, HGV/CAR handling, assignment fields, link-count associations,
+  and explicit deferral of demand adjustment.
+
+Reviewer roles will be fulfilled by the main implementer with explicit review notes because no human or delegated
+subagent reviewers have been assigned for this implementation pass. Each checkpoint below must be recorded here before
+the corresponding task is marked complete.
+
+## Review Checkpoints
+
+- Checkpoint A, VISUM semantics: complete after the field inventory and mapping assumptions are documented.
+- Checkpoint A, mapping contract: complete after API shape, diagnostics, mode mapping, link-type mapping, assignment
+  fields, source-ID storage, and validation severity are documented.
+- Checkpoint B: complete before adding schema-backed durable source mapping or count-location storage.
+- Checkpoint C: complete after reader diagnostics, validation severity, and public API behavior are implemented.
+- Checkpoint D: complete after imported VISUM-like fixtures build graphs and pass assignment-readiness checks.
+- Checkpoint E: complete after docs and tests explicitly defer public transport, OD matrix import, and count-based demand
+  adjustment.
+
+## Frontend/UI Scope
+
+This repository contains the Python package and Sphinx documentation, but not the interactive AequilibraE/QGIS frontend
+where file-menu import wiring would normally live. Task 9.1 is therefore scoped to documenting the API and noting that
+interactive UI wiring belongs in the adjacent frontend/plugin repository unless such frontend code is later added here.
+
+## Sample Layer Source
+
+No production VISUM GeoJSON files are checked into this repository. Source inventory and tests for this implementation
+use compact VISUM-like fixtures that intentionally cover the required fields, directional `R_*` values, CRS cases,
+topology references, count-location associations, and deferred public-transport/context layers.
+
+## Checkpoint C
+
+Checkpoint C is approved for the implemented diagnostics and validation behavior. The importer returns structured
+diagnostics with severity, code, layer, field, and source-record references; validation errors stop the import before
+database writes; non-assignment-ready records are warnings when graph construction can still proceed.
+
+## Checkpoint D
+
+Checkpoint D is approved for the compact VISUM-like fixture coverage. Tests build an AequilibraE graph for mode `c`,
+verify centroids/connectors, and exercise `TrafficAssignment.set_time_field(...)` and
+`TrafficAssignment.set_capacity_field(...)` against imported assignment fields.
+
+## Checkpoint E
+
+Checkpoint E is approved for the documented v1 scope. Public transport layers, OD matrix import, and count-based demand
+adjustment are recognized as deferred and are not imported or executed by this private-traffic network pipeline.
+
+## Verification Notes
+
+- `python -m compileall aequilibrae/project/network/visum_geojson_importer.py aequilibrae/project/network/network.py tests/aeq/project/test_network_visum_geojson.py docs/source/examples/network_manipulation/plot_create_from_visum_geojson.py` passed.
+- `ruff check aequilibrae/` passed.
+- `uv pip install -e ".[dev]" --system` passed after running through the Visual Studio Build Tools developer command
+  environment.
+- `python -m pytest tests/aeq/project/test_network_visum_geojson.py -q --basetemp C:/tmp/aequilibrae/.pytest-tmp-visum`
+  passed with 13 tests.
+- `python docs/source/examples/network_manipulation/plot_create_from_visum_geojson.py` passed.
+- No SQL schema, migration, table-list, trigger-list, or durable count/source-mapping table artifacts were added, so the
+  migration/schema verification task is not applicable for this implementation slice.

--- a/openspec/changes/add-visum-geojson-import-pipeline/implementation_notes.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/implementation_notes.md
@@ -66,3 +66,74 @@ adjustment are recognized as deferred and are not imported or executed by this p
 - `python docs/source/examples/network_manipulation/plot_create_from_visum_geojson.py` passed.
 - No SQL schema, migration, table-list, trigger-list, or durable count/source-mapping table artifacts were added, so the
   migration/schema verification task is not applicable for this implementation slice.
+
+## Post-Review Connector Compatibility
+
+Real VISUM GeoJSON connector exports may omit a numeric connector `NO` property and instead expose topology through
+`ZONENO`, `NODENO`, `DIRECTION`, and `R_DIRECTION`, with a vendor-specific feature ID. The importer now treats connector
+`NO` as optional, keeps `visum_connector_no` only when numeric source values are present, and stores a deterministic
+`visum_connector_key` derived from zone, node, and usable mapped direction. Duplicate generated keys receive stable
+numeric suffixes.
+
+Post-review verification:
+
+- `python -m pytest tests/aeq/project/test_network_visum_geojson.py -q --basetemp C:/tmp/aequilibrae/.pytest-tmp-visum`
+  passed with 15 tests and 1 skipped opt-in external-data test.
+- `ruff check aequilibrae/project/network/visum_geojson_importer.py tests/aeq/project/test_network_visum_geojson.py tests/conftest.py`
+  passed.
+- `python -m compileall aequilibrae/project/network/visum_geojson_importer.py tests/aeq/project/test_network_visum_geojson.py`
+  passed.
+- The opt-in external-data smoke test for `C:\Users\Pablo Barceló\Downloads` progressed past connector source-ID
+  handling and now fails on unmapped transport systems such as `BUS`, `TRAIN`, and `TRAM`, which is a separate
+  mode-filtering/mapping decision.
+
+## Post-Review Transport-System Mapping Policy
+
+VISUM transport systems outside the default `CAR -> c` and `HGV -> h` mapping now require an explicit caller decision:
+they must be included in `mode_mapping` or listed in `ignored_transport_systems`. Explicitly ignored transport systems
+are reported with diagnostics. Records whose declared transport systems are all ignored, or whose transport systems are
+empty in both directions, are skipped and reported rather than imported with an empty AequilibraE `modes` value.
+
+Post-review verification:
+
+- `python -m pytest tests/aeq/project/test_network_visum_geojson.py -q --basetemp C:/tmp/aequilibrae/.pytest-tmp-visum`
+  passed with 20 tests and 1 skipped opt-in external-data test.
+- `ruff check aequilibrae/project/network/visum_geojson_importer.py aequilibrae/project/network/network.py tests/aeq/project/test_network_visum_geojson.py tests/conftest.py`
+  passed.
+- A real-folder import using `ignored_transport_systems={'BUS', 'TRAIN', 'TRAM', 'BIKE', 'WALK', 'PUTW'}` progressed
+  past transport-system validation and then failed on a separate link-type uniqueness collision in the real VISUM link
+  classes.
+
+## Post-Review Numeric Link-Type Naming
+
+Real VISUM exports can include numeric `TYPENO` fallback values when `LC` is missing. AequilibraE link-type names only
+allow letters and underscores, so numeric source values are now encoded as words in generated names. For example,
+`TYPENO=2` becomes `visum_two` and `TYPENO=92` becomes `visum_nine_two`, avoiding collisions while satisfying the
+existing link-type API contract.
+
+Post-review verification:
+
+- `python -m pytest tests/aeq/project/test_network_visum_geojson.py -q --basetemp C:/tmp/aequilibrae/.pytest-tmp-visum`
+  passed with 21 tests and 1 skipped opt-in external-data test.
+- `ruff check aequilibrae/project/network/visum_geojson_importer.py aequilibrae/project/network/network.py tests/aeq/project/test_network_visum_geojson.py tests/conftest.py`
+  passed.
+- A real-folder import using `ignored_transport_systems={'BUS', 'TRAIN', 'TRAM', 'BIKE', 'WALK', 'PUTW'}` progressed
+  past link-type creation and now fails on a separate node integrity trigger: duplicate/on-top node geometries in the
+  source `node.geojson`.
+
+## Post-Review Coincident Node Compatibility
+
+The Karlsruhe VISUM export includes coincident nodes that encode separate modal/topological layers rather than duplicate
+data. AequilibraE rejects exact duplicate node coordinates, and merging these source nodes could create artificial
+connectivity while turn restrictions remain outside scope. The importer now preserves distinct source node IDs by
+default with `duplicate_node_policy="offset"`, stores original VISUM coordinates, rewrites imported link/connector
+endpoints to the adjusted coordinates, and reports duplicate coordinate groups. Callers can use
+`duplicate_node_policy="error"` to retain strict rejection behavior.
+
+The same Karlsruhe smoke check then exposed regular node IDs that collide with zone centroid IDs. The importer now keeps
+zone IDs as centroid node IDs, remaps only the conflicting regular node IDs, preserves `visum_node_no`, reports
+`node-id-remapped`, and inserts links/connectors through the source-to-imported node mapping.
+
+The following Karlsruhe smoke check then exposed zone centroid coordinates that collide with regular network node
+coordinates. The importer now offsets such centroid node geometries, preserves original VISUM centroid coordinates, and
+rewrites connector starts to the adjusted centroid coordinates.

--- a/openspec/changes/add-visum-geojson-import-pipeline/mapping_contract.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/mapping_contract.md
@@ -77,6 +77,11 @@ Assignment fields:
 - capacity is stored as vehicles per hour in `capacity_ab` and `capacity_ba`;
 - free-flow time is stored in minutes in `travel_time_ab` and `travel_time_ba`;
 - if explicit VISUM time is missing, free-flow time is derived from parsed source length and speed;
+- if connector time and speed are missing but connector length is available, connector free-flow time is derived from
+  length using a deterministic 30 km/h fallback connector speed;
+- if connector length is missing or non-positive, fallback connector time derivation uses geodesic geometry length;
+- if connector capacity is missing, connector capacity is set to a deterministic high value of 99,999;
+- connector fallback assignment values are reported with diagnostics;
 - geometry-derived AequilibraE `distance` remains trigger-owned;
 - parsed VISUM source length is preserved in `visum_length_ab` and `visum_length_ba` when present.
 
@@ -101,6 +106,11 @@ Source identifiers are preserved in importer-added core-table columns:
 
 The AequilibraE `nodes.node_id` value may differ from `nodes.visum_node_no` when the source node number collides with a
 zone centroid node ID.
+
+The AequilibraE `links.link_id` value is a compact internal identifier assigned during import. It SHALL NOT reuse VISUM
+link or connector identifiers when those source identifiers are sparse or high-valued. VISUM source link numbers are
+preserved in `links.visum_link_no`, connector source values are preserved in `links.visum_connector_no` or
+`links.visum_connector_key`, and `report.source_references` maps source identifiers to imported compact link IDs.
 
 Centroid nodes can also use `visum_original_lon`, `visum_original_lat`, `visum_xcoord`, `visum_ycoord`,
 `visum_duplicate_coord_group`, and `visum_coord_offset_m` when a VISUM zone centroid coordinate is offset.

--- a/openspec/changes/add-visum-geojson-import-pipeline/mapping_contract.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/mapping_contract.md
@@ -1,0 +1,93 @@
+# VISUM GeoJSON Mapping Contract
+
+## Public API
+
+The public network API is `Project.network.create_from_visum_geojson(...)`.
+
+Accepted inputs:
+
+- A folder path containing conventional layer names such as `node.geojson`, `link.geojson`, `connector.geojson`,
+  `zone_centroid.geojson`, optional `zone_polygon.geojson`, and optional `countlocation.geojson`.
+- An explicit mapping of importer layer names to file paths for custom names or partial exports.
+
+The importer requires an empty network by default. Importing into a non-empty project is allowed only when the caller
+passes an explicit override; this protects users from accidentally blending two network sources.
+
+## Diagnostics
+
+The importer returns a report object with:
+
+- diagnostics containing severity, code, message, layer, field, and optional source record ID;
+- discovered layer paths;
+- deferred layer names;
+- field inventory;
+- mapping choices for modes and link types;
+- imported row counts;
+- source-to-imported-ID references for nodes, links, zones, connectors, and count associations;
+- CRS assumptions and reprojection choices.
+
+Severity levels:
+
+- `error`: missing required layers, unresolved topology references, unmapped required modes/link types, invalid CRS
+  handling, invalid geometry, or assignment-required fields that cannot be parsed in strict mode.
+- `warning`: missing optional layers, CRS default accepted by the user, deferred layers, deferred count fields, or
+  records that can build graphs but are not assignment-ready.
+- `info`: discovered layers, mapping choices, imported row counts, and explicit out-of-scope behavior.
+
+## Default Mappings
+
+Transport systems:
+
+- `CAR -> c`
+- `HGV -> h`
+
+Users may override `HGV -> c` to merge heavy goods vehicles into car mode. Every mapped mode ID must be a single
+character and must be created or already valid before links or connectors are inserted.
+
+Link types:
+
+- default class/type values map deterministically to AequilibraE link-type records;
+- `LC` is preferred over `TYPENO` for default classification;
+- values that exceed configured IDs receive deterministic fallback IDs from unused ASCII letters;
+- if no unused ID exists, import fails with an error diagnostic.
+
+Assignment fields:
+
+- speed is stored as km/h in `speed_ab` and `speed_ba`;
+- capacity is stored as vehicles per hour in `capacity_ab` and `capacity_ba`;
+- free-flow time is stored in minutes in `travel_time_ab` and `travel_time_ba`;
+- if explicit VISUM time is missing, free-flow time is derived from parsed source length and speed;
+- geometry-derived AequilibraE `distance` remains trigger-owned;
+- parsed VISUM source length is preserved in `visum_length_ab` and `visum_length_ba` when present.
+
+## Source Metadata
+
+Source identifiers are preserved in importer-added core-table columns:
+
+- `nodes.visum_node_no`
+- `nodes.visum_zone_no`
+- `links.visum_link_no`
+- `links.visum_connector_no`
+- `links.visum_length_ab`
+- `links.visum_length_ba`
+- `zones.visum_zone_no`
+
+Supported count-location associations are reported in diagnostics and source-reference maps in v1. No new durable
+count-location or generic source-mapping table is required for this change, so no SQL schema or migration artifact is
+needed.
+
+## Count Locations
+
+`countlocation` is the first recognized traffic-data input. Supported link-count associations use `LINKNO` with optional
+`FROMNODENO` and `TONODENO` checks. Observed fields such as `CAR_ORIG`, `HVG_ORIG`, `MOTOR_ORIG`, and `DTVW` are
+reported as count candidates. Turn counts, projected values, detector/lane counts, screenlines, speeds, routes, and
+travel-time observations are deferred.
+
+Count locations SHALL NOT modify OD matrices, perform demand adjustment, trigger ODME, or calibrate assignment demand in
+this import pipeline.
+
+## Checkpoints
+
+Checkpoint A is approved for the mapping contract above.
+Checkpoint B is approved with the decision to avoid new schema/migration artifacts and to use importer-added core-table
+columns plus diagnostics for v1 count associations.

--- a/openspec/changes/add-visum-geojson-import-pipeline/mapping_contract.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/mapping_contract.md
@@ -13,6 +13,18 @@ Accepted inputs:
 The importer requires an empty network by default. Importing into a non-empty project is allowed only when the caller
 passes an explicit override; this protects users from accidentally blending two network sources.
 
+Coincident VISUM node coordinates are handled with `duplicate_node_policy`. The default policy, `offset`, preserves
+separate source nodes by applying a tiny deterministic coordinate offset and preserving the original VISUM coordinates.
+The strict policy, `error`, rejects coincident source nodes before project database writes.
+
+VISUM regular node `NO` values are used as AequilibraE node IDs when possible. If a regular node `NO` collides with a
+zone centroid `NO`, the importer keeps the zone ID as the centroid node ID and remaps the regular node to a deterministic
+free AequilibraE node ID. The returned `source_references["nodes"]` mapping records the source-to-imported ID relation.
+
+VISUM zone centroid coordinates are also disambiguated when they collide with already imported node coordinates. The
+zone ID remains the centroid node ID, connector geometries are adjusted to start at the imported centroid coordinate, and
+the original VISUM centroid coordinates are preserved on the centroid node.
+
 ## Diagnostics
 
 The importer returns a report object with:
@@ -44,10 +56,18 @@ Transport systems:
 Users may override `HGV -> c` to merge heavy goods vehicles into car mode. Every mapped mode ID must be a single
 character and must be created or already valid before links or connectors are inserted.
 
+Any VISUM transport system outside the configured mapping must be explicitly mapped or explicitly listed in
+`ignored_transport_systems`. The importer SHALL fail before database writes when extra transport systems are neither
+mapped nor ignored. Records whose available transport systems are all explicitly ignored SHALL be skipped and reported.
+Records with no declared transport systems in either direction SHALL also be skipped and reported because they cannot
+produce an AequilibraE mode string. This keeps simple `CAR`/`HGV` networks automatic while forcing richer VISUM exports
+to receive a deliberate modeling decision.
+
 Link types:
 
 - default class/type values map deterministically to AequilibraE link-type records;
 - `LC` is preferred over `TYPENO` for default classification;
+- numeric `TYPENO` fallback values generate distinct valid names such as `visum_two` and `visum_nine_two`;
 - values that exceed configured IDs receive deterministic fallback IDs from unused ASCII letters;
 - if no unused ID exists, import fails with an error diagnostic.
 
@@ -66,11 +86,28 @@ Source identifiers are preserved in importer-added core-table columns:
 
 - `nodes.visum_node_no`
 - `nodes.visum_zone_no`
+- `nodes.visum_original_lon`
+- `nodes.visum_original_lat`
+- `nodes.visum_xcoord`, when the source node layer provides projected `XCOORD`
+- `nodes.visum_ycoord`, when the source node layer provides projected `YCOORD`
+- `nodes.visum_duplicate_coord_group`, when a source node belongs to a duplicate coordinate group
+- `nodes.visum_coord_offset_m`, the approximate offset applied during import
 - `links.visum_link_no`
-- `links.visum_connector_no`
+- `links.visum_connector_no`, when the source connector layer provides a numeric `NO`
+- `links.visum_connector_key`, generated deterministically from connector zone, node, and usable direction
 - `links.visum_length_ab`
 - `links.visum_length_ba`
 - `zones.visum_zone_no`
+
+The AequilibraE `nodes.node_id` value may differ from `nodes.visum_node_no` when the source node number collides with a
+zone centroid node ID.
+
+Centroid nodes can also use `visum_original_lon`, `visum_original_lat`, `visum_xcoord`, `visum_ycoord`,
+`visum_duplicate_coord_group`, and `visum_coord_offset_m` when a VISUM zone centroid coordinate is offset.
+
+Connector keys use `connector:{ZONENO}:{NODENO}:{direction}`, where `direction` is `B`, `O`, or `D` according to mapped
+mode availability in the forward and reverse connector fields. If multiple connector records produce the same key, the
+importer appends a stable numeric suffix such as `:2`.
 
 Supported count-location associations are reported in diagnostics and source-reference maps in v1. No new durable
 count-location or generic source-mapping table is required for this change, so no SQL schema or migration artifact is

--- a/openspec/changes/add-visum-geojson-import-pipeline/proposal.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+AequilibraE can import networks from OSM, GMNS, and manual link-layer workflows, but it does not provide a first-class path for importing rich simulator exports such as PTV VISUM GeoJSON layers. Supporting this workflow would make AequilibraE easier to use with established planning models while preserving enough source metadata to validate, assign, and later calibrate imported models.
+
+## What Changes
+
+- Add a VISUM GeoJSON import pipeline for private-traffic network construction.
+- Expose the importer through the existing user interface where network imports are initiated, such as a File menu or equivalent import action.
+- Import and validate VISUM node, link, zone centroid, connector, optional zone polygon, and supported count-location information.
+- Map VISUM transport systems, link classes, directions, capacities, speeds, and lengths into AequilibraE network fields using deterministic defaults and user-overridable mapping configuration.
+- Preserve relevant VISUM source identifiers and metadata so imported AequilibraE records remain traceable to source layers.
+- Create assignment-ready graph fields for private traffic when required source values are available.
+- Analyze count-location information against AequilibraE traffic-data needs and preserve supported network associations where possible.
+- Defer public transport import, OD matrix import, count-data calibration, and count-based OD adjustment to later changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `visum-geojson-import`: VISUM GeoJSON layer discovery, validation, mapping, import behavior, source metadata preservation, and count-location import.
+
+### Modified Capabilities
+
+- `network-datamodel`: Network import/export boundaries expand to include VISUM GeoJSON private-traffic network import.
+- `documentation-and-examples`: User-facing documentation and examples must describe the VISUM GeoJSON import workflow.
+
+## Impact
+
+- Adds a public import entry point under the project network API, likely `Project.network.create_from_visum_geojson(...)` or an equivalent named method.
+- Adds or updates UI wiring so users can launch the VISUM GeoJSON import workflow from the existing frontend.
+- Uses existing GeoPandas/Shapely/PyProj dependencies for reading, validating, and transforming geospatial layers.
+- Touches network table population, mode/link-type creation or validation, zone/centroid handling, connector import, and possibly database schema if supported traffic-data/count-location associations need durable storage.
+- Adds tests using compact VISUM-like GeoJSON fixtures covering topology, mappings, assignment fields, connectors, zones, and count locations.
+- Adds Sphinx documentation and examples for private-traffic import and known deferred VISUM features.

--- a/openspec/changes/add-visum-geojson-import-pipeline/reviewers.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/reviewers.md
@@ -1,0 +1,137 @@
+# Reviewer Subagent Drafts
+
+These reviewer roles are intended for implementation planning and review. They do not replace the main implementer; they provide focused domain checks before and during coding.
+
+## VISUM Semantics Reviewer
+
+### Responsibilities
+
+- Interpret PTV VISUM GeoJSON layer semantics before importer implementation begins.
+- Confirm which VISUM fields are required, optional, directional, derived, preserved-only, or deferred for private-traffic import.
+- Review default mappings from VISUM concepts to AequilibraE concepts, especially transport systems, link types, directions, capacities, speeds, lengths, zones, connectors, and supported count-location associations.
+- Identify VISUM public-transport fields and layers that must be explicitly deferred rather than partially or incorrectly imported.
+- Ensure importer diagnostics describe VISUM-specific problems in terms a transport modeler can understand.
+
+### Required Inputs
+
+- Sample VISUM GeoJSON files: `node.geojson`, `link.geojson`, `connector.geojson`, `zone_centroid.geojson`, `zone_polygon.geojson`, and `countlocation.geojson`.
+- Deferred context layers when available: `stop.geojson`, `stoppoint.geojson`, and `lineroute.geojson`.
+- Field inventory for each layer, including data types, null counts, unique categorical values, and example values.
+- Known VISUM export assumptions: CRS, units, directional-field meaning, and intended private-traffic transport systems.
+- Draft AequilibraE mapping configuration.
+
+### Questions Before Coding
+
+- Which VISUM layers are mandatory for v1 private-traffic import?
+- Is `node.geojson` authoritative for topology, or should link endpoint geometries ever create nodes?
+- Are `FROMNODENO` and `TONODENO` always the authoritative link endpoints?
+- How should `TSYSSET` and `R_TSYSSET` be interpreted when they differ by direction?
+- Which VISUM transport systems are private-traffic relevant for v1?
+- Should `HGV` be mapped to car mode `c`, a separate heavy-vehicle mode such as `h`, or require explicit user configuration?
+- How should empty or missing `TSYSSET` and `R_TSYSSET` values affect import direction and mode availability?
+- How should `TYPENO`, `R_TYPENO`, `LC`, and `R_LC` map to or be preserved in AequilibraE?
+- Which `R_*` fields are true reverse-direction values, and which are copied metadata?
+- Which source fields should be used for capacity, speed, distance, free-flow time, allowed modes, and link type?
+- Should source VISUM length be preserved separately from AequilibraE trigger-computed geometry distance?
+- Are connectors assignment links, centroid connectors, or both?
+- Which connector fields determine allowed private modes?
+- Must connector geometry connect exactly from zone centroid to network node?
+- Should `zone_polygon.geojson` be required, optional, or preserved when present?
+- What does `countlocation.geojson` reference: link, node, detector object, screenline, or a combination, and which references are useful to AequilibraE traffic-data workflows?
+- Which count-location fields identify direction, time period, count type, and associated network element?
+- Which public-transport layers and fields should be recognized and reported as deferred?
+
+### Validation Gates
+
+- A field dictionary exists for every included VISUM layer before importer coding starts.
+- Directional field pairs used by the importer have explicit semantics.
+- Private-traffic `TSYSSET` and `R_TSYSSET` values in fixtures are mapped or intentionally rejected.
+- `TYPENO`, `R_TYPENO`, `LC`, and `R_LC` values in fixtures are mapped, preserved, or intentionally ignored.
+- Link endpoint references are validated through `FROMNODENO` and `TONODENO`, not spatial snapping.
+- Connector references are validated through `ZONENO` and `NODENO`, not spatial snapping.
+- Supported count-location associations can be imported without implying count-data calibration or OD adjustment.
+- Deferred public-transport layers are detected and reported without being imported into private-traffic network tables.
+
+## AequilibraE Integration Reviewer
+
+### Responsibilities
+
+- Review that `Project.network` exposes the importer consistently with `create_from_osm(...)`, `create_from_gmns(...)`, and project lifecycle expectations.
+- Protect AequilibraE network contracts: `links`, `nodes`, `zones`, `modes`, `link_types`, centroids, connectors, SpatiaLite geometry columns, and triggers.
+- Verify imported networks can build graphs through `Network.build_graphs(...)` and can become `TrafficAssignment`-ready when demand is later supplied.
+- Review schema and migration decisions if supported traffic-data, count-location, or imported-layer metadata become durable project data.
+- Ensure docs and tests cover public API behavior, assignment readiness, and limitations around public transport, OD, and count-based calibration.
+
+### Required Inputs
+
+- OpenSpec artifacts for `add-visum-geojson-import-pipeline`.
+- VISUM sample field inventory for node, link, connector, zone centroid, zone polygon, and count-location layers.
+- Proposed VISUM-to-AequilibraE mapping config for modes, link types, direction, speed, capacity, length, and source IDs.
+- Decision on supported traffic-data object types and count-location association storage.
+- Proposed importer API signature and expected diagnostics object/report.
+- Compact test fixtures with topology, centroids, connectors, directional fields, and count locations.
+
+### Questions Before Coding
+
+- Should `create_from_visum_geojson(...)` require an empty network like OSM import, or support importing into explicitly targeted non-empty projects?
+- Will VISUM source IDs be stored as new columns on core tables or in a separate source-mapping table?
+- If VISUM link classes exceed available single-character `link_type_id` values, what is the deterministic fallback?
+- Are VISUM connector records always imported as AequilibraE `centroid_connector` links with `a_node = zone centroid` and `b_node = regular network node`?
+- Should source length be preserved separately when it differs from trigger-derived geodesic `distance`?
+- Which count-location associations should live durably, and should storage require migrations for existing projects?
+- What is the minimum assignment-ready promise: graph builds only, or `TrafficAssignment.set_time_field(...)` and `set_capacity_field(...)` pass for mode `c`?
+
+### Validation Gates
+
+- The importer method is documented, stable, typed, and follows existing `Project.network` patterns.
+- Any new durable tables or columns include SQL specs, migrations, metadata documentation, and upgrade tests.
+- Stored geometries are compatible with the current SRID 4326 SpatiaLite schema.
+- Link and node insertion does not fight triggers that derive `a_node`, `b_node`, node modes, link types, and `distance`.
+- Every imported link has non-empty `modes`, and every mode and `link_type` exists before link insertion.
+- Imported zone centroids become `nodes.is_centroid = 1`, have positive unique IDs, and align with zone IDs where required by AequilibraE workflows.
+- Connectors are valid links, support configured private modes, and connect centroid nodes to regular nodes.
+- `project.network.build_graphs(fields=[...], modes=["c"])` succeeds and preserves expected centroids.
+- Imported assignment fields contain no NaN, zero, or negative values for selected time and capacity fields.
+- Supported count-location associations are imported or reported without triggering OD adjustment or calibration behavior.
+
+## Traffic Data And Counts Reviewer
+
+### Responsibilities
+
+- Review private-traffic mode handling, especially `CAR`, `HGV`, and mixed `TSYSSET` / `R_TSYSSET` values.
+- Review assignment-readiness requirements for imported links and connectors.
+- Define expectations for deriving capacity, speed, distance, and free-flow travel time from VISUM fields.
+- Confirm which VISUM fields are required, optional, preserved, or explicitly deferred.
+- Review count-location associations with imported links/nodes and determine which traffic-data object types AequilibraE should support first.
+- Ensure supported count-location associations are preserved as validation/calibration assets, not consumed by OD adjustment in v1.
+- Identify traffic-modeling assumptions that must be configurable rather than hardcoded.
+
+### Required Inputs
+
+- Sample VISUM GeoJSON layers: `link`, `node`, `connector`, `zone_centroid`, `zone_polygon`, and `countlocation`.
+- Field inventory for directional VISUM attributes, especially `TSYSSET`, `R_TSYSSET`, `CAP_*`, `R_CAP_*`, `V0PRT`, `R_V0PRT`, `LENGTH`, `R_LENGTH`, `TYPENO`, `R_TYPENO`, `LC`, and `R_LC`.
+- AequilibraE graph and assignment field requirements.
+- Proposed default mode and link-type mapping configuration.
+- Proposed traffic-data object scope and count-location association model.
+
+### Questions Before Coding
+
+- Should default `HGV` handling merge into car mode `c`, create mode `h`, or require explicit user choice?
+- Which capacity field is the default for assignment: hourly capacity, daily capacity, or user-selected?
+- Are VISUM `LENGTH` fields authoritative, or should AequilibraE geometry-derived distances be primary?
+- How should one-way restrictions and directional missing values be interpreted?
+- Should links with non-private transport systems be excluded, imported without assignment fields, or preserved as metadata?
+- Should connectors inherit private modes from zones, connected links, or importer configuration?
+- What is the minimum count-location association: source VISUM reference only, imported link ID, geometry proximity, or node/link pair?
+- Should count locations without resolvable associations be imported with warnings or rejected?
+
+### Validation Gates
+
+- Imported private-traffic links have valid direction, modes, link type, geometry, and source identifiers.
+- Assignment-enabled links have strictly positive usable capacity and free-flow time in every permitted direction.
+- Speed, capacity, distance, and time parsing fails clearly on unknown formats.
+- Directional fields do not silently copy AB values to BA unless explicitly configured.
+- HGV/CAR policy is visible in the validation report.
+- Supported count-location associations preserve the information needed to compare observations with network flows, speeds, routes, or travel times.
+- Count-location handling does not trigger OD estimation, OD correction, or demand calibration in v1.
+- Deferred ODME and count-calibration behavior is documented and tested as not implemented.

--- a/openspec/changes/add-visum-geojson-import-pipeline/specs/documentation-and-examples/spec.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/specs/documentation-and-examples/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: VISUM GeoJSON import is documented
+The system SHALL document the VISUM GeoJSON import workflow and its private-traffic scope.
+
+#### Scenario: Documenting the import workflow
+- **WHEN** the VISUM GeoJSON import API is added
+- **THEN** user documentation SHALL describe required and optional layers, mapping configuration, CRS handling, assignment-ready field derivation, count-location import, and deferred public-transport and demand workflows
+
+#### Scenario: Providing an executable example
+- **WHEN** examples are updated for VISUM GeoJSON import
+- **THEN** the documentation SHALL include an executable example or gallery script using compact local VISUM-like fixtures
+- **AND** the example SHALL avoid external network downloads

--- a/openspec/changes/add-visum-geojson-import-pipeline/specs/network-datamodel/spec.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/specs/network-datamodel/spec.md
@@ -16,3 +16,7 @@ The system SHALL support creating and exporting network data through supported e
 - **WHEN** VISUM GeoJSON private-traffic import is requested
 - **THEN** the system SHALL populate network links, nodes, zones, centroids, and connectors according to configured VISUM mappings
 - **AND** preserve source identifiers and imported count locations for traceability and validation
+- **AND** preserve separate VISUM nodes that share coordinates unless strict duplicate-node handling is requested
+- **AND** preserve original VISUM coordinates when imported node geometries are offset to satisfy AequilibraE node uniqueness rules
+- **AND** preserve source-to-imported node ID mappings when VISUM regular node numbers collide with centroid node IDs
+- **AND** preserve zone centroids with adjusted coordinates when VISUM centroid coordinates collide with another imported node

--- a/openspec/changes/add-visum-geojson-import-pipeline/specs/network-datamodel/spec.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/specs/network-datamodel/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Network import and export is supported
+The system SHALL support creating and exporting network data through supported external formats and services.
+
+#### Scenario: Importing from OSM
+- **WHEN** a new empty network is created from OpenStreetMap
+- **THEN** the system SHALL download applicable network data for the requested area or place
+- **AND** populate network links and nodes according to configured modes and OSM parameters
+
+#### Scenario: Importing or exporting GMNS
+- **WHEN** GMNS import or export is requested
+- **THEN** the system SHALL map configured GMNS fields to or from AequilibraE network fields
+
+#### Scenario: Importing private traffic network data from VISUM GeoJSON
+- **WHEN** VISUM GeoJSON private-traffic import is requested
+- **THEN** the system SHALL populate network links, nodes, zones, centroids, and connectors according to configured VISUM mappings
+- **AND** preserve source identifiers and imported count locations for traceability and validation

--- a/openspec/changes/add-visum-geojson-import-pipeline/specs/visum-geojson-import/spec.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/specs/visum-geojson-import/spec.md
@@ -1,0 +1,132 @@
+## ADDED Requirements
+
+### Requirement: VISUM GeoJSON imports private-traffic network layers
+The system SHALL import VISUM GeoJSON private-traffic network layers into an AequilibraE project using deterministic layer and field mappings.
+
+#### Scenario: Importing required private network layers
+- **WHEN** a VISUM GeoJSON import is requested with node, link, zone centroid, and connector layers
+- **THEN** the system SHALL read the layers through geospatial data-frame handling
+- **AND** create or update AequilibraE nodes, links, zones, centroids, and centroid connectors according to the configured mapping
+- **AND** preserve VISUM source identifiers needed to trace imported records to the source layers
+
+#### Scenario: Importing optional zone polygons
+- **WHEN** a VISUM GeoJSON import includes zone polygon layers
+- **THEN** the system SHALL import supported zone polygon data as zone geometry
+- **AND** SHALL allow import to proceed without zone polygons when zone centroids and connectors provide the required assignment topology
+
+#### Scenario: Rejecting missing required layers
+- **WHEN** a VISUM GeoJSON import is requested without a required node or link layer
+- **THEN** the system SHALL reject the import with a diagnostic that identifies the missing layer
+
+### Requirement: VISUM topology is validated from source identifiers
+The system SHALL validate VISUM topology using explicit source identifiers rather than fuzzy spatial snapping.
+
+#### Scenario: Validating link endpoint references
+- **WHEN** a VISUM link references `FROMNODENO` and `TONODENO`
+- **THEN** the system SHALL require both referenced nodes to exist in the node layer
+- **AND** verify that the link geometry endpoints are compatible with the referenced node geometries according to the configured validation tolerance
+
+#### Scenario: Validating connector references
+- **WHEN** a VISUM connector references `ZONENO` and `NODENO`
+- **THEN** the system SHALL require the referenced zone centroid and network node to exist
+- **AND** import the connector as a centroid connector associated with the referenced zone and node
+
+#### Scenario: Rejecting inferred snapping
+- **WHEN** link or connector references cannot be resolved by source identifiers
+- **THEN** the system SHALL report the unresolved references
+- **AND** SHALL NOT silently connect records by nearest geometry
+
+### Requirement: VISUM mappings are deterministic and configurable
+The system SHALL use deterministic default mappings and allow user-provided overrides for VISUM transport systems, link classes, and fields.
+
+#### Scenario: Mapping transport systems
+- **WHEN** VISUM transport-system values are mapped to AequilibraE modes
+- **THEN** the system SHALL map only configured transport systems into single-character AequilibraE mode identifiers
+- **AND** report any unmapped transport-system values encountered in imported private-traffic layers
+
+#### Scenario: Mapping heavy goods vehicles
+- **WHEN** VISUM private-traffic transport systems include `HGV`
+- **THEN** the default mapping SHALL preserve `HGV` as a separate AequilibraE mode
+- **AND** the system SHALL create or validate the mapped AequilibraE mode before importing links or connectors that reference it
+- **AND** allow users to override the mapping to merge `HGV` into car mode when desired
+
+#### Scenario: Mapping link types
+- **WHEN** VISUM link-class or type values are mapped to AequilibraE link types
+- **THEN** the system SHALL create or validate corresponding AequilibraE link types according to the configured mapping
+- **AND** report any unmapped link-type values that prevent import
+
+#### Scenario: Avoiding runtime AI mapping
+- **WHEN** the importer maps VISUM fields or values
+- **THEN** the system SHALL use configured deterministic rules
+- **AND** SHALL NOT require a runtime GenAI service to decide mappings
+
+### Requirement: Assignment-ready fields are derived where possible
+The system SHALL derive private-traffic assignment fields from VISUM source values when the configured mapping provides enough information.
+
+#### Scenario: Deriving directional network fields
+- **WHEN** VISUM link records include directional length, speed, capacity, and direction availability values
+- **THEN** the system SHALL derive numeric AequilibraE fields for private-traffic distance, speed, capacity, and free-flow time
+- **AND** represent directionality using AequilibraE direction and directional field conventions
+
+#### Scenario: Reporting non-assignment-ready records
+- **WHEN** a private-traffic link lacks required positive numeric time or capacity values for assignment
+- **THEN** the system SHALL report the affected source records and fields
+- **AND** indicate whether graph building can proceed without traffic assignment readiness
+
+### Requirement: VISUM CRS handling is explicit
+The system SHALL handle VISUM GeoJSON coordinate reference systems explicitly.
+
+#### Scenario: Importing layers with CRS metadata
+- **WHEN** VISUM GeoJSON layers provide CRS metadata or a CRS is supplied by the user
+- **THEN** the system SHALL transform geometries to the project network CRS when required before storing them
+
+#### Scenario: Importing layers without CRS metadata
+- **WHEN** VISUM GeoJSON layers do not provide CRS metadata
+- **THEN** the system SHALL require a user-supplied CRS or explicit acceptance of the importer default
+- **AND** include the CRS assumption in the import diagnostics
+
+### Requirement: VISUM link-count associations are preserved
+The system SHALL preserve supported VISUM count-location information as link-count associations for validation and future calibration workflows.
+
+#### Scenario: Identifying link-count support
+- **WHEN** a VISUM count-location layer is provided
+- **THEN** the system SHALL identify which records can be associated to imported links using fields such as `LINKNO`, `FROMNODENO`, and `TONODENO`
+- **AND** identify observed link-count candidates such as `CAR_ORIG`, `HVG_ORIG`, `MOTOR_ORIG`, and `DTVW`
+- **AND** report records or fields that are unsupported by the current link-count model
+
+#### Scenario: Associating count locations to imported links
+- **WHEN** count-location source references match imported network links
+- **THEN** the system SHALL preserve the supported association needed to compare observations to assigned link flows
+
+#### Scenario: Deferring other count-location fields
+- **WHEN** count-location fields represent turn counts, projected values, detector/lane counts, screenlines, speeds, routes, travel times, or other unsupported traffic-data objects
+- **THEN** the system SHALL report those fields as recognized but deferred
+
+#### Scenario: Deferring count-based demand adjustment
+- **WHEN** count locations are imported
+- **THEN** the system SHALL NOT adjust OD matrices or traffic demand from count data as part of this import pipeline
+- **AND** SHALL leave count-based validation, calibration, and OD adjustment to separate workflows
+
+### Requirement: VISUM inputs can be provided by folder or explicit layer paths
+The system SHALL support both conventional folder-based VISUM GeoJSON import and explicit file-to-layer mapping.
+
+#### Scenario: Importing from conventional folder names
+- **WHEN** a VISUM GeoJSON import is requested for a folder containing conventional layer file names
+- **THEN** the system SHALL discover recognized layer files by their conventional names
+- **AND** map them to the corresponding importer layer types
+
+#### Scenario: Importing from explicit layer paths
+- **WHEN** a VISUM GeoJSON import is requested with explicit file paths for layer types
+- **THEN** the system SHALL use those paths regardless of file name
+- **AND** validate that each supplied file provides the expected layer type
+
+### Requirement: Deferred VISUM layers are reported
+The system SHALL identify VISUM layers that are recognized but outside the private-traffic import scope.
+
+#### Scenario: Encountering public transport layers
+- **WHEN** VISUM stop, stop-point, line-route, or public-transport-only layers are present
+- **THEN** the system SHALL report that those layers are recognized but not imported into the private-traffic network in this version
+
+#### Scenario: Encountering OD matrix files
+- **WHEN** demand matrix files are provided or discovered with the VISUM GeoJSON layers
+- **THEN** the system SHALL report that OD matrix import is outside this pipeline unless a separate supported demand import workflow is invoked

--- a/openspec/changes/add-visum-geojson-import-pipeline/specs/visum-geojson-import/spec.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/specs/visum-geojson-import/spec.md
@@ -9,6 +9,11 @@ The system SHALL import VISUM GeoJSON private-traffic network layers into an Aeq
 - **AND** create or update AequilibraE nodes, links, zones, centroids, and centroid connectors according to the configured mapping
 - **AND** preserve VISUM source identifiers needed to trace imported records to the source layers
 
+#### Scenario: Compacting imported link identifiers
+- **WHEN** VISUM link or connector source identifiers are sparse, high-valued, or non-contiguous
+- **THEN** the system SHALL assign compact AequilibraE `links.link_id` values for imported links and connectors
+- **AND** preserve VISUM source link and connector identifiers in source metadata fields and source-reference mappings
+
 #### Scenario: Importing optional zone polygons
 - **WHEN** a VISUM GeoJSON import includes zone polygon layers
 - **THEN** the system SHALL import supported zone polygon data as zone geometry
@@ -104,6 +109,17 @@ The system SHALL derive private-traffic assignment fields from VISUM source valu
 - **WHEN** a private-traffic link lacks required positive numeric time or capacity values for assignment
 - **THEN** the system SHALL report the affected source records and fields
 - **AND** indicate whether graph building can proceed without traffic assignment readiness
+
+#### Scenario: Defaulting connector assignment fields
+- **WHEN** an imported VISUM connector has usable private-traffic modes and length but lacks exported assignment time, speed, or capacity fields
+- **THEN** the system SHALL derive connector travel time from connector length using a deterministic fallback connector speed
+- **AND** assign a deterministic high fallback connector capacity
+- **AND** report that connector assignment defaults were applied
+
+#### Scenario: Defaulting connector length from geometry
+- **WHEN** an imported VISUM connector lacks a positive exported connector length needed for assignment fallback
+- **THEN** the system SHALL derive fallback connector travel time from the connector geometry length
+- **AND** report that connector length was defaulted from geometry
 
 ### Requirement: VISUM CRS handling is explicit
 The system SHALL handle VISUM GeoJSON coordinate reference systems explicitly.

--- a/openspec/changes/add-visum-geojson-import-pipeline/specs/visum-geojson-import/spec.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/specs/visum-geojson-import/spec.md
@@ -26,10 +26,39 @@ The system SHALL validate VISUM topology using explicit source identifiers rathe
 - **THEN** the system SHALL require both referenced nodes to exist in the node layer
 - **AND** verify that the link geometry endpoints are compatible with the referenced node geometries according to the configured validation tolerance
 
+#### Scenario: Preserving coincident node topology
+- **WHEN** multiple VISUM node records share identical coordinates
+- **THEN** the system SHALL NOT merge the source nodes by default
+- **AND** SHALL preserve separate source node identifiers so modal or topological separation in VISUM is retained
+- **AND** SHALL support a deterministic offset policy that stores adjusted AequilibraE node coordinates while preserving original VISUM coordinates for traceability
+- **AND** SHALL adjust imported link and connector endpoint geometries consistently with the adjusted node coordinates
+- **AND** SHALL report the duplicate coordinate group and applied offset diagnostics
+
+#### Scenario: Strictly rejecting coincident nodes
+- **WHEN** a VISUM GeoJSON import is requested with strict duplicate-node handling
+- **THEN** the system SHALL reject coincident VISUM node coordinates before writing network records to the project database
+
+#### Scenario: Handling source node and zone ID collisions
+- **WHEN** a VISUM regular node `NO` collides with a VISUM zone centroid `NO`
+- **THEN** the system SHALL preserve the zone ID as the AequilibraE centroid node ID
+- **AND** SHALL import the regular source node with a deterministic free AequilibraE node ID
+- **AND** SHALL preserve the original VISUM node number in source metadata and source-reference mappings
+- **AND** SHALL import links and connectors using the mapped AequilibraE regular node ID
+
+#### Scenario: Preserving zone centroids that coincide with network nodes
+- **WHEN** a VISUM zone centroid shares coordinates with another imported node
+- **THEN** the system SHALL preserve the zone ID as the AequilibraE centroid node ID
+- **AND** SHALL apply a deterministic coordinate offset to the centroid node geometry
+- **AND** SHALL preserve original VISUM centroid coordinates for traceability
+- **AND** SHALL adjust imported connector start geometries consistently with the adjusted centroid coordinate
+- **AND** SHALL report the applied centroid offset diagnostic
+
 #### Scenario: Validating connector references
 - **WHEN** a VISUM connector references `ZONENO` and `NODENO`
 - **THEN** the system SHALL require the referenced zone centroid and network node to exist
 - **AND** import the connector as a centroid connector associated with the referenced zone and node
+- **AND** SHALL NOT require a numeric connector `NO` field when the connector can be identified from its zone, node, and directional availability
+- **AND** SHALL preserve a deterministic connector source key for traceability
 
 #### Scenario: Rejecting inferred snapping
 - **WHEN** link or connector references cannot be resolved by source identifiers
@@ -43,6 +72,9 @@ The system SHALL use deterministic default mappings and allow user-provided over
 - **WHEN** VISUM transport-system values are mapped to AequilibraE modes
 - **THEN** the system SHALL map only configured transport systems into single-character AequilibraE mode identifiers
 - **AND** report any unmapped transport-system values encountered in imported private-traffic layers
+- **AND** require any transport system outside the default mapping to be explicitly mapped or explicitly ignored before import writes to the project database
+- **AND** skip records whose transport systems are all explicitly ignored, with diagnostics that identify the skipped scope
+- **AND** skip records with no declared transport systems in either direction, with diagnostics that identify the skipped scope
 
 #### Scenario: Mapping heavy goods vehicles
 - **WHEN** VISUM private-traffic transport systems include `HGV`

--- a/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
@@ -1,108 +1,108 @@
 ## 1. Expert Review Setup
 
-- [ ] 1.1 Review `reviewers.md` and confirm the VISUM semantics, AequilibraE integration, and traffic data/counts reviewer roles are sufficient for this change.
-- [ ] 1.2 Decide whether reviewer roles will be fulfilled by subagents, humans, or the main implementer with explicit review notes.
-- [ ] 1.3 Record the reviewer assignment and review checkpoints in the implementation notes for this change.
-- [ ] 1.4 Confirm whether frontend/UI wiring belongs in this repository or an adjacent UI/plugin repository.
+- [x] 1.1 Review `reviewers.md` and confirm the VISUM semantics, AequilibraE integration, and traffic data/counts reviewer roles are sufficient for this change.
+- [x] 1.2 Decide whether reviewer roles will be fulfilled by subagents, humans, or the main implementer with explicit review notes.
+- [x] 1.3 Record the reviewer assignment and review checkpoints in the implementation notes for this change.
+- [x] 1.4 Confirm whether frontend/UI wiring belongs in this repository or an adjacent UI/plugin repository.
 
 ## 2. Source Inventory And VISUM Semantics
 
-- [ ] 2.1 Produce a field inventory from sample VISUM layers: `node`, `link`, `connector`, `zone_centroid`, optional `zone_polygon`, `countlocation`, and deferred PT/context layers when present.
-- [ ] 2.2 For each inventoried field, record data type, null count, unique categorical values where relevant, sample values, unit pattern, and whether the field is required, optional, directional, derived, preserved-only, or deferred.
-- [ ] 2.3 Document semantics for `TSYSSET`, `R_TSYSSET`, empty transport-system values, and asymmetric directional availability.
-- [ ] 2.4 Document semantics for `TYPENO`, `R_TYPENO`, `LC`, and `R_LC`, including whether each drives link-type mapping or source metadata preservation.
-- [ ] 2.5 Identify all directional `R_*` fields used for private-traffic import and explicitly mark fields that must not be copied across directions.
-- [ ] 2.6 Define zone centroid, optional zone polygon, connector, and link-count semantics from the VISUM sample layers.
-- [ ] 2.7 Confirm deferred public-transport layers and fields are recognized, reported, and not imported in v1.
-- [ ] 2.8 Complete VISUM semantics reviewer checkpoint A for the field inventory and mapping assumptions.
+- [x] 2.1 Produce a field inventory from sample VISUM layers: `node`, `link`, `connector`, `zone_centroid`, optional `zone_polygon`, `countlocation`, and deferred PT/context layers when present.
+- [x] 2.2 For each inventoried field, record data type, null count, unique categorical values where relevant, sample values, unit pattern, and whether the field is required, optional, directional, derived, preserved-only, or deferred.
+- [x] 2.3 Document semantics for `TSYSSET`, `R_TSYSSET`, empty transport-system values, and asymmetric directional availability.
+- [x] 2.4 Document semantics for `TYPENO`, `R_TYPENO`, `LC`, and `R_LC`, including whether each drives link-type mapping or source metadata preservation.
+- [x] 2.5 Identify all directional `R_*` fields used for private-traffic import and explicitly mark fields that must not be copied across directions.
+- [x] 2.6 Define zone centroid, optional zone polygon, connector, and link-count semantics from the VISUM sample layers.
+- [x] 2.7 Confirm deferred public-transport layers and fields are recognized, reported, and not imported in v1.
+- [x] 2.8 Complete VISUM semantics reviewer checkpoint A for the field inventory and mapping assumptions.
 
 ## 3. Mapping Contract And API Shape
 
-- [ ] 3.1 Confirm the public API name and accepted inputs for folder-based conventional-name imports and explicit file-to-layer mapping.
-- [ ] 3.2 Define the diagnostics/report object returned or logged by the importer, including warnings, errors, CRS assumptions, deferred layers, mapping choices, and source-record references.
-- [ ] 3.3 Define default private-traffic mode mapping with `CAR -> c`, `HGV -> h`, user override behavior for models that merge HGV into car, and mode creation/validation rules for mapped mode IDs.
-- [ ] 3.4 Define default link-type mapping from VISUM link classes/types to AequilibraE `link_type` and single-character `link_type_id` values.
-- [ ] 3.5 Define deterministic fallback behavior when VISUM classes exceed available or configured link-type IDs.
-- [ ] 3.6 Define default assignment-field derivation for capacity, speed, distance, and free-flow time, including unit conversions and selected default capacity period.
-- [ ] 3.7 Define source-ID storage per table or mapping structure for imported nodes, links, zones, and connectors, preserving only source fields needed for AequilibraE import, audit, or near-term workflows.
-- [ ] 3.8 Define validation severity levels for missing layers, unmapped values, CRS assumptions, topology mismatches, invalid units, and non-assignment-ready records.
-- [ ] 3.9 Complete VISUM, AequilibraE, and traffic-data reviewer checkpoint A for the mapping contract and API shape.
+- [x] 3.1 Confirm the public API name and accepted inputs for folder-based conventional-name imports and explicit file-to-layer mapping.
+- [x] 3.2 Define the diagnostics/report object returned or logged by the importer, including warnings, errors, CRS assumptions, deferred layers, mapping choices, and source-record references.
+- [x] 3.3 Define default private-traffic mode mapping with `CAR -> c`, `HGV -> h`, user override behavior for models that merge HGV into car, and mode creation/validation rules for mapped mode IDs.
+- [x] 3.4 Define default link-type mapping from VISUM link classes/types to AequilibraE `link_type` and single-character `link_type_id` values.
+- [x] 3.5 Define deterministic fallback behavior when VISUM classes exceed available or configured link-type IDs.
+- [x] 3.6 Define default assignment-field derivation for capacity, speed, distance, and free-flow time, including unit conversions and selected default capacity period.
+- [x] 3.7 Define source-ID storage per table or mapping structure for imported nodes, links, zones, and connectors, preserving only source fields needed for AequilibraE import, audit, or near-term workflows.
+- [x] 3.8 Define validation severity levels for missing layers, unmapped values, CRS assumptions, topology mismatches, invalid units, and non-assignment-ready records.
+- [x] 3.9 Complete VISUM, AequilibraE, and traffic-data reviewer checkpoint A for the mapping contract and API shape.
 
 ## 4. Data Model And Storage Decisions
 
-- [ ] 4.1 Decide whether the importer requires an empty network or supports importing into explicitly targeted non-empty projects.
-- [ ] 4.2 Confirm link counts as the first supported traffic-data object and report turn counts, detector/lane counts, screenlines, speeds, routes, and travel-time observations as deferred.
-- [ ] 4.3 Decide whether source VISUM length is preserved separately from trigger-derived AequilibraE `distance`.
-- [ ] 4.4 Decide whether source-ID preservation uses importer-added core-table columns or a separate source-mapping table.
-- [ ] 4.5 Decide where supported link-count associations are stored durably, if any, and keep unsupported count-location fields diagnostic-only.
-- [ ] 4.6 Add SQL schema and migration artifacts for link-count or source-mapping storage if required.
-- [ ] 4.7 Add tests for any new table list, trigger list, migration listing, metadata documentation, and project upgrade behavior.
-- [ ] 4.8 Complete AequilibraE integration reviewer checkpoint B before coding schema-backed storage.
+- [x] 4.1 Decide whether the importer requires an empty network or supports importing into explicitly targeted non-empty projects.
+- [x] 4.2 Confirm link counts as the first supported traffic-data object and report turn counts, detector/lane counts, screenlines, speeds, routes, and travel-time observations as deferred.
+- [x] 4.3 Decide whether source VISUM length is preserved separately from trigger-derived AequilibraE `distance`.
+- [x] 4.4 Decide whether source-ID preservation uses importer-added core-table columns or a separate source-mapping table.
+- [x] 4.5 Decide where supported link-count associations are stored durably, if any, and keep unsupported count-location fields diagnostic-only.
+- [x] 4.6 Add SQL schema and migration artifacts for link-count or source-mapping storage if required.
+- [x] 4.7 Add tests for any new table list, trigger list, migration listing, metadata documentation, and project upgrade behavior.
+- [x] 4.8 Complete AequilibraE integration reviewer checkpoint B before coding schema-backed storage.
 
 ## 5. Fixtures And Test-First Coverage
 
-- [ ] 5.1 Add compact VISUM-like GeoJSON fixtures covering nodes, links, zone centroids, optional zone polygons, connectors, count locations, asymmetric directions, unmapped values, invalid units, missing CRS, and deferred public-transport layers.
-- [ ] 5.2 Add tests for field inventory and layer discovery before implementing importer behavior.
-- [ ] 5.3 Add tests for default and user-overridden mode mappings, including `CAR` and `HGV` behavior.
-- [ ] 5.4 Add tests for default and user-overridden link-type mappings and fallback behavior.
-- [ ] 5.5 Add tests for CRS handling with declared, user-supplied, missing, and explicitly accepted default CRS.
-- [ ] 5.6 Add tests for unit parsing for length, speed, time, and capacity fields, including unparsable values.
-- [ ] 5.7 Add tests for topology validation failures: missing node references, endpoint mismatch, missing zone centroid references, and connector mismatch.
-- [ ] 5.8 Add tests for assignment-readiness failures: missing, zero, negative, NaN, or unparsable time and capacity values.
-- [ ] 5.9 Add tests that supported link-count associations are preserved even when not usable for assignment validation.
-- [ ] 5.10 Add tests that count locations do not modify OD matrices, trigger demand adjustment, or perform calibration.
-- [ ] 5.11 Add tests that deferred public-transport layers are reported and not imported into private-traffic network tables.
+- [x] 5.1 Add compact VISUM-like GeoJSON fixtures covering nodes, links, zone centroids, optional zone polygons, connectors, count locations, asymmetric directions, unmapped values, invalid units, missing CRS, and deferred public-transport layers.
+- [x] 5.2 Add tests for field inventory and layer discovery before implementing importer behavior.
+- [x] 5.3 Add tests for default and user-overridden mode mappings, including `CAR` and `HGV` behavior.
+- [x] 5.4 Add tests for default and user-overridden link-type mappings and fallback behavior.
+- [x] 5.5 Add tests for CRS handling with declared, user-supplied, missing, and explicitly accepted default CRS.
+- [x] 5.6 Add tests for unit parsing for length, speed, time, and capacity fields, including unparsable values.
+- [x] 5.7 Add tests for topology validation failures: missing node references, endpoint mismatch, missing zone centroid references, and connector mismatch.
+- [x] 5.8 Add tests for assignment-readiness failures: missing, zero, negative, NaN, or unparsable time and capacity values.
+- [x] 5.9 Add tests that supported link-count associations are preserved even when not usable for assignment validation.
+- [x] 5.10 Add tests that count locations do not modify OD matrices, trigger demand adjustment, or perform calibration.
+- [x] 5.11 Add tests that deferred public-transport layers are reported and not imported into private-traffic network tables.
 
 ## 6. Reader And Validation Implementation
 
-- [ ] 6.1 Implement layer discovery for conventional folder file names and explicit file-path handling for VISUM GeoJSON inputs.
-- [ ] 6.2 Implement GeoPandas-based layer reading with CRS validation and optional reprojection.
-- [ ] 6.3 Implement field inventory generation for diagnostics and reviewer workflows.
-- [ ] 6.4 Implement unit parsers for VISUM length, speed, time, and capacity-like fields.
-- [ ] 6.5 Implement mapping configuration loading, default mapping application, and user override validation.
-- [ ] 6.6 Implement node/link source-reference validation and link geometry endpoint compatibility checks.
-- [ ] 6.7 Implement zone centroid, zone polygon, and connector source-reference validation and connector geometry compatibility checks.
-- [ ] 6.8 Implement count-location source-reference validation for link-count associations and diagnostics for deferred count-location fields.
-- [ ] 6.9 Implement recognized-deferred-layer reporting for stops, stop points, line routes, public-transport-only layers, and OD matrix files.
-- [ ] 6.10 Complete reviewer checkpoint C for diagnostics, validation severity, and public API behavior.
+- [x] 6.1 Implement layer discovery for conventional folder file names and explicit file-path handling for VISUM GeoJSON inputs.
+- [x] 6.2 Implement GeoPandas-based layer reading with CRS validation and optional reprojection.
+- [x] 6.3 Implement field inventory generation for diagnostics and reviewer workflows.
+- [x] 6.4 Implement unit parsers for VISUM length, speed, time, and capacity-like fields.
+- [x] 6.5 Implement mapping configuration loading, default mapping application, and user override validation.
+- [x] 6.6 Implement node/link source-reference validation and link geometry endpoint compatibility checks.
+- [x] 6.7 Implement zone centroid, zone polygon, and connector source-reference validation and connector geometry compatibility checks.
+- [x] 6.8 Implement count-location source-reference validation for link-count associations and diagnostics for deferred count-location fields.
+- [x] 6.9 Implement recognized-deferred-layer reporting for stops, stop points, line routes, public-transport-only layers, and OD matrix files.
+- [x] 6.10 Complete reviewer checkpoint C for diagnostics, validation severity, and public API behavior.
 
 ## 7. Network Import Implementation
 
-- [ ] 7.1 Implement the public network API entry point and keep behavior consistent with existing `Network.create_from_osm(...)` and `Network.create_from_gmns(...)` patterns.
-- [ ] 7.2 Implement mode and link-type creation or validation before any link insert, including default creation/validation of `h` when `HGV` maps to a separate heavy-vehicle mode.
-- [ ] 7.3 Import VISUM nodes while preserving source node identifiers and geometry.
-- [ ] 7.4 Import VISUM zones and centroids while preserving source zone identifiers and geometry.
-- [ ] 7.5 Import VISUM links with AequilibraE direction, modes, link types, geometry, assignment fields, and source metadata.
-- [ ] 7.6 Derive assignment-ready numeric fields for distance, speed, capacity, and free-flow time where possible.
-- [ ] 7.7 Preserve source VISUM length separately when configured and when it differs from geometry-derived distance.
-- [ ] 7.8 Import VISUM connectors as centroid connectors with configured modes, link type, geometry, and source metadata.
-- [ ] 7.9 Import or report supported link-count associations without performing demand adjustment.
-- [ ] 7.10 Ensure failed imports are transactional or provide explicit partial-import diagnostics and cleanup guidance.
+- [x] 7.1 Implement the public network API entry point and keep behavior consistent with existing `Network.create_from_osm(...)` and `Network.create_from_gmns(...)` patterns.
+- [x] 7.2 Implement mode and link-type creation or validation before any link insert, including default creation/validation of `h` when `HGV` maps to a separate heavy-vehicle mode.
+- [x] 7.3 Import VISUM nodes while preserving source node identifiers and geometry.
+- [x] 7.4 Import VISUM zones and centroids while preserving source zone identifiers and geometry.
+- [x] 7.5 Import VISUM links with AequilibraE direction, modes, link types, geometry, assignment fields, and source metadata.
+- [x] 7.6 Derive assignment-ready numeric fields for distance, speed, capacity, and free-flow time where possible.
+- [x] 7.7 Preserve source VISUM length separately when configured and when it differs from geometry-derived distance.
+- [x] 7.8 Import VISUM connectors as centroid connectors with configured modes, link type, geometry, and source metadata.
+- [x] 7.9 Import or report supported link-count associations without performing demand adjustment.
+- [x] 7.10 Ensure failed imports are transactional or provide explicit partial-import diagnostics and cleanup guidance.
 
 ## 8. Graph, Assignment, And Database Verification
 
-- [ ] 8.1 Test trigger behavior after import: `a_node`, `b_node`, `distance`, node `modes`, and node `link_types`.
-- [ ] 8.2 Verify imported centroids with `Network.count_centroids()` and graph centroid arrays.
-- [ ] 8.3 Verify imported connectors connect centroid nodes to regular network nodes and support configured private modes.
-- [ ] 8.4 Run `project.network.build_graphs(fields=[...], modes=["c"])` on imported fixtures.
-- [ ] 8.5 Verify `TrafficAssignment.set_time_field(...)` and `set_capacity_field(...)` pass for configured assignment-ready imported fields.
-- [ ] 8.6 Verify supported link-count associations can be queried with network associations intact.
-- [ ] 8.7 Complete reviewer checkpoint D before documenting the workflow as assignment-ready.
+- [x] 8.1 Test trigger behavior after import: `a_node`, `b_node`, `distance`, node `modes`, and node `link_types`.
+- [x] 8.2 Verify imported centroids with `Network.count_centroids()` and graph centroid arrays.
+- [x] 8.3 Verify imported connectors connect centroid nodes to regular network nodes and support configured private modes.
+- [x] 8.4 Run `project.network.build_graphs(fields=[...], modes=["c"])` on imported fixtures.
+- [x] 8.5 Verify `TrafficAssignment.set_time_field(...)` and `set_capacity_field(...)` pass for configured assignment-ready imported fields.
+- [x] 8.6 Verify supported link-count associations can be queried with network associations intact.
+- [x] 8.7 Complete reviewer checkpoint D before documenting the workflow as assignment-ready.
 
 ## 9. UI, Documentation, And Examples
 
-- [ ] 9.1 Add or update UI wiring so users can launch the VISUM GeoJSON import workflow from the existing frontend when that frontend lives in this repository.
-- [ ] 9.2 Add API docstrings for the VISUM GeoJSON import entry point, mapping configuration, and diagnostics/report object.
-- [ ] 9.3 Add user documentation for required layers, optional zone polygons, CRS handling, default mappings, assignment readiness, UI access, link-count scope, and deferred workflows.
-- [ ] 9.4 Add a runnable documentation example using compact local fixtures and no external downloads.
-- [ ] 9.5 Document count locations as future inputs for validation, calibration, and ODME workflows, not as v1 demand-estimation logic.
-- [ ] 9.6 Complete reviewer checkpoint E for deferred public transport, OD matrix import, and count-based OD adjustment.
+- [x] 9.1 Add or update UI wiring so users can launch the VISUM GeoJSON import workflow from the existing frontend when that frontend lives in this repository.
+- [x] 9.2 Add API docstrings for the VISUM GeoJSON import entry point, mapping configuration, and diagnostics/report object.
+- [x] 9.3 Add user documentation for required layers, optional zone polygons, CRS handling, default mappings, assignment readiness, UI access, link-count scope, and deferred workflows.
+- [x] 9.4 Add a runnable documentation example using compact local fixtures and no external downloads.
+- [x] 9.5 Document count locations as future inputs for validation, calibration, and ODME workflows, not as v1 demand-estimation logic.
+- [x] 9.6 Complete reviewer checkpoint E for deferred public transport, OD matrix import, and count-based OD adjustment.
 
 ## 10. Final Verification
 
-- [ ] 10.1 Run focused project/network importer tests.
-- [ ] 10.2 Run focused graph and traffic-assignment tests against imported VISUM-like fixtures.
-- [ ] 10.3 Run migration/schema tests if count-location or source-mapping storage changes the project database.
-- [ ] 10.4 Run relevant documentation doctests or example checks.
-- [ ] 10.5 Run `ruff check aequilibrae/` on touched package code.
-- [ ] 10.6 Run `openspec.cmd status --change add-visum-geojson-import-pipeline` and resolve any incomplete artifacts.
+- [x] 10.1 Run focused project/network importer tests.
+- [x] 10.2 Run focused graph and traffic-assignment tests against imported VISUM-like fixtures.
+- [x] 10.3 Run migration/schema tests if count-location or source-mapping storage changes the project database.
+- [x] 10.4 Run relevant documentation doctests or example checks.
+- [x] 10.5 Run `ruff check aequilibrae/` on touched package code.
+- [x] 10.6 Run `openspec.cmd status --change add-visum-geojson-import-pipeline` and resolve any incomplete artifacts.

--- a/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
@@ -1,0 +1,108 @@
+## 1. Expert Review Setup
+
+- [ ] 1.1 Review `reviewers.md` and confirm the VISUM semantics, AequilibraE integration, and traffic data/counts reviewer roles are sufficient for this change.
+- [ ] 1.2 Decide whether reviewer roles will be fulfilled by subagents, humans, or the main implementer with explicit review notes.
+- [ ] 1.3 Record the reviewer assignment and review checkpoints in the implementation notes for this change.
+- [ ] 1.4 Confirm whether frontend/UI wiring belongs in this repository or an adjacent UI/plugin repository.
+
+## 2. Source Inventory And VISUM Semantics
+
+- [ ] 2.1 Produce a field inventory from sample VISUM layers: `node`, `link`, `connector`, `zone_centroid`, optional `zone_polygon`, `countlocation`, and deferred PT/context layers when present.
+- [ ] 2.2 For each inventoried field, record data type, null count, unique categorical values where relevant, sample values, unit pattern, and whether the field is required, optional, directional, derived, preserved-only, or deferred.
+- [ ] 2.3 Document semantics for `TSYSSET`, `R_TSYSSET`, empty transport-system values, and asymmetric directional availability.
+- [ ] 2.4 Document semantics for `TYPENO`, `R_TYPENO`, `LC`, and `R_LC`, including whether each drives link-type mapping or source metadata preservation.
+- [ ] 2.5 Identify all directional `R_*` fields used for private-traffic import and explicitly mark fields that must not be copied across directions.
+- [ ] 2.6 Define zone centroid, optional zone polygon, connector, and link-count semantics from the VISUM sample layers.
+- [ ] 2.7 Confirm deferred public-transport layers and fields are recognized, reported, and not imported in v1.
+- [ ] 2.8 Complete VISUM semantics reviewer checkpoint A for the field inventory and mapping assumptions.
+
+## 3. Mapping Contract And API Shape
+
+- [ ] 3.1 Confirm the public API name and accepted inputs for folder-based conventional-name imports and explicit file-to-layer mapping.
+- [ ] 3.2 Define the diagnostics/report object returned or logged by the importer, including warnings, errors, CRS assumptions, deferred layers, mapping choices, and source-record references.
+- [ ] 3.3 Define default private-traffic mode mapping with `CAR -> c`, `HGV -> h`, user override behavior for models that merge HGV into car, and mode creation/validation rules for mapped mode IDs.
+- [ ] 3.4 Define default link-type mapping from VISUM link classes/types to AequilibraE `link_type` and single-character `link_type_id` values.
+- [ ] 3.5 Define deterministic fallback behavior when VISUM classes exceed available or configured link-type IDs.
+- [ ] 3.6 Define default assignment-field derivation for capacity, speed, distance, and free-flow time, including unit conversions and selected default capacity period.
+- [ ] 3.7 Define source-ID storage per table or mapping structure for imported nodes, links, zones, and connectors, preserving only source fields needed for AequilibraE import, audit, or near-term workflows.
+- [ ] 3.8 Define validation severity levels for missing layers, unmapped values, CRS assumptions, topology mismatches, invalid units, and non-assignment-ready records.
+- [ ] 3.9 Complete VISUM, AequilibraE, and traffic-data reviewer checkpoint A for the mapping contract and API shape.
+
+## 4. Data Model And Storage Decisions
+
+- [ ] 4.1 Decide whether the importer requires an empty network or supports importing into explicitly targeted non-empty projects.
+- [ ] 4.2 Confirm link counts as the first supported traffic-data object and report turn counts, detector/lane counts, screenlines, speeds, routes, and travel-time observations as deferred.
+- [ ] 4.3 Decide whether source VISUM length is preserved separately from trigger-derived AequilibraE `distance`.
+- [ ] 4.4 Decide whether source-ID preservation uses importer-added core-table columns or a separate source-mapping table.
+- [ ] 4.5 Decide where supported link-count associations are stored durably, if any, and keep unsupported count-location fields diagnostic-only.
+- [ ] 4.6 Add SQL schema and migration artifacts for link-count or source-mapping storage if required.
+- [ ] 4.7 Add tests for any new table list, trigger list, migration listing, metadata documentation, and project upgrade behavior.
+- [ ] 4.8 Complete AequilibraE integration reviewer checkpoint B before coding schema-backed storage.
+
+## 5. Fixtures And Test-First Coverage
+
+- [ ] 5.1 Add compact VISUM-like GeoJSON fixtures covering nodes, links, zone centroids, optional zone polygons, connectors, count locations, asymmetric directions, unmapped values, invalid units, missing CRS, and deferred public-transport layers.
+- [ ] 5.2 Add tests for field inventory and layer discovery before implementing importer behavior.
+- [ ] 5.3 Add tests for default and user-overridden mode mappings, including `CAR` and `HGV` behavior.
+- [ ] 5.4 Add tests for default and user-overridden link-type mappings and fallback behavior.
+- [ ] 5.5 Add tests for CRS handling with declared, user-supplied, missing, and explicitly accepted default CRS.
+- [ ] 5.6 Add tests for unit parsing for length, speed, time, and capacity fields, including unparsable values.
+- [ ] 5.7 Add tests for topology validation failures: missing node references, endpoint mismatch, missing zone centroid references, and connector mismatch.
+- [ ] 5.8 Add tests for assignment-readiness failures: missing, zero, negative, NaN, or unparsable time and capacity values.
+- [ ] 5.9 Add tests that supported link-count associations are preserved even when not usable for assignment validation.
+- [ ] 5.10 Add tests that count locations do not modify OD matrices, trigger demand adjustment, or perform calibration.
+- [ ] 5.11 Add tests that deferred public-transport layers are reported and not imported into private-traffic network tables.
+
+## 6. Reader And Validation Implementation
+
+- [ ] 6.1 Implement layer discovery for conventional folder file names and explicit file-path handling for VISUM GeoJSON inputs.
+- [ ] 6.2 Implement GeoPandas-based layer reading with CRS validation and optional reprojection.
+- [ ] 6.3 Implement field inventory generation for diagnostics and reviewer workflows.
+- [ ] 6.4 Implement unit parsers for VISUM length, speed, time, and capacity-like fields.
+- [ ] 6.5 Implement mapping configuration loading, default mapping application, and user override validation.
+- [ ] 6.6 Implement node/link source-reference validation and link geometry endpoint compatibility checks.
+- [ ] 6.7 Implement zone centroid, zone polygon, and connector source-reference validation and connector geometry compatibility checks.
+- [ ] 6.8 Implement count-location source-reference validation for link-count associations and diagnostics for deferred count-location fields.
+- [ ] 6.9 Implement recognized-deferred-layer reporting for stops, stop points, line routes, public-transport-only layers, and OD matrix files.
+- [ ] 6.10 Complete reviewer checkpoint C for diagnostics, validation severity, and public API behavior.
+
+## 7. Network Import Implementation
+
+- [ ] 7.1 Implement the public network API entry point and keep behavior consistent with existing `Network.create_from_osm(...)` and `Network.create_from_gmns(...)` patterns.
+- [ ] 7.2 Implement mode and link-type creation or validation before any link insert, including default creation/validation of `h` when `HGV` maps to a separate heavy-vehicle mode.
+- [ ] 7.3 Import VISUM nodes while preserving source node identifiers and geometry.
+- [ ] 7.4 Import VISUM zones and centroids while preserving source zone identifiers and geometry.
+- [ ] 7.5 Import VISUM links with AequilibraE direction, modes, link types, geometry, assignment fields, and source metadata.
+- [ ] 7.6 Derive assignment-ready numeric fields for distance, speed, capacity, and free-flow time where possible.
+- [ ] 7.7 Preserve source VISUM length separately when configured and when it differs from geometry-derived distance.
+- [ ] 7.8 Import VISUM connectors as centroid connectors with configured modes, link type, geometry, and source metadata.
+- [ ] 7.9 Import or report supported link-count associations without performing demand adjustment.
+- [ ] 7.10 Ensure failed imports are transactional or provide explicit partial-import diagnostics and cleanup guidance.
+
+## 8. Graph, Assignment, And Database Verification
+
+- [ ] 8.1 Test trigger behavior after import: `a_node`, `b_node`, `distance`, node `modes`, and node `link_types`.
+- [ ] 8.2 Verify imported centroids with `Network.count_centroids()` and graph centroid arrays.
+- [ ] 8.3 Verify imported connectors connect centroid nodes to regular network nodes and support configured private modes.
+- [ ] 8.4 Run `project.network.build_graphs(fields=[...], modes=["c"])` on imported fixtures.
+- [ ] 8.5 Verify `TrafficAssignment.set_time_field(...)` and `set_capacity_field(...)` pass for configured assignment-ready imported fields.
+- [ ] 8.6 Verify supported link-count associations can be queried with network associations intact.
+- [ ] 8.7 Complete reviewer checkpoint D before documenting the workflow as assignment-ready.
+
+## 9. UI, Documentation, And Examples
+
+- [ ] 9.1 Add or update UI wiring so users can launch the VISUM GeoJSON import workflow from the existing frontend when that frontend lives in this repository.
+- [ ] 9.2 Add API docstrings for the VISUM GeoJSON import entry point, mapping configuration, and diagnostics/report object.
+- [ ] 9.3 Add user documentation for required layers, optional zone polygons, CRS handling, default mappings, assignment readiness, UI access, link-count scope, and deferred workflows.
+- [ ] 9.4 Add a runnable documentation example using compact local fixtures and no external downloads.
+- [ ] 9.5 Document count locations as future inputs for validation, calibration, and ODME workflows, not as v1 demand-estimation logic.
+- [ ] 9.6 Complete reviewer checkpoint E for deferred public transport, OD matrix import, and count-based OD adjustment.
+
+## 10. Final Verification
+
+- [ ] 10.1 Run focused project/network importer tests.
+- [ ] 10.2 Run focused graph and traffic-assignment tests against imported VISUM-like fixtures.
+- [ ] 10.3 Run migration/schema tests if count-location or source-mapping storage changes the project database.
+- [ ] 10.4 Run relevant documentation doctests or example checks.
+- [ ] 10.5 Run `ruff check aequilibrae/` on touched package code.
+- [ ] 10.6 Run `openspec.cmd status --change add-visum-geojson-import-pipeline` and resolve any incomplete artifacts.

--- a/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
@@ -106,3 +106,49 @@
 - [x] 10.4 Run relevant documentation doctests or example checks.
 - [x] 10.5 Run `ruff check aequilibrae/` on touched package code.
 - [x] 10.6 Run `openspec.cmd status --change add-visum-geojson-import-pipeline` and resolve any incomplete artifacts.
+
+## 11. Post-Review Real VISUM Connector Compatibility
+
+- [x] 11.1 Document that connector `NO` is optional and deterministic connector keys are generated from zone, node, and usable direction.
+- [x] 11.2 Implement connector import for layers without a numeric `NO`, preserving optional `visum_connector_no` and durable `visum_connector_key`.
+- [x] 11.3 Add regression tests for connector layers without `NO` and for duplicate deterministic connector keys.
+- [x] 11.4 Run focused VISUM importer tests and linting for touched files.
+
+## 12. Explicit Transport-System Mapping Decisions
+
+- [x] 12.1 Document that transport systems outside the default mapping require explicit mapping or explicit ignore decisions.
+- [x] 12.2 Add an `ignored_transport_systems` API option and report unmapped/ignored transport systems with structured diagnostics.
+- [x] 12.3 Skip records whose transport systems are all explicitly ignored and keep imported counts consistent.
+- [x] 12.4 Add regression tests for extra transport systems, explicit ignores, and user mappings such as `BUS -> t`.
+- [x] 12.5 Run focused VISUM importer tests and linting for touched files.
+
+## 13. Numeric Link-Type Naming Compatibility
+
+- [x] 13.1 Document that numeric VISUM `TYPENO` fallback values produce distinct AequilibraE link-type names.
+- [x] 13.2 Preserve digits in generated link-type names while keeping valid names for values that begin with digits.
+- [x] 13.3 Add regression tests for numeric `TYPENO` values such as `2` and `92`.
+- [x] 13.4 Run focused VISUM importer tests and linting for touched files.
+
+## 14. Coincident VISUM Node Compatibility
+
+- [x] 14.1 Document that coincident VISUM nodes can encode separate modal/topological layers and must not be merged by default.
+- [x] 14.2 Add a `duplicate_node_policy` API option with deterministic offset behavior and strict error behavior.
+- [x] 14.3 Preserve original VISUM node coordinates and offset diagnostics when disambiguating coincident nodes.
+- [x] 14.4 Update link and connector geometries to use adjusted endpoint coordinates for offset nodes.
+- [x] 14.5 Add regression tests for duplicate-node offset import and strict duplicate-node rejection.
+
+## 15. Source Node And Zone ID Collision Compatibility
+
+- [x] 15.1 Document that VISUM regular node numbers may collide with VISUM zone numbers.
+- [x] 15.2 Preserve zone IDs as centroid node IDs and remap only conflicting regular network nodes to free AequilibraE node IDs.
+- [x] 15.3 Preserve `visum_node_no` and source-reference mappings for remapped regular nodes.
+- [x] 15.4 Update link and connector endpoint imports to use the source-to-AequilibraE node ID mapping.
+- [x] 15.5 Add regression tests for a VISUM regular node whose `NO` collides with a zone centroid `NO`.
+
+## 16. Coincident Zone Centroid Compatibility
+
+- [x] 16.1 Document that VISUM zone centroids may share coordinates with regular network nodes.
+- [x] 16.2 Offset coincident zone centroid node geometries while preserving original VISUM centroid coordinates.
+- [x] 16.3 Update connector geometries to start from adjusted centroid coordinates.
+- [x] 16.4 Add regression tests for coincident zone centroid offset behavior.
+- [x] 16.5 Normalize adjusted VISUM link and connector endpoint geometries to AequilibraE XY line geometry.

--- a/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
+++ b/openspec/changes/add-visum-geojson-import-pipeline/tasks.md
@@ -152,3 +152,19 @@
 - [x] 16.3 Update connector geometries to start from adjusted centroid coordinates.
 - [x] 16.4 Add regression tests for coincident zone centroid offset behavior.
 - [x] 16.5 Normalize adjusted VISUM link and connector endpoint geometries to AequilibraE XY line geometry.
+
+## 17. Compact Imported Link IDs
+
+- [x] 17.1 Document that imported AequilibraE link IDs are compact internal IDs while VISUM source IDs are preserved separately.
+- [x] 17.2 Update VISUM link and connector import to allocate compact `links.link_id` values.
+- [x] 17.3 Update source-reference and count-location mappings to point from VISUM source IDs to compact imported link IDs.
+- [x] 17.4 Add regression tests for high sparse VISUM link numbers and compact imported link IDs.
+- [x] 17.5 Regenerate the Karlsruhe example project from Downloads GeoJSON files and import `Visum_3_modes.omx`.
+- [x] 17.6 Run focused VISUM importer, matrix import, and assignment smoke checks.
+
+## 18. Connector Assignment Defaults
+
+- [x] 18.1 Document fallback connector travel-time and capacity behavior when VISUM GeoJSON lacks connector assignment fields.
+- [x] 18.2 Implement deterministic connector fallback speed and high capacity defaults in the VISUM importer.
+- [x] 18.3 Add regression tests for connector fallback assignment values and diagnostics.
+- [x] 18.4 Regenerate the Karlsruhe example project and rerun assignment-readiness checks.

--- a/openspec/changes/add-visum-sqlite-import-pipeline/.openspec.yaml
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/add-visum-sqlite-import-pipeline/design.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/design.md
@@ -1,0 +1,137 @@
+## Context
+
+AequilibraE has a VISUM GeoJSON import pipeline in progress that builds private-traffic networks from exported GIS
+layers. The Karlsruhe VISUM SQLite export shows that SQLite contains richer source data than GeoJSON for several
+objects, especially connector travel times, VISUM transport systems, link-type defaults, and relational geometry.
+
+The inspected Karlsruhe SQLite export contains explicit `NODE`, `LINK`, `CONNECTOR`, `ZONE`, `TSYS`, `MODE`,
+`LINKTYPE`, and `COUNTLOCATION` tables. It also exposes geometry through relational tables: `LINKPOLY` for link shape
+vertices and `SURFACEITEM`/`FACEITEM`/`EDGE`/`EDGEITEM`/`POINT` for zone surfaces. The export stores projected
+coordinates and a WKT projection definition in `NETWORK.PROJECTIONDEFINITION`.
+
+The SQLite source still has the same structural issues that required engineering in the GeoJSON path:
+
+- sparse VISUM link numbers up to `2,030,064,882`;
+- duplicate node coordinate groups;
+- regular node IDs colliding with zone IDs;
+- connectors identified by `ZONENO`, `NODENO`, and `DIRECTION`, not a connector number;
+- transport-system availability encoded by VISUM `TSYSSET` strings.
+
+The same export also shows that explicit zero private connector times exist in SQLite. These zeroes are source data,
+not missing fields, and should be treated differently from GeoJSON connector fields that were not exported at all.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a first-class VISUM SQLite import entry point under the project network API.
+- Parse source VISUM object tables and transform them into the same AequilibraE network shape produced by the GeoJSON
+  importer where the source topology is equivalent.
+- Reconstruct source-faithful geometry for links, connectors, nodes, centroids, and supported zone polygons.
+- Use SQLite-native assignment data where available, including connector `T0_TSYS(...)`.
+- Preserve source identifiers and diagnostics in the same style as the GeoJSON importer.
+- Compare imported graph connectivity by mode against the SQLite source and the existing GeoJSON-derived Karlsruhe
+  project so fallback assignment values are not mistaken for modal connectivity changes.
+
+**Non-Goals:**
+
+- Import VISUM public transport schedules, line routes, vehicle journeys, stop timing, or route-system behavior.
+- Import or estimate OD matrices from SQLite.
+- Implement VISUM turn restrictions or node-control delay modeling.
+- Perform count-based OD adjustment, calibration, or validation beyond preserving supported count-location associations.
+- Preserve every VISUM source table or user-defined attribute.
+
+## Decisions
+
+### Build the real SQLite importer before graph comparison
+
+The graph comparison needs most of the same parsing as the importer: `LINK`, `CONNECTOR`, `TSYSSET`, directionality,
+source IDs, geometry, and CRS. A throwaway comparison-only parser would duplicate the hard part without producing a
+reusable feature. The SQLite importer should therefore be implemented first, and graph comparison should be expressed as
+tests and validation utilities on top of the imported model and source reader.
+
+Alternative considered: build a one-off SQLite connectivity parser only for checking the GeoJSON fallback. This was
+rejected because it would still need to solve VISUM SQLite semantics but would not produce a durable user workflow.
+
+### Reuse VISUM mapping and diagnostics concepts
+
+The SQLite importer should share mode mapping, ignored-transport-system handling, link-type normalization, diagnostics,
+source-reference reporting, compact internal link IDs, duplicate-node offset policy, zone/node collision remapping, and
+connector key behavior with the GeoJSON importer. SQLite-specific readers should feed normalized source records into
+common import logic where feasible.
+
+Alternative considered: implement SQLite import as a fully separate pipeline. This would be faster initially but would
+increase drift between VISUM import paths and make graph equivalence harder to reason about.
+
+### Collapse directed VISUM link rows into AequilibraE directional links
+
+The SQLite `LINK` table is direction-expanded: each source `NO` has two rows with opposite `FROMNODENO` and `TONODENO`.
+The importer should collapse these rows into one AequilibraE link, storing AB/BA directional attributes and using compact
+internal `link_id` values. Links whose two directions have empty `TSYSSET` should be skipped with diagnostics, consistent
+with GeoJSON import behavior.
+
+Alternative considered: import each SQLite `LINK` row as a separate one-way AequilibraE link. This would preserve the
+source table shape but would not match the existing AequilibraE directional-field model or the GeoJSON importer output.
+
+### Reconstruct VISUM geometry without inventing non-source geometry
+
+The importer should use source geometry when VISUM stores it. For links, it should build geometry from node endpoints
+plus ordered `LINKPOLY` vertices when they exist. Reverse-direction rows should reuse the same shape in reverse. Links
+without `LINKPOLY` in either direction should use straight node-to-node geometry because that is the geometry available
+in the VISUM export. Connectors should use straight centroid-to-node geometry unless a future VISUM export exposes
+connector shape vertices. Zone polygons should be reconstructed from `ZONE.SURFACEID` through the surface, face, edge,
+edge-item, and point tables when possible.
+
+Alternative considered: prefer GeoJSON files for geometry and SQLite for attributes. This creates a multi-source import
+that is harder to reproduce and validate. The SQLite importer should be able to stand on the SQLite export alone.
+
+### Use SQLite assignment values and epsilon for explicit zero connector times
+
+For links, the importer should derive travel time from SQLite `LENGTH` and `V0PRT` and capacity from `CAPPRT` or
+documented period-specific capacity fields when selected. For connectors, it should use `T0_TSYS(<transport system>)`
+where present. When SQLite explicitly stores a private connector time as zero, the importer should import a positive
+epsilon travel time and report an explicit-zero diagnostic. This differs from GeoJSON missing connector times, which use
+a fallback speed because the field was not exported.
+
+Alternative considered: apply the GeoJSON fallback speed to SQLite zero connector times. This was rejected because zero
+is explicit source data and likely represents instant transfer in the VISUM model.
+
+### Validate connectivity by mode, not by impedance
+
+The primary comparison between SQLite, GeoJSON, and AequilibraE should check modal connectivity: which directed
+node-to-node and centroid-to-node arcs exist for each mapped mode. Impedance values should be compared separately because
+GeoJSON fallback and SQLite epsilon handling intentionally affect costs without changing whether a mode can use a link
+or connector.
+
+Alternative considered: compare full assignment-ready graphs including costs. This would conflate mode availability with
+expected differences in connector travel-time source data.
+
+## Risks / Trade-offs
+
+- VISUM relational polygon reconstruction can be subtle when faces contain enclaves or reversed edges -> Add small
+  fixtures for surface reconstruction and validate Karlsruhe zone polygon counts and geometry validity.
+- CRS is an ESRI-style WKT without an EPSG code -> Use `pyproj.CRS.from_wkt(...)` and transform explicitly, reporting the
+  parsed CRS and any transform failure.
+- Shared GeoJSON/SQLite import code can become tangled -> Introduce only source-reader abstractions that remove real
+  duplication and keep public APIs clear.
+- Explicit zero connector times can create very low-cost centroid access -> Use positive epsilon, make it configurable if
+  needed, and report affected source connectors.
+- VISUM public transport objects are present in the SQLite export -> Recognize and report them as deferred rather than
+  partially importing transit semantics.
+- Connectivity comparison can hide turn restrictions because AequilibraE import does not model VISUM turns -> Scope
+  comparison to link/connector modal graph connectivity and report turn restrictions as deferred.
+
+## Migration Plan
+
+No database migration is expected unless implementation introduces new durable source-mapping or count-location storage.
+The importer should populate empty projects or explicitly targeted projects using existing network tables and source
+metadata columns/patterns from the GeoJSON importer. Failed imports should stop before writes when validation catches the
+problem, or provide explicit cleanup diagnostics if a transaction cannot cover the whole operation.
+
+## Open Questions
+
+- Should the public method accept only a SQLite file path, or should folder-based discovery pick a conventional
+  `*.sqlite`/`*.sqlite3` file when present beside VISUM GeoJSON exports?
+- Which capacity field should be default for SQLite import when both `CAPPRT` and period-specific fields such as
+  `CAP_1H`/`CAP_24H` exist?
+- Should zero connector epsilon be fixed globally, configurable per import, or read from project parameters?

--- a/openspec/changes/add-visum-sqlite-import-pipeline/implementation_notes.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/implementation_notes.md
@@ -1,0 +1,76 @@
+# Implementation Notes
+
+## Karlsruhe SQLite Inventory
+
+Source file checked: `C:\Users\Pablo Barceló\Downloads\Karlsruhe\Karlsruhe-sqlite.sqlite3`.
+
+The importer currently consumes the private-traffic network tables `NETWORK`, `NODE`, `ZONE`, `TSYS`, `MODE`,
+`LINKTYPE`, `LINK`, `CONNECTOR`, `COUNTLOCATION`, `LINKPOLY`, `POINT`, `EDGE`, `EDGEITEM`, `FACEITEM`, and
+`SURFACEITEM`. The Karlsruhe export also contains recognized deferred tables for public transport, stop, line-route,
+turn, and detector-like workflows that are reported but not imported by this change.
+
+The real SQLite import completed with no errors and these source object counts:
+
+- Nodes: 8,432
+- Zones: 726
+- Links: 10,902
+- Connectors: 2,821
+
+Relevant diagnostics from the real SQLite import:
+
+- `directional-mode-split`: 298
+- `sqlite-zero-connector-time`: 1,849
+- `empty-transport-systems`: 845
+- `non-assignment-ready`: 3,640
+- `coincident-node-offset`: 19
+- `coincident-centroid-offset`: 108
+- `node-id-remapped`: 3
+
+## Directional Mode Split
+
+The first Karlsruhe comparison showed that both the GeoJSON and SQLite paths produced extra modal arcs relative to the
+SQLite source graph. The root cause was the shared VISUM importer collapsing asymmetric AB/BA transport-system sets into a
+single bidirectional AequilibraE link row with the union of modes. Because AequilibraE stores one modal set per link row,
+the fix is to split asymmetric source links and connectors into two one-way rows.
+
+After the split, both imports match the SQLite source graph exactly by mapped mode.
+
+| Mode | Source arcs | SQLite imported arcs | GeoJSON imported arcs | Missing | Extra |
+| ---- | ----------- | -------------------- | --------------------- | ------- | ----- |
+| `b`  | 19,915      | 19,915               | 19,915                | 0       | 0     |
+| `c`  | 18,378      | 18,378               | 18,378                | 0       | 0     |
+| `h`  | 18,433      | 18,433               | 18,433                | 0       | 0     |
+| `t`  | 12,271      | 12,271               | 12,271                | 0       | 0     |
+| `w`  | 3,070       | 3,070                | 3,070                 | 0       | 0     |
+
+SQLite-imported and GeoJSON-imported modal graphs also match each other exactly for the same modes.
+
+## Assignment Smoke
+
+A fresh project was generated at:
+
+`C:\tmp\aequilibrae\karlsruhe-sqlite-example-split-20260608_160406`
+
+The `Visum_3_modes.omx` file was imported into the project with `project.matrices.import_file(...)`, and the `Car` core
+was used for an all-or-nothing assignment smoke test.
+
+Assignment smoke result:
+
+- Matrix total: 776,784.884
+- Car graph nodes: 8,367
+- Car graph zones: 726
+- Car graph links: 25,041
+- Assignment result rows: 14,021
+- Non-zero result rows: 6,569
+- `Car_tot` sum: 36,187,327.676
+
+Graph building reported 28 matrix centroids not present in the compressed car graph:
+`2000115` through `2000142`. The assignment still executed successfully; this remains a real-model connectivity warning
+rather than an importer error.
+
+## Verification Notes
+
+Focused SQLite importer tests and focused SQLite graph-readiness tests pass. GeoJSON validation tests pass in smaller
+slices, but the full `test_network_visum_geojson.py` file exits the Python process silently on Windows/Python 3.14 when
+it reaches `test_non_positive_assignment_fields_are_diagnostic_warnings` after the preceding tests. The same test passes
+in isolation and in tail slices, including with the new SQLite tests. Ruff is clean for touched importer and test files.

--- a/openspec/changes/add-visum-sqlite-import-pipeline/proposal.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+AequilibraE can now import VISUM GeoJSON exports, but VISUM SQLite exports preserve richer object data such as
+connector travel times, transport-system definitions, link-type defaults, and relational geometry. Supporting SQLite
+import gives users a more faithful path from VISUM to AequilibraE and provides a durable way to validate whether
+GeoJSON imports preserve modal connectivity.
+
+## What Changes
+
+- Add a VISUM SQLite import pipeline for private-traffic network construction.
+- Import VISUM `NODE`, `LINK`, `CONNECTOR`, `ZONE`, `TSYS`, `MODE`, `LINKTYPE`, and supported `COUNTLOCATION` data from a
+  SQLite export.
+- Reconstruct source-faithful link and zone geometries from VISUM relational geometry tables where available.
+- Preserve source VISUM identifiers while assigning compact AequilibraE internal link IDs.
+- Reuse the VISUM mapping and topology safeguards established for GeoJSON import, including duplicate-node handling,
+  zone/node ID collision handling, connector source keys, explicit transport-system mapping, and diagnostics.
+- Use SQLite-native assignment values, including connector `T0_TSYS(...)` values, and treat explicit zero connector
+  private-traffic times as positive epsilon costs rather than missing exported data.
+- Add validation utilities or tests that compare imported AequilibraE graph connectivity by mode against the VISUM
+  SQLite source connectivity and against the existing GeoJSON-derived Karlsruhe project.
+- Keep public-transport schedule import, turn restrictions, OD matrix import, and count-based demand adjustment outside
+  this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `visum-sqlite-import`: VISUM SQLite source discovery, relational object parsing, geometry reconstruction, import
+  behavior, source metadata preservation, assignment-field derivation, diagnostics, and connectivity validation.
+
+### Modified Capabilities
+
+- `network-datamodel`: Network import boundaries expand to include VISUM SQLite private-traffic network import.
+- `documentation-and-examples`: User-facing documentation and examples describe the VISUM SQLite import workflow and
+  validation relationship to VISUM GeoJSON imports.
+
+## Impact
+
+- Adds a public import entry point under the project network API, likely `Project.network.create_from_visum_sqlite(...)`
+  or an equivalent method consistent with `create_from_visum_geojson(...)`.
+- Touches VISUM import shared mapping/diagnostic code, network table population, mode and link-type creation, zone and
+  centroid handling, connector import, graph-building validation tests, and documentation.
+- Uses existing SQLite, Shapely, and pyproj dependencies; no new external runtime dependency is expected.
+- Adds focused fixtures or local-data tests for VISUM SQLite object tables, relational geometry reconstruction, compact
+  IDs, duplicate coordinates, zero connector times, and graph connectivity equivalence.

--- a/openspec/changes/add-visum-sqlite-import-pipeline/specs/documentation-and-examples/spec.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/specs/documentation-and-examples/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: VISUM SQLite import is documented
+The system SHALL document the VISUM SQLite import workflow and its relationship to VISUM GeoJSON imports.
+
+#### Scenario: Documenting the SQLite import workflow
+- **WHEN** the VISUM SQLite import API is added
+- **THEN** user documentation SHALL describe required and optional VISUM SQLite tables, CRS handling, mapping
+  configuration, geometry reconstruction, assignment-field derivation, connector zero-time epsilon behavior,
+  count-location scope, and deferred public-transport and demand workflows
+
+#### Scenario: Documenting connectivity validation
+- **WHEN** VISUM SQLite import documentation is added
+- **THEN** the documentation SHALL explain how SQLite source connectivity can be compared with SQLite-imported and
+  GeoJSON-imported AequilibraE graph connectivity
+- **AND** distinguish modal-connectivity validation from impedance or assignment-result comparison
+
+#### Scenario: Providing an executable SQLite example
+- **WHEN** examples are updated for VISUM SQLite import
+- **THEN** the documentation SHALL include an executable example or gallery script using compact local VISUM-like SQLite
+  fixtures
+- **AND** the example SHALL avoid external network downloads

--- a/openspec/changes/add-visum-sqlite-import-pipeline/specs/network-datamodel/spec.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/specs/network-datamodel/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Network import and export is supported
+
+The system SHALL support creating and exporting network data through supported external formats and services.
+
+#### Scenario: Importing from OSM
+
+- **WHEN** a new empty network is created from OpenStreetMap
+- **THEN** the system SHALL download applicable network data for the requested area or place
+- **AND** populate network links and nodes according to configured modes and OSM parameters
+
+#### Scenario: Importing or exporting GMNS
+
+- **WHEN** GMNS import or export is requested
+- **THEN** the system SHALL map configured GMNS fields to or from AequilibraE network fields
+
+#### Scenario: Importing private traffic network data from VISUM GeoJSON
+
+- **WHEN** VISUM GeoJSON private-traffic import is requested
+- **THEN** the system SHALL populate network links, nodes, zones, centroids, and connectors according to configured VISUM
+  mappings
+- **AND** preserve source identifiers and imported count locations for traceability and validation
+- **AND** preserve separate VISUM nodes that share coordinates unless strict duplicate-node handling is requested
+- **AND** preserve original VISUM coordinates when imported node geometries are offset to satisfy AequilibraE node
+  uniqueness rules
+- **AND** preserve source-to-imported node ID mappings when VISUM regular node numbers collide with centroid node IDs
+- **AND** preserve zone centroids with adjusted coordinates when VISUM centroid coordinates collide with another imported
+  node
+
+#### Scenario: Importing private traffic network data from VISUM SQLite
+
+- **WHEN** VISUM SQLite private-traffic import is requested
+- **THEN** the system SHALL populate network links, nodes, zones, centroids, and connectors according to configured VISUM
+  mappings
+- **AND** preserve source identifiers and supported count-location associations for traceability and validation
+- **AND** preserve separate VISUM nodes that share coordinates unless strict duplicate-node handling is requested
+- **AND** preserve source-to-imported node ID mappings when VISUM regular node numbers collide with centroid node IDs
+- **AND** assign compact AequilibraE internal link IDs while preserving VISUM source link numbers
+- **AND** reconstruct source-faithful geometries from VISUM SQLite coordinate and relational geometry tables

--- a/openspec/changes/add-visum-sqlite-import-pipeline/specs/visum-sqlite-import/spec.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/specs/visum-sqlite-import/spec.md
@@ -1,0 +1,170 @@
+## ADDED Requirements
+
+### Requirement: VISUM SQLite imports private-traffic network objects
+The system SHALL import VISUM SQLite private-traffic network objects into an AequilibraE project using deterministic
+source-table mappings.
+
+#### Scenario: Importing required SQLite object tables
+- **WHEN** a VISUM SQLite import is requested with `NODE`, `LINK`, `CONNECTOR`, `ZONE`, `TSYS`, and `LINKTYPE` tables
+- **THEN** the system SHALL read the source tables from the supplied SQLite database
+- **AND** create AequilibraE nodes, links, zones, centroids, connectors, modes, and link types according to configured
+  VISUM mappings
+- **AND** preserve VISUM source identifiers needed to trace imported records to the source tables
+
+#### Scenario: Rejecting missing required SQLite tables
+- **WHEN** a VISUM SQLite import is requested without a required source table
+- **THEN** the system SHALL reject the import with diagnostics that identify the missing table
+
+#### Scenario: Reporting deferred VISUM SQLite tables
+- **WHEN** VISUM public-transport schedule, stop timing, vehicle journey, route-system, turn, fare, point-of-interest, or
+  other unsupported source tables are present
+- **THEN** the system SHALL report that those tables are recognized but not imported into the private-traffic network in
+  this version
+
+### Requirement: VISUM SQLite topology is preserved from source identifiers
+The system SHALL construct network topology from VISUM SQLite source identifiers rather than inferred spatial snapping.
+
+#### Scenario: Collapsing directed link rows
+- **WHEN** two VISUM `LINK` rows share a source `NO` and represent opposite `FROMNODENO`/`TONODENO` directions
+- **THEN** the system SHALL import one AequilibraE link with directional AB/BA mode and assignment attributes
+- **AND** assign a compact internal AequilibraE `link_id`
+- **AND** preserve the VISUM source link `NO` separately
+
+#### Scenario: Skipping source links with no usable transport systems
+- **WHEN** both VISUM SQLite directions for a source link have no declared transport systems after configured mapping and
+  ignore rules
+- **THEN** the system SHALL skip that source link
+- **AND** report diagnostics that identify the skipped VISUM source link
+
+#### Scenario: Importing connectors from source keys
+- **WHEN** a VISUM SQLite connector is identified by `ZONENO`, `NODENO`, and `DIRECTION`
+- **THEN** the system SHALL import the connector as a centroid connector associated with the referenced zone and node
+- **AND** preserve a deterministic connector source key for traceability
+
+#### Scenario: Preserving coincident node topology
+- **WHEN** multiple VISUM SQLite `NODE` records share identical coordinates
+- **THEN** the system SHALL NOT merge the source nodes by default
+- **AND** SHALL preserve separate source node identifiers with deterministic coordinate offset behavior
+- **AND** SHALL report the duplicate coordinate group and applied offset diagnostics
+
+#### Scenario: Handling source node and zone ID collisions
+- **WHEN** a VISUM SQLite regular node `NO` collides with a VISUM SQLite zone `NO`
+- **THEN** the system SHALL preserve the zone ID as the AequilibraE centroid node ID
+- **AND** import the regular source node with a deterministic free AequilibraE node ID
+- **AND** import links and connectors using the mapped AequilibraE regular node ID
+
+### Requirement: VISUM SQLite geometry is reconstructed faithfully
+The system SHALL reconstruct AequilibraE geometries from VISUM SQLite coordinate and relational geometry tables without
+inventing geometry not represented by the source export.
+
+#### Scenario: Reconstructing link geometry
+- **WHEN** a VISUM SQLite source link has ordered vertices in `LINKPOLY`
+- **THEN** the system SHALL construct link geometry from the source node endpoint, ordered `LINKPOLY` vertices, and target
+  node endpoint
+- **AND** use the reverse vertex order for the opposite source direction when needed
+
+#### Scenario: Using straight link geometry when no link polyline exists
+- **WHEN** a VISUM SQLite source link has no `LINKPOLY` vertices in either direction
+- **THEN** the system SHALL construct straight node-to-node geometry from the source node coordinates
+- **AND** report this as source-straight geometry rather than a fallback error
+
+#### Scenario: Reconstructing connector geometry
+- **WHEN** a VISUM SQLite connector references a zone centroid and network node
+- **THEN** the system SHALL construct straight centroid-to-node connector geometry unless a supported source connector
+  geometry table is available
+
+#### Scenario: Reconstructing zone polygons
+- **WHEN** a VISUM SQLite zone references a reconstructable `SURFACEID`
+- **THEN** the system SHALL reconstruct zone geometry from the related surface, face, edge, edge-item, and point tables
+- **AND** store supported geometry as an AequilibraE zone multipolygon
+
+### Requirement: VISUM SQLite CRS handling is explicit
+The system SHALL transform VISUM SQLite projected coordinates into the project storage CRS using explicit source CRS
+metadata.
+
+#### Scenario: Reading source projection definition
+- **WHEN** `NETWORK.PROJECTIONDEFINITION` contains a parseable CRS definition
+- **THEN** the system SHALL parse it with the project CRS tooling
+- **AND** include the parsed source CRS in import diagnostics
+
+#### Scenario: Rejecting missing or unparseable CRS
+- **WHEN** VISUM SQLite source coordinates are projected but the source CRS is missing or unparseable
+- **THEN** the system SHALL require a caller-supplied source CRS or explicit default acceptance before writing network
+  records
+
+### Requirement: VISUM SQLite mappings are deterministic and configurable
+The system SHALL map VISUM SQLite transport systems, modes, link types, and fields using deterministic defaults and
+caller-provided overrides.
+
+#### Scenario: Mapping transport systems from TSYSSET
+- **WHEN** VISUM SQLite `LINK` or `CONNECTOR` rows declare `TSYSSET` values
+- **THEN** the system SHALL map only configured transport systems into single-character AequilibraE mode identifiers
+- **AND** report unmapped transport systems before import writes to the project database
+
+#### Scenario: Reading VISUM system definitions
+- **WHEN** VISUM SQLite `TSYS` or `MODE` definitions are present
+- **THEN** the system SHALL use them for diagnostics and validation of configured transport-system mappings
+- **AND** SHALL NOT require runtime AI or heuristic mode inference
+
+#### Scenario: Mapping link types
+- **WHEN** VISUM SQLite link `TYPENO`, `LC`, or `LINKTYPE` values are mapped to AequilibraE link types
+- **THEN** the system SHALL create or validate corresponding AequilibraE link types according to deterministic configured
+  rules
+
+### Requirement: VISUM SQLite assignment fields use source values
+The system SHALL derive assignment-ready private-traffic fields from VISUM SQLite source assignment values where
+available.
+
+#### Scenario: Deriving link assignment fields
+- **WHEN** a VISUM SQLite link direction includes positive length, speed, and capacity values
+- **THEN** the system SHALL derive numeric AequilibraE distance, speed, capacity, and free-flow travel-time fields for the
+  mapped private-traffic modes
+
+#### Scenario: Using connector transport-system travel times
+- **WHEN** a VISUM SQLite connector includes `T0_TSYS(<transport system>)` for a mapped private-traffic mode
+- **THEN** the system SHALL use that source connector travel time for the imported connector direction
+- **AND** SHALL NOT replace it with the GeoJSON missing-field fallback behavior
+
+#### Scenario: Handling explicit zero connector travel times
+- **WHEN** a VISUM SQLite connector explicitly stores zero travel time for a mapped private-traffic transport system
+- **THEN** the system SHALL import a positive epsilon travel time suitable for AequilibraE graph and assignment algorithms
+- **AND** report diagnostics identifying the source connector and zero-time field
+
+#### Scenario: Reporting non-assignment-ready SQLite records
+- **WHEN** a mapped private-traffic SQLite link or connector lacks required positive capacity or computable time values
+  after source-value and epsilon rules are applied
+- **THEN** the system SHALL report the affected source records and fields
+- **AND** indicate whether graph building can proceed without assignment readiness
+
+### Requirement: VISUM SQLite graph connectivity can be validated
+The system SHALL provide tests or validation routines that compare imported AequilibraE graph connectivity against VISUM
+SQLite source connectivity by mapped mode.
+
+#### Scenario: Comparing SQLite import to SQLite source connectivity
+- **WHEN** a VISUM SQLite project is imported and graph connectivity validation is requested
+- **THEN** the system SHALL compare directed node-to-node and centroid-to-node arc availability for each mapped mode
+  between the imported AequilibraE graph inputs and the VISUM SQLite source tables
+- **AND** report missing, extra, or mode-mismatched arcs
+
+#### Scenario: Comparing GeoJSON import to SQLite source connectivity
+- **WHEN** equivalent VISUM GeoJSON and SQLite exports are available for the same source model
+- **THEN** the system SHALL support a validation test that compares the GeoJSON-imported modal connectivity against the
+  SQLite source modal connectivity
+- **AND** distinguish connectivity differences from expected impedance differences caused by fallback or epsilon values
+
+#### Scenario: Comparing SQLite and GeoJSON imported connectivity
+- **WHEN** equivalent VISUM SQLite and GeoJSON imports have been built as AequilibraE projects
+- **THEN** the system SHALL support validation that both imports expose the same mapped-mode link and connector
+  connectivity, subject to documented deferred features such as turn restrictions
+
+### Requirement: VISUM SQLite count-location associations are preserved
+The system SHALL preserve supported VISUM SQLite count-location associations for validation and future calibration
+workflows.
+
+#### Scenario: Associating count locations to imported links
+- **WHEN** `COUNTLOCATION` rows reference imported source links through `LINKNO`, `FROMNODENO`, and `TONODENO`
+- **THEN** the system SHALL preserve the association needed to compare observations to assigned link flows
+
+#### Scenario: Deferring count-based demand adjustment
+- **WHEN** VISUM SQLite count-location fields are imported or reported
+- **THEN** the system SHALL NOT adjust OD matrices or traffic demand as part of the SQLite network import pipeline

--- a/openspec/changes/add-visum-sqlite-import-pipeline/tasks.md
+++ b/openspec/changes/add-visum-sqlite-import-pipeline/tasks.md
@@ -1,0 +1,78 @@
+## 1. SQLite Source Inventory And Fixtures
+
+- [x] 1.1 Add compact VISUM-like SQLite fixtures covering `NODE`, `LINK`, `CONNECTOR`, `ZONE`, `TSYS`, `MODE`, `LINKTYPE`, `COUNTLOCATION`, and relational geometry tables.
+- [x] 1.2 Add fixture cases for directed `LINK` row pairs, asymmetric `TSYSSET`, empty `TSYSSET`, sparse source link numbers, duplicate node coordinates, and zone/node ID collisions.
+- [x] 1.3 Add fixture cases for `LINKPOLY`, reverse-direction link geometry, straight source links without `LINKPOLY`, connector geometry, and reconstructable zone surfaces.
+- [x] 1.4 Add fixture cases for connector `T0_TSYS(...)`, explicit zero private connector times, missing required tables, and unparseable CRS metadata.
+- [x] 1.5 Document the Karlsruhe SQLite export inventory and expected real-data counts in implementation notes.
+
+## 2. Reader And Normalization
+
+- [x] 2.1 Implement VISUM SQLite file validation and required-table discovery.
+- [x] 2.2 Implement table readers for `NETWORK`, `TSYS`, `MODE`, `LINKTYPE`, `NODE`, `ZONE`, `LINK`, `CONNECTOR`, and `COUNTLOCATION`.
+- [x] 2.3 Parse `NETWORK.PROJECTIONDEFINITION` and transform source coordinates into project storage CRS.
+- [x] 2.4 Normalize source transport-system, mode, and link-type definitions into the existing VISUM mapping configuration model.
+- [x] 2.5 Normalize directed SQLite `LINK` row pairs into source link records with AB/BA directional attributes.
+- [x] 2.6 Normalize SQLite connector rows into source connector records keyed by zone, node, and direction.
+- [x] 2.7 Report recognized deferred SQLite source tables without importing public-transport schedule or turn-restriction semantics.
+
+## 3. Geometry Reconstruction
+
+- [x] 3.1 Reconstruct node and zone centroid point geometry from source coordinates.
+- [x] 3.2 Reconstruct link geometry from node endpoints and ordered `LINKPOLY` vertices.
+- [x] 3.3 Reuse reversed link geometry for opposite source directions when only one source orientation has `LINKPOLY`.
+- [x] 3.4 Construct straight source geometry for links and connectors when VISUM SQLite stores no shape vertices.
+- [x] 3.5 Reconstruct supported zone multipolygons from `SURFACEID`, `SURFACEITEM`, `FACEITEM`, `EDGE`, `EDGEITEM`, and `POINT`.
+- [x] 3.6 Add geometry validity diagnostics for missing endpoints, broken surface references, invalid polygons, and CRS transformation failures.
+
+## 4. Import Implementation
+
+- [x] 4.1 Add the public `Project.network.create_from_visum_sqlite(...)` entry point consistent with the GeoJSON importer API.
+- [x] 4.2 Share or factor VISUM diagnostics, source-reference, mode-mapping, ignored-transport-system, and link-type normalization logic with the GeoJSON importer.
+- [x] 4.3 Import SQLite nodes while preserving source node IDs and applying duplicate-coordinate offset or strict rejection behavior.
+- [x] 4.4 Import SQLite zones and centroids while preserving zone IDs and remapping colliding regular node IDs.
+- [x] 4.5 Import collapsed SQLite links with compact AequilibraE link IDs, directional modes, link types, assignment fields, and source metadata.
+- [x] 4.6 Import SQLite connectors with compact AequilibraE link IDs, deterministic connector keys, directional modes, assignment fields, and source metadata.
+- [x] 4.7 Preserve supported count-location associations to imported links without performing demand adjustment.
+- [x] 4.8 Ensure validation failures stop before writes or provide explicit transactional cleanup diagnostics.
+
+## 5. Assignment Field Behavior
+
+- [x] 5.1 Derive SQLite link travel times from source length and speed and derive capacity from the selected source capacity field.
+- [x] 5.2 Use connector `T0_TSYS(...)` source values for mapped transport systems instead of GeoJSON missing-field fallback behavior.
+- [x] 5.3 Treat explicit zero private connector travel times as positive epsilon costs and report zero-time diagnostics.
+- [x] 5.4 Report non-assignment-ready SQLite links or connectors after source-value and epsilon rules are applied.
+- [x] 5.5 Verify imported SQLite private-traffic graphs pass `set_time_field(...)` and `set_capacity_field(...)` on compact fixtures.
+
+## 6. Connectivity Validation
+
+- [x] 6.1 Build source-connectivity extraction from SQLite `LINK` and `CONNECTOR` records by mapped AequilibraE mode.
+- [x] 6.2 Compare SQLite-imported AequilibraE modal connectivity against SQLite source connectivity.
+- [x] 6.3 Compare GeoJSON-imported modal connectivity against equivalent SQLite source connectivity on the Karlsruhe export.
+- [x] 6.4 Compare SQLite-imported and GeoJSON-imported modal connectivity for equivalent source exports.
+- [x] 6.5 Keep impedance comparison separate from modal-connectivity comparison and report expected differences from fallback or epsilon handling.
+
+## 7. Real Karlsruhe Smoke Checks
+
+- [x] 7.1 Import `C:\Users\Pablo Barceló\Downloads\Karlsruhe\Karlsruhe-sqlite.sqlite3` into a fresh Karlsruhe SQLite example project.
+- [x] 7.2 Import `Visum_3_modes.omx` into the regenerated SQLite example project.
+- [x] 7.3 Run graph-building and assignment-readiness checks for the car graph.
+- [x] 7.4 Run a short traffic-assignment smoke test using the `Car` matrix core.
+- [x] 7.5 Record any centroid connectivity warnings, zero connector epsilon diagnostics, and graph comparison differences in implementation notes.
+
+## 8. Documentation And Examples
+
+- [x] 8.1 Add API docstrings for the VISUM SQLite import entry point and any public diagnostics or comparison helpers.
+- [x] 8.2 Add Sphinx documentation for required SQLite tables, geometry reconstruction, CRS handling, mapping options, assignment values, zero connector epsilon behavior, and deferred VISUM scope.
+- [x] 8.3 Add a compact executable documentation example using local VISUM-like SQLite fixtures.
+- [x] 8.4 Document how to use SQLite source connectivity to validate GeoJSON-imported model connectivity.
+
+## 9. Verification
+
+- [x] 9.1 Run focused VISUM SQLite importer unit tests.
+- [x] 9.2 Run focused VISUM SQLite graph and assignment-readiness tests.
+- [x] 9.3 Run focused GeoJSON/SQLite connectivity comparison tests.
+- [x] 9.4 Run matrix import tests if real Karlsruhe smoke uses OMX project import.
+- [x] 9.5 Run ruff on touched package and test files.
+- [x] 9.6 Run relevant documentation example or doctest checks.
+- [x] 9.7 Run `openspec.cmd status --change add-visum-sqlite-import-pipeline` and resolve incomplete artifacts.

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/.openspec.yaml
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/design.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/design.md
@@ -1,0 +1,55 @@
+## Context
+
+AequilibraE now has an OpenSpec baseline for the largest project surfaces, but the baseline is incomplete relative to the scanned implementation. Several public modules, command entry points, result registries, and high-risk modeling workflows have tests and docs but no capability-level requirements.
+
+This change is intentionally a specification-baseline change. It documents existing behavior so future OpenSpec proposals can target the right capability instead of rediscovering the architecture.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add durable current-state requirements for implemented but missing capability areas.
+- Keep capabilities small enough that future changes can modify one focused spec.
+- Clarify boundaries where existing specs overlap, especially base schema versus migrations and transit import versus transit assignment.
+- Avoid changing runtime behavior, public APIs, database schemas, dependencies, or tests.
+
+**Non-Goals:**
+
+- Reorganize source code or test files.
+- Split the production transit package into separate import and assignment modules.
+- Change assignment, route-choice, distribution, connector, parameter, logging, result, or export behavior.
+- Replace current docs with OpenSpec content.
+
+## Decisions
+
+1. Add separate specs for missing public capabilities.
+
+   The new specs mirror implementation ownership rather than compressing everything into existing broad specs. This keeps future changes easier to route: distribution work goes to `distribution-models`, connector work goes to `zoning-and-connectors`, and route-choice/select-link work goes to `route-choice`.
+
+   Alternative considered: fold these behaviors into `graph-and-paths`, `traffic-assignment`, or `network-datamodel`. That would keep fewer files but would blur ownership for large areas that already have distinct modules and tests.
+
+2. Keep `transit-gtfs` as the current transit umbrella, with an explicit boundary requirement.
+
+   Transit import, transit graph construction, preload, and assignment are coupled in the current baseline. The spec now documents that coupling while leaving a clear future path to split assignment into a separate capability when behavior changes require it.
+
+   Alternative considered: create a new `transit-assignment` capability immediately. That would be reasonable later, but this change is a baseline tightening pass and does not need to create a second transit contract unless the implementation changes.
+
+3. Clarify database ownership with added boundary requirements.
+
+   `network-datamodel` owns the current base schema and trigger behavior. `database-migrations` owns evolution of already-created databases. The specs should cross-reference this boundary without duplicating complete schema details.
+
+   Alternative considered: move all schema language into migrations. That would make new-project schema less visible and would not reflect how the code initializes current databases from ordered SQL specifications.
+
+4. Treat results and SimWrapper as one capability for now.
+
+   Project result registration, assignment result persistence, and SimWrapper export all describe user-visible outputs. Keeping them together gives future output-related changes a single first landing zone.
+
+   Alternative considered: separate `simwrapper-export`. That can happen if SimWrapper grows independently from project result persistence.
+
+## Risks / Trade-offs
+
+- Spec drift from over-documenting implementation details: keep requirements behavioral and testable, with code paths named only for traceability.
+- Capability overlap remains possible around select-link assignment outputs: route-choice owns route-set/select-link semantics, while traffic assignment owns standard equilibrium assignment workflows.
+- Transit remains broad: a future implementation change may need to split `transit-assignment` out of `transit-gtfs`.
+- Baseline specs may reveal undocumented edge cases: resolve future conflicts against source code, tests, SQL schema, and docs before changing requirements.
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/proposal.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The initial brownfield OpenSpec baseline covers the central project, network, matrix, assignment, transit, migration, and documentation contracts, but several implemented public capabilities still lack durable requirements. Tightening the baseline now reduces drift before OpenSpec becomes the normal gate for future changes.
+
+## What Changes
+
+- Add missing current-state capability specs for distribution models, zoning/connectors, route choice/select-link, results/export behavior, and parameters/logging.
+- Clarify that transit GTFS import and transit assignment are both covered today, while documenting boundaries that may justify a future split.
+- Clarify ownership between initial database/schema requirements and migration requirements so future schema changes know where to land.
+- No runtime code behavior is intended to change in this proposal.
+- No breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `distribution-models`: Gravity application/calibration, synthetic gravity model persistence, and iterative proportional fitting behavior.
+- `zoning-and-connectors`: Project zoning, centroid nodes, closest-zone lookup, and centroid connector creation.
+- `route-choice`: Route choice set generation, path-file output, link loading, and select-link behavior.
+- `results-and-exports`: Project result registry, assignment/result persistence, SimWrapper export, and `aeq-sim` command behavior.
+- `parameters-and-logging`: YAML parameter loading, active-project parameter precedence, package defaults, and project logging behavior.
+
+### Modified Capabilities
+
+- `network-datamodel`: Clarify that it owns base table/schema and trigger contracts, while schema evolution belongs to database migrations.
+- `database-migrations`: Clarify that it owns schema evolution, migration state, ordering, and upgrade behavior rather than the complete base schema contract.
+- `transit-gtfs`: Clarify current boundaries between GTFS/transit graph behavior and transit assignment behavior.
+
+## Impact
+
+- Affected OpenSpec artifacts: new spec files under `openspec/specs/` when archived, plus deltas for `network-datamodel`, `database-migrations`, and `transit-gtfs`.
+- Affected implementation areas for future traceability: `aequilibrae/distribution/`, `aequilibrae/project/zoning.py`, `aequilibrae/project/network/connector_creation.py`, `aequilibrae/paths/route_choice*.py`, `aequilibrae/paths/cython/route_choice_*`, `aequilibrae/project/results.py`, `aequilibrae/paths/results/`, `aequilibrae/utils/simwrapper/`, `aequilibrae/parameters.py`, and `aequilibrae/log.py`.
+- Affected tests for future verification: distribution, connector creation, select-link/route-choice, results, SimWrapper, parameters, logging, transit graph, and migration tests.
+- This is a specification-baseline change only; implementation and public API behavior should remain unchanged.

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/database-migrations/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/database-migrations/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Migrations own schema evolution
+
+The migration system SHALL own the behavior for moving existing project, transit, and results databases from earlier schemas to newer schemas.
+
+#### Scenario: Planning schema evolution
+
+- **WHEN** a change modifies tables, triggers, required fields, protected fields, or database metadata for existing projects
+- **THEN** the change SHALL define the migration behavior needed to preserve or transform existing data
+
+### Requirement: Migration specs do not duplicate the full base schema
+
+The migration capability SHALL describe upgrade behavior rather than duplicating the complete current schema for newly created databases.
+
+#### Scenario: Documenting a new table
+
+- **WHEN** a new table is added to the base schema and existing projects must receive it
+- **THEN** the base table contract SHALL be described by the owning data-model capability
+- **AND** the upgrade path SHALL be described by the database migrations capability
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/distribution-models/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/distribution-models/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Gravity application distributes demand
+
+The system SHALL apply gravity models to produce origin-destination demand matrices from production and attraction vectors, impedance data, and configured deterrence functions.
+
+#### Scenario: Applying a configured gravity model
+
+- **WHEN** gravity application is executed with compatible productions, attractions, impedance, and model parameters
+- **THEN** the system SHALL produce an origin-destination matrix with demand distributed according to the configured deterrence function
+- **AND** preserve the configured numerical convergence controls
+
+### Requirement: Gravity calibration estimates model parameters
+
+The system SHALL calibrate supported gravity models against observed demand and impedance data.
+
+#### Scenario: Calibrating a model
+
+- **WHEN** calibration is run with observed matrix data and impedance values
+- **THEN** the system SHALL estimate parameters for a supported gravity model function
+- **AND** expose calibration convergence information through the distribution result interface
+
+### Requirement: Synthetic gravity models persist configuration
+
+The system SHALL represent synthetic gravity model configuration in a reusable object that can be saved and loaded.
+
+#### Scenario: Loading a saved model
+
+- **WHEN** a saved synthetic gravity model is loaded
+- **THEN** the system SHALL restore its function type and parameter values for reuse in gravity application
+
+### Requirement: IPF balances matrices to marginals
+
+The system SHALL support iterative proportional fitting to balance an input matrix to target row and column marginals.
+
+#### Scenario: Balancing with IPF
+
+- **WHEN** IPF is executed with compatible seed matrix, row totals, and column totals
+- **THEN** the system SHALL iteratively adjust the matrix until configured convergence criteria or iteration limits are reached
+- **AND** expose convergence status for the run
+
+### Requirement: Distribution workflows use configured defaults
+
+The system SHALL use project parameters when an active project is available and package defaults otherwise.
+
+#### Scenario: Running outside a project
+
+- **WHEN** a distribution workflow is executed without an active project
+- **THEN** the system SHALL fall back to package default parameters
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/network-datamodel/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/network-datamodel/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Base schema ownership is separate from migration ownership
+
+The network data model SHALL own the current base tables, triggers, required fields, protected fields, and integrity constraints for newly created project databases.
+
+#### Scenario: Planning a base schema change
+
+- **WHEN** a change modifies the schema expected in newly created project databases
+- **THEN** the change SHALL update the network data model requirements for the affected table, trigger, or field behavior
+- **AND** use database migration requirements to describe how existing databases are upgraded
+
+### Requirement: Network data model does not replace migrations
+
+The network data model SHALL NOT be treated as sufficient documentation for upgrading existing project databases.
+
+#### Scenario: Changing an existing database contract
+
+- **WHEN** a change affects databases that may already exist in user projects
+- **THEN** the change SHALL include migration behavior under the database migrations capability
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/parameters-and-logging/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/parameters-and-logging/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Parameters load from the active project first
+
+The system SHALL load parameters from the active project's `parameters.yml` when an active project is available.
+
+#### Scenario: Loading project parameters
+
+- **WHEN** parameters are requested while a project is active
+- **THEN** the system SHALL read parameter values from that project's `parameters.yml`
+
+### Requirement: Package defaults are available without a project
+
+The system SHALL provide package default parameters when no active project parameter file is available.
+
+#### Scenario: Loading default parameters
+
+- **WHEN** parameters are requested without an active project
+- **THEN** the system SHALL return a copy of the package default parameter structure
+
+### Requirement: New projects receive parameter files
+
+The system SHALL create a project-local parameter file when initializing a new project.
+
+#### Scenario: Creating a new project
+
+- **WHEN** a new project is created
+- **THEN** the system SHALL write `parameters.yml` into the project folder using the default parameter structure
+
+### Requirement: Project logging is configured on open
+
+The system SHALL configure the AequilibraE logger for an opened project.
+
+#### Scenario: Opening a project
+
+- **WHEN** a project is opened
+- **THEN** the system SHALL attach project logging so runtime messages can be written to the project log
+
+### Requirement: Project logging is cleaned on close
+
+The system SHALL clean project logging resources when a project is closed.
+
+#### Scenario: Closing a project
+
+- **WHEN** a project is closed
+- **THEN** the system SHALL close project log handlers and deactivate project-specific logging state
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/results-and-exports/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/results-and-exports/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Project results are registered
+
+The system SHALL maintain a project result registry in the results database.
+
+#### Scenario: Listing project results
+
+- **WHEN** project results are listed
+- **THEN** the system SHALL return registered result records available to the project
+
+### Requirement: Assignment results can be persisted
+
+The system SHALL save supported assignment result tables and associated metadata to project result storage.
+
+#### Scenario: Saving assignment results
+
+- **WHEN** supported assignment results are saved for an open project
+- **THEN** the system SHALL persist result data and register it for later discovery
+
+### Requirement: Matrix outputs can be registered
+
+The system SHALL register supported matrix output files in the project matrix registry.
+
+#### Scenario: Saving matrix output
+
+- **WHEN** an output matrix is saved through a project-aware workflow
+- **THEN** the system SHALL create or update the corresponding matrix registry entry
+
+### Requirement: SimWrapper export generates dashboard files
+
+The system SHALL generate SimWrapper dashboard configuration and supporting output files for a valid AequilibraE project.
+
+#### Scenario: Generating SimWrapper output
+
+- **WHEN** SimWrapper export is requested for a project
+- **THEN** the system SHALL write dashboard configuration and supported geospatial/result outputs under the requested output directory
+
+### Requirement: SimWrapper export constrains output location
+
+The system SHALL prevent SimWrapper export from writing files outside the accepted output scope.
+
+#### Scenario: Rejecting unsafe output path
+
+- **WHEN** SimWrapper export is configured with an output path outside the allowed project/output location
+- **THEN** the system SHALL reject the path rather than writing files there
+
+### Requirement: aeq-sim exposes SimWrapper generation
+
+The system SHALL provide the `aeq-sim` command entry point for SimWrapper configuration generation.
+
+#### Scenario: Running aeq-sim
+
+- **WHEN** the `aeq-sim` command is invoked with supported arguments
+- **THEN** the system SHALL execute the SimWrapper generation workflow for the requested project
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/route-choice/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/route-choice/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Route choice sets can be generated
+
+The system SHALL generate route choice sets for compatible graph and demand inputs.
+
+#### Scenario: Running route choice
+
+- **WHEN** route choice is executed with a prepared graph and demand
+- **THEN** the system SHALL generate candidate paths according to the selected route choice procedure
+- **AND** store route set outputs in the route choice result structures
+
+### Requirement: Path files can be written
+
+The system SHALL support writing generated route paths to supported path-file outputs.
+
+#### Scenario: Saving path files
+
+- **WHEN** path-file saving is requested after route choice execution
+- **THEN** the system SHALL write route path records to the requested output location using the supported file format
+
+### Requirement: Link loading can be computed from route choice
+
+The system SHALL compute link loading from route choice demand and generated routes.
+
+#### Scenario: Computing route-choice link loading
+
+- **WHEN** link loading is requested for route choice results
+- **THEN** the system SHALL return loading values by link and demand core according to the route choice probabilities
+
+### Requirement: Select-link sets are supported
+
+The system SHALL support select-link definitions as named sets of link conditions for route choice loading outputs.
+
+#### Scenario: Computing select-link outputs
+
+- **WHEN** route choice is executed with named select-link definitions
+- **THEN** the system SHALL compute select-link loading and origin-destination outputs for each named definition
+
+### Requirement: Select-link assignment outputs can be persisted
+
+The system SHALL allow supported select-link assignment outputs to be saved through project matrix and result registries.
+
+#### Scenario: Saving select-link results
+
+- **WHEN** select-link assignment results are saved for an open project
+- **THEN** the system SHALL register the matrix and result outputs in the project registries
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/transit-gtfs/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/transit-gtfs/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Transit capability boundaries are explicit
+
+The transit GTFS capability SHALL cover the current public transport database, GTFS import, route-system persistence, transit graph creation, transit preload, and transit assignment contracts until a separate transit assignment capability is introduced.
+
+#### Scenario: Planning a transit change
+
+- **WHEN** a change affects GTFS import, transit graph persistence, preload, or transit assignment before a separate transit assignment spec exists
+- **THEN** the change SHALL update the transit GTFS capability requirements
+
+### Requirement: Transit assignment may be split later
+
+The transit assignment behavior SHALL be eligible for a separate capability when a future change materially changes assignment APIs, algorithms, result contracts, or persistence.
+
+#### Scenario: Introducing a transit assignment change
+
+- **WHEN** a future proposal changes transit assignment behavior independently of GTFS import and transit graph construction
+- **THEN** the proposal SHALL consider creating or modifying a dedicated transit assignment capability
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/zoning-and-connectors/spec.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/specs/zoning-and-connectors/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Project zoning is available
+
+The system SHALL expose project zoning data through the loaded project.
+
+#### Scenario: Accessing zoning data
+
+- **WHEN** a project is opened
+- **THEN** the system SHALL provide access to zone records stored in the project database
+- **AND** preserve zone identifiers and geometries as project data
+
+### Requirement: Zones and centroids are linked concepts
+
+The system SHALL support zone and centroid workflows that connect traffic analysis areas to network nodes.
+
+#### Scenario: Using centroid nodes
+
+- **WHEN** zones are used for graph or connector workflows
+- **THEN** the system SHALL treat centroid nodes as the network representation of traffic analysis zones where applicable
+
+### Requirement: Closest-zone lookup is supported
+
+The system SHALL support lookup of the closest zone for geospatial inputs.
+
+#### Scenario: Finding a zone for a point
+
+- **WHEN** closest-zone lookup is requested for a point geometry
+- **THEN** the system SHALL identify the nearest applicable project zone according to the zoning implementation
+
+### Requirement: Bulk centroid connector creation is supported
+
+The system SHALL create centroid connector links between centroid nodes and eligible network nodes.
+
+#### Scenario: Creating connectors
+
+- **WHEN** bulk connector creation is requested with modes and connector limits
+- **THEN** the system SHALL create connector links with centroid endpoints, supported modes, valid geometries, and centroid connector link type
+
+### Requirement: Connector creation avoids duplicate work
+
+The system SHALL avoid creating duplicate connectors when existing connectors already satisfy the requested work.
+
+#### Scenario: Re-running connector creation
+
+- **WHEN** connector creation is run again with the same effective inputs
+- **THEN** the system SHALL preserve existing suitable connectors rather than adding duplicates
+

--- a/openspec/changes/tighten-openspec-baseline-capability-coverage/tasks.md
+++ b/openspec/changes/tighten-openspec-baseline-capability-coverage/tasks.md
@@ -1,0 +1,20 @@
+## 1. Baseline Review
+
+- [ ] 1.1 Review `distribution-models` requirements against distribution source files, tests, and docs.
+- [ ] 1.2 Review `zoning-and-connectors` requirements against zoning, connector creation, closest-zone behavior, tests, and docs.
+- [ ] 1.3 Review `route-choice` requirements against route choice, path-file, select-link source files, tests, and docs.
+- [ ] 1.4 Review `results-and-exports` requirements against result registries, assignment saving, SimWrapper, `aeq-sim`, tests, and docs.
+- [ ] 1.5 Review `parameters-and-logging` requirements against parameter loading, project creation/opening/closing, logging tests, and docs.
+
+## 2. Boundary Review
+
+- [ ] 2.1 Confirm `network-datamodel` and `database-migrations` deltas clearly separate base schema ownership from upgrade behavior.
+- [ ] 2.2 Confirm `transit-gtfs` deltas clearly state the current transit umbrella boundary and future split condition.
+- [ ] 2.3 Check that new specs do not duplicate requirements already owned by `traffic-assignment`, `graph-and-paths`, `matrix-io`, or `project-lifecycle`.
+
+## 3. Validation
+
+- [ ] 3.1 Run `openspec.cmd validate tighten-openspec-baseline-capability-coverage`.
+- [ ] 3.2 Run `openspec.cmd validate --all`.
+- [ ] 3.3 Update `openspec/project.md` related-documents or baseline-spec list if the change is approved and archived.
+

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,20 +1,32 @@
 schema: spec-driven
 
-# Project context (optional)
-# This is shown to AI when creating artifacts.
-# Add your tech stack, conventions, style guides, domain knowledge, etc.
-# Example:
-#   context: |
-#     Tech stack: TypeScript, React, Node.js
-#     We use conventional commits
-#     Domain: e-commerce platform
+context: |
+  AequilibraE is a brownfield Python 3.10+ transportation modeling library.
+  Core public contracts include Project, Network, Graph, TrafficAssignment,
+  AequilibraeMatrix, SQLite/SpatiaLite project schemas, migrations, Cython
+  kernels, Sphinx documentation, and bundled test datasets.
 
-# Per-artifact rules (optional)
-# Add custom rules for specific artifacts.
-# Example:
-#   rules:
-#     proposal:
-#       - Keep proposals under 500 words
-#       - Always include a "Non-goals" section
-#     tasks:
-#       - Break tasks into chunks of max 2 hours
+  Use AGENTS.md for operational routing, openspec/project.md for architecture
+  orientation, openspec/specs/*/spec.md for durable capability behavior, and
+  openspec/changes/* for in-flight decisions and implementation notes.
+
+rules:
+  proposal:
+    - Keep proposals scoped to user-visible or maintainer-visible intent.
+    - State non-goals for deferred behavior, especially imports, algorithms, schemas, and public APIs.
+
+  design:
+    - Call out compatibility, migration, numerical, performance, and SpatiaLite risks when relevant.
+    - For database changes, identify schema files, migrations, triggers, and transaction behavior.
+    - For network import changes, describe source provenance, identifier mapping, topology validation, and deferred source features.
+
+  specs:
+    - Write durable requirements using SHALL language and concrete scenarios.
+    - Capture intended behavior, not implementation steps.
+    - Avoid contradicting Sphinx docs, SQL schema, triggers, tests, or existing public API behavior.
+    - Mark deferred behavior explicitly rather than leaving it implicit.
+
+  tasks:
+    - Include focused tests for changed behavior.
+    - Include docs or doctest updates when public APIs, workflows, parameters, schemas, or examples change.
+    - Include relevant validation commands and OpenSpec status or archive-readiness checks.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,294 @@
+# AequilibraE Project Context
+
+Generated from a repository scan on 2026-05-21. Treat this as a brownfield orientation document for OpenSpec planning. It describes the current implementation shape; durable behavioral requirements should live in `openspec/specs/`.
+
+## Related Documents
+
+- `openspec/project.md` is the most detailed project-context snapshot for agents and spec planning.
+- `openspec/specs/*/spec.md` files are the canonical current-state behavioral specs, organized by capability.
+- `AGENTS.md` is the operational contract for Codex, GitHub Copilot, and other coding agents.
+- `README.md` is the public package overview and should stay concise.
+
+If these documents disagree, resolve the disagreement against implementation files, SQL schema, tests, and CI before updating the docs.
+
+## Purpose
+
+AequilibraE is a Python transportation modeling package. It supports project-based network modeling, traffic assignment, transit and GTFS workflows, trip distribution, matrix handling, and geospatial import/export. The codebase combines Python orchestration with Cython kernels for performance-critical network and matrix operations.
+
+## Current Scale
+
+- Main package: about 150 Python files under `aequilibrae/`.
+- Compiled code: about 27 Cython-related files (`.pyx`, `.pxd`, `.pxi`).
+- Database specification: about 43 SQL files under `aequilibrae/project/database_specification/`.
+- Tests: about 85 `test_*.py` files under `tests/`.
+- Documentation: Sphinx/reST docs, gallery examples, doctests, static images, and documentation deployment workflow.
+- OpenSpec: initialized under `openspec/` with `schema: spec-driven`.
+
+## Technical Stack
+
+- Python: package requires Python 3.10+ and CI tests 3.10 through 3.14.
+- Native build: setuptools, Cython, C++17, OpenMP.
+- Data/science libraries: NumPy, SciPy, pandas, GeoPandas, Shapely, pyproj, rtree, pyarrow.
+- Matrix format support: native `.aem`, OMX through `openmatrix`, sparse matrices through SciPy and Cython wrappers.
+- Geospatial database: SQLite plus SpatiaLite; bundled blank `spatialite.sqlite` is copied into new projects.
+- HTTP/network access: `requests` for OSM/Nominatim/Overpass, `urllib.request.urlretrieve` for Windows SpatiaLite support and some docs examples.
+- Documentation: Sphinx, pydata-sphinx-theme, sphinx-gallery, doctest, LaTeX/PDF generation.
+- Testing: pytest, pytest-xdist, pytest-random-order, pytest-cov, pytest-subtests.
+- Linting: ruff 0.14.8, line length 120, rules B/C/E/F/W with B017 ignored.
+- Packaging: cibuildwheel for CPython 3.10-3.14 wheels. The active wheel workflow builds on Ubuntu, Windows, and Ubuntu ARM. Old Python, 32-bit Windows, i686 Linux, musllinux, s390x, ppc64le, and macOS wheel tags are skipped by the current configuration/workflow.
+
+## Repository Layout
+
+- `aequilibrae/__init__.py` exposes the public package facade: `Project`, `Graph`, `TrafficAssignment`, `TrafficClass`, `AequilibraeMatrix`, distribution models, result holders, logging, parameters, and subpackages.
+- `aequilibrae/context.py` stores the active `Project` singleton used by components that default to the currently open project.
+- `aequilibrae/log.py` defines the global `aequilibrae` logger and project log file access.
+- `aequilibrae/parameters.py` loads YAML parameters from the active project or from the package default `parameters.yml`.
+- `aequilibrae/project/` owns project lifecycle, database connections, schema creation, migrations, scenarios, matrices, results, zoning, and network APIs.
+- `aequilibrae/project/database_specification/` is the schema source of truth for project and transit databases.
+- `aequilibrae/project/network/` contains link/node/mode/link-type/period APIs plus OSM and GMNS builders/exporters.
+- `aequilibrae/paths/` contains graph construction, path computation, skimming, all-or-nothing loading, traffic assignment, transit assignment, route choice, connectivity, and result objects.
+- `aequilibrae/paths/cython/` contains shortest path, graph compression, public transport, VDF, route choice, and path-file kernels.
+- `aequilibrae/distribution/` contains gravity application/calibration, synthetic gravity model, and IPF.
+- `aequilibrae/matrix/` contains the native matrix implementation and sparse/COO Cython helpers.
+- `aequilibrae/transit/` contains GTFS import, route-system reading/writing, transit elements, route map matching, transit graph building, and preloading.
+- `aequilibrae/utils/` contains database/geospatial helpers, SpatiaLite utilities, example creation, Delaunay network creation, signals, QGIS adapter stubs, and SimWrapper export.
+- `aequilibrae/reference_files/` contains bundled blank/sample data files used to create examples and projects.
+- `tests/` mirrors major package areas and includes test project data, GTFS data, migration fixtures, shapefiles, SQLite projects, and path-file fixtures.
+- `docs/` contains Sphinx configuration, examples, generated table documentation helpers, website deployment helpers, and many static images.
+- `benchmarking/` contains standalone performance scripts for transit and select-link workflows.
+
+## Runtime Architecture
+
+### Project Lifecycle
+
+`Project` is the central runtime object. `Project.new(path)` creates a project folder by copying the bundled SpatiaLite database, writing `parameters.yml`, creating a `run/__init__.py`, and initializing network tables and triggers. `Project.open(path)` loads an existing folder containing `project_database.sqlite`, activates the project globally, attaches a project logger, and loads child gateways.
+
+A loaded project owns:
+
+- `scenario`: current `Scenario` object.
+- `network`: network gateway and graph builder.
+- `transit`: public transport gateway backed by `public_transport.sqlite`.
+- `matrices`: matrix registry and matrix-file gateway.
+- `results`: result registry backed by `results_database.sqlite`.
+- `about`: project metadata gateway.
+- `zoning`: zone and centroid tooling.
+
+The project uses context managers for database access:
+
+- `db_connection`: non-spatial connection to `project_database.sqlite`.
+- `db_connection_spatial`: SpatiaLite connection to `project_database.sqlite`.
+- `transit_connection`: SpatiaLite connection to `public_transport.sqlite`.
+- `results_connection`: SQLite connection to `results_database.sqlite`.
+
+`Project.close()` commits/cleans, closes log handlers, and deactivates the active project.
+
+### Scenario Model
+
+The root project lives in the project folder. Additional scenarios live under `scenarios/<scenario_name>/` and can be empty or cloned from the active scenario. Scenario creation copies databases and parameters as needed, then registers the scenario in the root project database.
+
+### Parameter Model
+
+Parameters are YAML-backed. `Parameters()` reads the active project's `parameters.yml` when one exists, otherwise it deep-copies the package default. Parameters cover run entry points, assignment equilibrium settings, distribution settings, network field definitions, OSM behavior, GMNS mappings, and system settings.
+
+### Database Model
+
+The project has three database/file layers:
+
+- `project_database.sqlite`: core network, metadata, matrices registry, results registry, periods, scenarios, and transit graph configurations.
+- `public_transport.sqlite`: GTFS-derived transit data, transit network tables, transit graph data, and transit migrations.
+- `results_database.sqlite`: output tables registered through the project `results` table.
+- `matrices/`: matrix files (`.omx`, `.aem`) registered in the project database.
+
+Schema creation is driven by ordered `table_list.txt` files and SQL table files. Trigger creation is driven by `triggers_list.txt`. SQL files are split on `--#` and executed command by command for easier failure diagnosis.
+
+Migrations are listed in Python `migrations.py` files and may be SQL or Python. The migration system tracks `MISSING`, `SKIPPED`, and `APPLIED` states in a `migrations` table. Python migrations expose a callable `migrate(...)` and run inside manual transactions using `AequilibraEConnection`.
+
+### Network Data Model
+
+Core network tables include:
+
+- `links`: directed/undirected link records with `link_id`, `a_node`, `b_node`, `direction`, `distance`, `modes`, `link_type`, name, directional speed/travel-time/capacity fields, and SpatiaLite `LINESTRING` geometry.
+- `nodes`: node records with `node_id`, `is_centroid`, `modes`, `link_types`, and SpatiaLite `POINT` geometry.
+- `zones`: TAZ records with `zone_id`, `area`, `name`, and SpatiaLite `MULTIPOLYGON` geometry.
+- `modes`: single-letter mode IDs with passenger-car equivalent, value of time, and persons-per-vehicle fields.
+- `link_types`: facility/link-type metadata.
+- `periods`: time periods, defaulting to period 1 for the whole day.
+- `matrices`: matrix registry.
+- `results`: result registry.
+- `transit_graph_configs`: saved transit graph configurations.
+- `scenarios`: registered scenarios.
+- `attributes_documentation`, `about`, and `migrations`: metadata and schema support.
+
+Triggers enforce much of the data integrity for spatial/network editing, including derived geometry fields, link/node consistency, mode/link-type consistency, zone area, periods, scenarios, and transit tables. Do not treat SQL table definitions alone as the full data contract.
+
+### Network API
+
+`Network` owns `Modes`, `LinkTypes`, `Links`, `Nodes`, and `Periods`. It can:
+
+- import OSM networks through Nominatim/Overpass, gridding large query areas when necessary;
+- import/export GMNS files;
+- build mode-specific `Graph` instances from database links;
+- compute network extent and convex hull;
+- list modes and skimmable fields.
+
+`Links`, `Nodes`, `Modes`, `LinkTypes`, and `Periods` use table-gateway patterns: load structure through `TableLoader`, instantiate record objects on demand, cache edits in memory, and save through record APIs.
+
+### Graph And Assignment Architecture
+
+`Graph` transforms a link DataFrame into a directed graph suitable for shortest-path computation. It normalizes column names to lower case, requires `link_id`, `a_node`, `b_node`, and `direction`, expands two-way links into directed edges, maps arbitrary node IDs to dense indices, places centroids first, builds forward-star arrays, and stores graph fields in pandas/NumPy structures.
+
+Graph compression has two layers:
+
+- dead-end removal;
+- link contraction for degree-two sequences.
+
+Compressed graph structures are built by Cython code and are used for assignment and skimming. Centroids are preserved, and centroid-through-flow blocking is supported.
+
+Traffic assignment is organized through:
+
+- `TrafficClass`: one demand class with graph and matrix.
+- `TrafficAssignment`: multi-class assignment controller.
+- `LinearApproximation`: equilibrium algorithm implementation.
+- VDF implementations in Cython/Python wrappers: BPR, BPR2, conical, INRETS, Akcelik.
+- result holders under `aequilibrae/paths/results/`.
+
+Available assignment concepts include all-or-nothing, MSA, Frank-Wolfe variants, skimming, select-link outputs, path-file saving to Feather/Parquet, and multi-threading.
+
+Transit assignment uses `TransitClass`, `TransitAssignment`, `OptimalStrategies`, and Cython public transport/hyperpath logic.
+
+### Matrix Architecture
+
+`AequilibraeMatrix` supports memory-only matrices and file-backed matrices. Native `.aem` files use a binary layout with a fixed header, core metadata, index metadata, and matrix blocks. OMX support is provided through `openmatrix`. Computational views select cores used by assignment and skimming.
+
+Cython sparse matrix helpers wrap C++ vectors and can convert to/from SciPy sparse matrices or OMX datasets.
+
+### Transit Architecture
+
+`Transit` ensures a `public_transport.sqlite` database exists when a project is loaded. It creates GTFS builders, imports route systems, creates/saves/removes/loads transit graphs by period, and can build transit preload vectors for traffic assignment.
+
+Transit tables include agencies, fares, links, nodes, stops, stop connectors, routes, route links, pattern mapping, trips, trip schedules, modes, node types, zones, trigger settings, and migrations. Transit route geometries use SpatiaLite `MULTILINESTRING`.
+
+GTFS import is represented through element classes (`Agency`, `Fare`, `Route`, `Pattern`, `Stop`, `Trip`, etc.), reader/writer modules, route map matching, and graph construction that links transit data to project network periods and zones.
+
+## Build And Packaging
+
+Editable development install:
+
+```bash
+pip install -e ".[dev]"
+```
+
+CI commonly uses:
+
+```bash
+uv pip install -e ".[dev]"
+```
+
+`setup.py` defines Cython extensions for path loading, IPF, public transport, route choice, graph building, sparse matrix, and COO demand code. Compilation uses C++17 and OpenMP. Environment flags:
+
+- `AEQ_DEBUG`: adds `-O0` and debug symbols.
+- `AEQ_ASAN`: enables AddressSanitizer and, outside Windows, UndefinedBehaviorSanitizer.
+
+macOS CI uses Homebrew LLVM for OpenMP during tests. Linux CI installs SpatiaLite packages. Windows test setup downloads SpatiaLite/SQLite DLL support. macOS wheel builds are not active in the current wheel matrix, and macOS wheel tags are skipped in `pyproject.toml`.
+
+## Testing
+
+Run the full test suite:
+
+```bash
+pytest tests/ --durations=50 --dist=loadscope -n 4 --random-order --verbose
+```
+
+Run a quicker local pass:
+
+```bash
+pytest tests/ -x
+```
+
+Coverage workflow runs:
+
+```bash
+pytest tests/ --cov=aequilibrae --cov-branch --cov-report=term-missing --dist=loadscope --numprocesses=4 --random-order --verbose
+```
+
+Important test patterns:
+
+- `tests/conftest.py` creates cached example projects for `sioux_falls`, `nauru`, `coquimbo`, scenario projects, no-trigger projects, and transit projects.
+- Doctest fixtures in root `conftest.py` provide `Project`, `Transit`, `AequilibraeMatrix`, NumPy, pandas, `Path`, and helper project paths to documentation examples.
+- `faulthandler.enable()` is active in tests to improve diagnostics for native-code failures.
+- SQL table and trigger list consistency is tested in `tests/test_list_of_files.py`.
+- Tests cover distribution, matrix, path/assignment, project/database/network, transit, logging, and utilities.
+
+## Documentation
+
+Docs are Sphinx-based under `docs/source/`, with autodoc, autosummary, napoleon, doctest, sphinx-gallery, sphinx-design, sphinx-git, and pydata-sphinx-theme. Gallery examples live under `docs/source/examples/`.
+
+Documentation CI:
+
+- validates version/documentation metadata;
+- runs doctests across core modules and selected `.rst` files;
+- builds LaTeX/PDF with `plot_gallery=False`;
+- builds HTML with gallery;
+- publishes to S3 when secrets are present.
+
+Changing public APIs, examples, parameters, data model behavior, or algorithm outputs often requires docs updates and may require doctest updates.
+
+## Programming Style And Conventions
+
+- Public API classes commonly use Sphinx/reST docstrings with `:Arguments:` and `:Returns:`.
+- The package facade imports many public classes at top level. Avoid adding imports that create circular dependencies.
+- Project-aware components often default to `get_active_project(must_exist=False)` and fall back to default parameters/loggers.
+- Database access should use context managers from `Project` or `commit_and_close`.
+- User-provided SQL values should be parameterized. Table/field-name interpolation exists in controlled internal paths, but new user-driven SQL should not format raw user strings into SQL.
+- Record/gateway classes frequently cache objects in private dictionaries and expose `reload`, `refresh`, `save`, `delete`, or `list` methods.
+- pandas DataFrames are common at API boundaries; NumPy arrays and memoryviews are common at computational boundaries.
+- Graph logic lowercases DataFrame columns through `Graph.__setattr__`.
+- Warnings are used for non-fatal convergence, missing records, project upgrade caveats, and data-quality issues.
+- Library code should use the configured logger rather than `print`.
+
+## Security And Robustness Notes
+
+- The project loads SQLite/SpatiaLite extensions. On Windows it may download SpatiaLite binaries into a temp directory or use `AEQ_SPATIALITE_DIR`.
+- OSM import reaches external Nominatim/Overpass endpoints configured in `parameters.yml`.
+- Graphs are saved/loaded with `pickle`; do not load graph files from untrusted sources without an explicit risk decision.
+- Some existing code builds SQL dynamically for trusted table/field identifiers. New code that handles user input must validate identifiers or use parameterized SQL for values.
+- Migrations are powerful and can span multiple databases. Python migrations must preserve transaction integrity and avoid `executescript` in Python migration bodies.
+- CI deployment uses AWS secrets only in GitHub Actions guarded by secret presence checks.
+- Test and docs examples may download external assets; isolate or mark such behavior when adding tests.
+
+## OpenSpec Guidance For Future Work
+
+Use this file for orientation only. `README.md` may summarize this context publicly, and `AGENTS.md` may turn it into agent instructions, but capability-level behavior should be captured in specs. Create or update capability specs when changing behavior in these areas:
+
+- project lifecycle, scenarios, migrations, database schema, or triggers;
+- network import/export, network editing, or graph-building behavior;
+- path computation, graph compression, assignment algorithms, VDFs, route choice, or skimming;
+- transit import, route matching, transit graph construction, or transit assignment;
+- matrix binary format, OMX behavior, sparse matrix behavior, or matrix registry behavior;
+- public API signatures, CLI entry points, examples, docs promises, or parameter semantics;
+- security-relevant handling of SQL, files, downloads, extensions, or untrusted serialized data.
+
+Current baseline specs:
+
+- `openspec/specs/project-lifecycle/spec.md` - project creation, opening, scenarios, connections, and closure
+- `openspec/specs/network-datamodel/spec.md` - network tables, modes, zones, triggers, and import/export boundaries
+- `openspec/specs/graph-and-paths/spec.md` - graph preparation, centroids, compression, paths, and skims
+- `openspec/specs/traffic-assignment/spec.md` - traffic classes, VDFs, algorithms, results, skims, and reports
+- `openspec/specs/matrix-io/spec.md` - native matrices, OMX, computational views, project records, and sparse helpers
+- `openspec/specs/transit-gtfs/spec.md` - transit database, GTFS import, transit graphs, preload, and assignment
+- `openspec/specs/database-migrations/spec.md` - migration listing, status tracking, ordering, execution, and upgrades
+- `openspec/specs/documentation-and-examples/spec.md` - Sphinx docs, API docstrings, doctests, gallery examples, and publishing
+
+For each change, prefer a small capability-focused OpenSpec change over a broad rewrite. This codebase has many implicit contracts enforced by tests, SQL triggers, Cython memory layout, and docs examples.
+
+## High-Risk Areas
+
+- Cython kernels and OpenMP behavior.
+- SpatiaLite loading and platform-specific database setup.
+- SQL triggers and migrations.
+- Graph compression and centroid mapping.
+- Assignment convergence and numerical reproducibility.
+- Matrix binary layout and OMX interoperability.
+- Scenario cloning and multi-database consistency.
+- GTFS import and transit graph persistence.
+- Documentation doctests that execute real project workflows.

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -1,0 +1,94 @@
+# Database Migrations Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for schema creation, migration discovery, migration execution, and database transaction handling.
+
+## Requirements
+
+### Requirement: Migrations are listed explicitly
+
+The system SHALL discover migrations from the package migration listing files.
+
+#### Scenario: Loading migrations
+
+- **WHEN** a migration manager is created for a migration listing file
+- **THEN** the system SHALL load each listed SQL or Python migration path
+- **AND** sort migrations by numeric migration ID
+
+#### Scenario: Rejecting invalid migrations
+
+- **WHEN** a migration has a missing file, negative ID, duplicate ID, or unsupported extension
+- **THEN** the system SHALL reject the migration set
+
+### Requirement: Migration status is tracked
+
+The system SHALL track each migration's status in the target database.
+
+#### Scenario: Marking migrations as seen
+
+- **WHEN** migrations are marked as seen
+- **THEN** missing migration records SHALL be inserted with `MISSING` status
+
+#### Scenario: Creating a new database
+
+- **WHEN** a new database is created from the current schema
+- **THEN** the system SHALL mark current migrations as seen and skipped because the schema already includes their effects
+
+### Requirement: Applicable migrations are ordered
+
+The system SHALL apply migrations in ID order and detect out-of-order migration states.
+
+#### Scenario: Finding applicable migrations
+
+- **WHEN** migrations are checked for an existing database
+- **THEN** the system SHALL identify missing migrations after the last applied or skipped migration
+
+#### Scenario: Detecting out-of-order state
+
+- **WHEN** an applied migration appears after a missing migration
+- **THEN** the system SHALL report an out-of-order state that requires manual intervention
+
+### Requirement: SQL and Python migrations are supported
+
+The system SHALL support migrations implemented as SQL scripts or Python functions.
+
+#### Scenario: Applying SQL migration
+
+- **WHEN** an SQL migration is applied
+- **THEN** the system SHALL execute the SQL script against the main migration connection
+- **AND** mark the migration as applied after successful execution
+
+#### Scenario: Applying Python migration
+
+- **WHEN** a Python migration is applied
+- **THEN** the system SHALL import the migration module
+- **AND** call its `migrate` function with the provided database connections
+- **AND** mark the migration as applied after successful execution
+
+### Requirement: Multi-database migrations are transactional
+
+The system SHALL preserve transaction integrity when migrations span multiple databases.
+
+#### Scenario: Applying migration with multiple connections
+
+- **WHEN** a migration is applied with project, transit, or results database connections
+- **THEN** the system SHALL enter manual transactions for all provided connections
+- **AND** commit all successful work or roll back failed work as one migration operation
+
+### Requirement: Project upgrade applies migrations
+
+The system SHALL upgrade project databases by applying applicable network and transit migrations.
+
+#### Scenario: Upgrading a project
+
+- **WHEN** `Project.upgrade()` is called
+- **THEN** the system SHALL apply applicable project database migrations
+- **AND** apply transit database migrations when a transit database exists and is not ignored
+
+#### Scenario: Ignoring a database
+
+- **WHEN** a project upgrade is called with an ignore flag
+- **THEN** the system SHALL skip that database
+- **AND** warn that ignoring migrations can leave the project in an incompatible state
+

--- a/openspec/specs/documentation-and-examples/spec.md
+++ b/openspec/specs/documentation-and-examples/spec.md
@@ -1,0 +1,71 @@
+# Documentation And Examples Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for documentation, examples, doctests, and documentation build workflows.
+
+## Requirements
+
+### Requirement: Documentation is Sphinx-based
+
+The system SHALL maintain user documentation under the Sphinx documentation tree.
+
+#### Scenario: Building documentation
+
+- **WHEN** documentation is built locally or in CI
+- **THEN** the system SHALL use `docs/source` as the source tree
+- **AND** produce build outputs under the documentation build directory
+
+### Requirement: API docs come from docstrings
+
+The system SHALL expose public API documentation through autodoc-compatible docstrings.
+
+#### Scenario: Documenting public APIs
+
+- **WHEN** public classes, functions, or methods are documented
+- **THEN** docstrings SHALL remain compatible with the Sphinx/reST style used by the project
+
+#### Scenario: Changing public APIs
+
+- **WHEN** public API behavior or signatures change
+- **THEN** related docstrings and generated API documentation SHALL be updated
+
+### Requirement: Examples remain executable
+
+The system SHALL keep documentation examples aligned with executable project workflows.
+
+#### Scenario: Running doctests
+
+- **WHEN** documentation CI runs doctests
+- **THEN** source docstrings and selected `.rst` examples SHALL execute successfully with the configured doctest fixtures
+
+#### Scenario: Updating behavior used by examples
+
+- **WHEN** behavior used by a documentation example changes
+- **THEN** the corresponding example SHALL be updated or explicitly skipped with a clear reason
+
+### Requirement: Gallery examples are maintained
+
+The system SHALL maintain runnable gallery examples under the documentation examples tree.
+
+#### Scenario: Building gallery documentation
+
+- **WHEN** HTML documentation is built with gallery generation enabled
+- **THEN** gallery examples SHALL be processed from `docs/source/examples`
+
+### Requirement: Documentation deployment is controlled
+
+The system SHALL publish documentation artifacts only through the configured CI deployment conditions.
+
+#### Scenario: Building pull request documentation
+
+- **WHEN** documentation CI runs for a pull request
+- **THEN** it SHALL build documentation artifacts
+- **AND** publish preview artifacts only when required secrets are available
+
+#### Scenario: Building release documentation
+
+- **WHEN** documentation CI runs for a release
+- **THEN** it SHALL build release documentation artifacts
+- **AND** publish release documentation only when required secrets are available
+

--- a/openspec/specs/graph-and-paths/spec.md
+++ b/openspec/specs/graph-and-paths/spec.md
@@ -1,0 +1,92 @@
+# Graph And Paths Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for building graphs from network data and computing paths, skims, and related graph outputs.
+
+## Requirements
+
+### Requirement: Graphs are built per mode
+
+The system SHALL build mode-specific graphs from project network links.
+
+#### Scenario: Building graphs from project links
+
+- **WHEN** `Network.build_graphs()` is called
+- **THEN** the system SHALL read link data from the project database
+- **AND** create one `Graph` per requested or available mode
+- **AND** exclude links that do not support the graph mode
+
+#### Scenario: Filtering by area
+
+- **WHEN** a graph is built with a limiting polygon
+- **THEN** the system SHALL use the spatial index to limit candidate links to that area
+
+### Requirement: Graph preparation validates structure
+
+The system SHALL validate required graph fields before preparing a graph for computation.
+
+#### Scenario: Preparing a valid graph
+
+- **WHEN** a graph contains `link_id`, `a_node`, `b_node`, and `direction`
+- **THEN** the system SHALL prepare directed graph records and forward-star arrays
+- **AND** map original node IDs to dense internal indices
+
+#### Scenario: Rejecting invalid direction values
+
+- **WHEN** a graph contains direction values outside `-1`, `0`, or `1`
+- **THEN** the system SHALL reject the graph preparation
+
+### Requirement: Directional links are expanded
+
+The system SHALL convert network link direction into directed graph edges for computation.
+
+#### Scenario: Expanding two-way links
+
+- **WHEN** a link allows travel in both directions
+- **THEN** the system SHALL create forward and reverse directed graph records
+
+#### Scenario: Mapping directional attributes
+
+- **WHEN** directional fields exist with `_ab` and `_ba` suffixes
+- **THEN** the system SHALL map those fields to the corresponding directed graph records
+
+### Requirement: Centroids are handled explicitly
+
+The system SHALL preserve and prioritize centroid nodes during graph preparation.
+
+#### Scenario: Preparing centroids
+
+- **WHEN** centroids are provided for graph preparation
+- **THEN** the system SHALL require unique positive integer centroid IDs
+- **AND** place centroids first in the internal node index
+
+#### Scenario: Blocking centroid through-flows
+
+- **WHEN** centroid through-flow blocking is enabled
+- **THEN** path and assignment procedures SHALL prevent flows from passing through centroids except as origins or destinations
+
+### Requirement: Graph compression preserves path behavior
+
+The system SHALL support compressed graph representations for efficient skimming and assignment while preserving required centroid behavior.
+
+#### Scenario: Preparing a graph with centroids
+
+- **WHEN** a graph is prepared with centroids
+- **THEN** the system SHALL build compressed graph structures for assignment and skimming
+- **AND** preserve centroid nodes in the compressed graph
+
+### Requirement: Paths and skims are computed from prepared graphs
+
+The system SHALL compute paths and skims only from graphs prepared for computation.
+
+#### Scenario: Computing a path
+
+- **WHEN** a path is requested between an origin and destination on a prepared graph
+- **THEN** the system SHALL return a path result prepared for that graph
+
+#### Scenario: Computing skims
+
+- **WHEN** skimming is requested on a prepared graph with skim fields
+- **THEN** the system SHALL compute skim matrices for the configured fields
+

--- a/openspec/specs/matrix-io/spec.md
+++ b/openspec/specs/matrix-io/spec.md
@@ -1,0 +1,94 @@
+# Matrix IO Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for AequilibraE matrix files, OMX interoperability, sparse matrices, and project matrix records.
+
+## Requirements
+
+### Requirement: Matrices can be memory-only or file-backed
+
+The system SHALL support matrix objects that live only in memory and matrix objects backed by files on disk.
+
+#### Scenario: Creating a memory matrix
+
+- **WHEN** a matrix is created without a file path
+- **THEN** the system SHALL allocate matrix data in memory
+- **AND** allow computational views to be selected from its cores
+
+#### Scenario: Creating a file-backed matrix
+
+- **WHEN** a matrix is created with a supported file path
+- **THEN** the system SHALL persist matrix data using the requested supported matrix format
+
+### Requirement: Native matrix files are supported
+
+The system SHALL support native AequilibraE `.aem` matrix files.
+
+#### Scenario: Saving native matrix data
+
+- **WHEN** a native matrix is saved
+- **THEN** the system SHALL flush matrix data and metadata to the `.aem` file layout
+
+#### Scenario: Loading native matrix data
+
+- **WHEN** a native matrix file is loaded
+- **THEN** the system SHALL expose its cores, indices, name, and description through the matrix object
+
+### Requirement: OMX interoperability is supported
+
+The system SHALL support reading and writing OMX matrices through the matrix API.
+
+#### Scenario: Loading an OMX matrix
+
+- **WHEN** an OMX file is loaded
+- **THEN** the system SHALL expose available matrix cores and mappings
+
+#### Scenario: Saving data to OMX
+
+- **WHEN** matrix data is saved to an OMX file
+- **THEN** the system SHALL write selected matrix cores and indices using OMX-compatible names and mappings
+
+### Requirement: Computational views select matrix cores
+
+The system SHALL require assignment and skimming procedures to operate on explicit matrix computational views.
+
+#### Scenario: Selecting cores
+
+- **WHEN** a computational view is selected
+- **THEN** the system SHALL expose only the selected core data for computation
+
+#### Scenario: Selecting unavailable cores
+
+- **WHEN** a requested core is absent from the matrix
+- **THEN** the system SHALL reject the computational view request
+
+### Requirement: Project matrices are registered
+
+The system SHALL maintain a registry of project matrix files in the project database.
+
+#### Scenario: Registering an existing matrix file
+
+- **WHEN** a matrix record is created for an existing `.omx` or `.aem` file
+- **THEN** the system SHALL register the record in the project matrices table
+- **AND** make the matrix available through the project matrices gateway
+
+#### Scenario: Cleaning missing records
+
+- **WHEN** a registered matrix file no longer exists on disk
+- **THEN** the system SHALL be able to remove the stale registry record
+
+### Requirement: Sparse matrix helpers interoperate
+
+The system SHALL support sparse matrix conversion between AequilibraE sparse helpers, SciPy sparse matrices, and OMX datasets.
+
+#### Scenario: Converting to SciPy
+
+- **WHEN** a sparse matrix helper is converted to SciPy
+- **THEN** the system SHALL return an equivalent SciPy sparse matrix
+
+#### Scenario: Reading sparse data from OMX
+
+- **WHEN** sparse data is loaded from an OMX file
+- **THEN** the system SHALL expose it as either SciPy sparse data or AequilibraE sparse data according to the request
+

--- a/openspec/specs/network-datamodel/spec.md
+++ b/openspec/specs/network-datamodel/spec.md
@@ -1,0 +1,97 @@
+# Network Data Model Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for AequilibraE network data stored in SQLite/SpatiaLite project databases.
+
+## Requirements
+
+### Requirement: Network tables are initialized
+
+The system SHALL initialize the network database using the ordered SQL table list and trigger list shipped with the package.
+
+#### Scenario: Building network schema
+
+- **WHEN** a new project or scenario network database is initialized
+- **THEN** the system SHALL create all tables listed in the network `table_list.txt`
+- **AND** create all triggers listed in the network `triggers_list.txt`
+- **AND** mark existing schema migrations as seen for a newly created database
+
+### Requirement: Links represent network edges
+
+The system SHALL store network links with stable identifiers, node endpoints, direction, modes, link type, directional attributes, and geometry.
+
+#### Scenario: Storing a link
+
+- **WHEN** a link is persisted in the network database
+- **THEN** it SHALL have a unique positive `link_id`
+- **AND** it SHALL reference `a_node` and `b_node`
+- **AND** it SHALL have a direction limited to `-1`, `0`, or `1`
+- **AND** it SHALL have at least one allowed mode
+- **AND** it SHALL store its geometry as a SpatiaLite `LINESTRING`
+
+### Requirement: Nodes represent network vertices
+
+The system SHALL store network nodes with stable identifiers, centroid flags, derived connectivity metadata, and geometry.
+
+#### Scenario: Storing a node
+
+- **WHEN** a node is persisted in the network database
+- **THEN** it SHALL have a unique `node_id`
+- **AND** it SHALL indicate whether it is a centroid
+- **AND** it SHALL store its geometry as a SpatiaLite `POINT`
+
+### Requirement: Zones represent traffic analysis areas
+
+The system SHALL store zones as geospatial traffic analysis areas.
+
+#### Scenario: Storing a zone
+
+- **WHEN** a zone is persisted in the network database
+- **THEN** it SHALL have a unique `zone_id`
+- **AND** it SHALL store its geometry as a SpatiaLite `MULTIPOLYGON`
+- **AND** the database triggers SHALL maintain the zone area where applicable
+
+### Requirement: Modes are single-letter identifiers
+
+The system SHALL identify available network modes with single-letter mode IDs and associated assignment metadata.
+
+#### Scenario: Creating default modes
+
+- **WHEN** network tables are initialized
+- **THEN** the system SHALL create default modes for car, transit, walk, and bicycle
+
+#### Scenario: Validating mode identifiers
+
+- **WHEN** a mode is stored
+- **THEN** its `mode_id` SHALL be exactly one character
+
+### Requirement: Triggers maintain network integrity
+
+The system SHALL use database triggers to maintain spatial and relational consistency for network editing.
+
+#### Scenario: Editing through supported paths
+
+- **WHEN** links, nodes, zones, modes, link types, periods, or scenarios are edited through the supported database/API paths
+- **THEN** triggers SHALL maintain derived fields and consistency constraints defined by the database specification
+
+#### Scenario: Changing schema behavior
+
+- **WHEN** a change modifies tables, triggers, protected fields, or required fields
+- **THEN** the change SHALL update the SQL specification and tests that validate table and trigger registration
+
+### Requirement: Network import and export is supported
+
+The system SHALL support creating and exporting network data through supported external formats and services.
+
+#### Scenario: Importing from OSM
+
+- **WHEN** a new empty network is created from OpenStreetMap
+- **THEN** the system SHALL download applicable network data for the requested area or place
+- **AND** populate network links and nodes according to configured modes and OSM parameters
+
+#### Scenario: Importing or exporting GMNS
+
+- **WHEN** GMNS import or export is requested
+- **THEN** the system SHALL map configured GMNS fields to or from AequilibraE network fields
+

--- a/openspec/specs/project-lifecycle/spec.md
+++ b/openspec/specs/project-lifecycle/spec.md
@@ -1,0 +1,100 @@
+# Project Lifecycle Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for creating, opening, using, upgrading, and closing AequilibraE projects.
+
+## Requirements
+
+### Requirement: Project creation initializes storage
+
+The system SHALL create a new project only in a non-existing directory and initialize the files needed for normal project operation.
+
+#### Scenario: Creating a new project
+
+- **WHEN** `Project.new(path)` is called with a path that does not already exist
+- **THEN** the system SHALL create the project directory
+- **AND** create `project_database.sqlite`
+- **AND** create project `parameters.yml`
+- **AND** create a `run/__init__.py` module
+- **AND** initialize the network database tables and triggers
+
+#### Scenario: Rejecting an existing directory
+
+- **WHEN** `Project.new(path)` is called with a path that already exists as a directory
+- **THEN** the system SHALL raise an error instead of overwriting that directory
+
+### Requirement: Project opening loads gateways
+
+The system SHALL open an existing project folder by locating its root project database and loading the project gateways used by client code.
+
+#### Scenario: Opening an existing project
+
+- **WHEN** `Project.open(path)` is called for a folder containing `project_database.sqlite`
+- **THEN** the system SHALL create the root scenario
+- **AND** activate the project as the current project
+- **AND** load gateways for network, transit, matrices, results, about metadata, and zoning
+
+#### Scenario: Rejecting a missing project database
+
+- **WHEN** `Project.open(path)` is called for a folder without `project_database.sqlite`
+- **THEN** the system SHALL raise an error indicating the model does not exist
+
+### Requirement: Active project is globally available
+
+The system SHALL expose the active project to components that default to project context.
+
+#### Scenario: Activating a project
+
+- **WHEN** a project is opened or created
+- **THEN** the system SHALL make it available through the active-project context
+
+#### Scenario: Requesting a missing active project
+
+- **WHEN** code requests the active project and none is active
+- **THEN** the system SHALL raise an error unless missing projects are explicitly allowed
+
+### Requirement: Project connections are scoped
+
+The system SHALL expose scoped context managers for the project, transit, and results databases.
+
+#### Scenario: Opening project database connections
+
+- **WHEN** client code enters the project database connection context
+- **THEN** the system SHALL provide a SQLite connection to the correct project database
+- **AND** commit successful work or roll back failed work when leaving the context
+
+#### Scenario: Opening spatial connections
+
+- **WHEN** client code enters a spatial database connection context
+- **THEN** the system SHALL load SpatiaLite support for that connection
+
+### Requirement: Scenarios are isolated
+
+The system SHALL manage scenarios as registered project variants with their own scenario storage.
+
+#### Scenario: Creating an empty scenario
+
+- **WHEN** a new empty scenario is created
+- **THEN** the system SHALL create scenario storage under `scenarios/<scenario_name>/`
+- **AND** register the scenario in the root project database
+- **AND** initialize scenario network tables without copying root network data
+
+#### Scenario: Cloning a scenario
+
+- **WHEN** a scenario is cloned
+- **THEN** the system SHALL copy the active scenario's databases, matrices, and parameters where present
+- **AND** register the new scenario in the root project database
+
+### Requirement: Project closure releases resources
+
+The system SHALL close project resources and clear active project context when a project is closed.
+
+#### Scenario: Closing an open project
+
+- **WHEN** `Project.close()` is called for an open project
+- **THEN** the system SHALL commit pending project database work
+- **AND** clean temporary project resources
+- **AND** close and detach project log handlers
+- **AND** deactivate the project context
+

--- a/openspec/specs/traffic-assignment/spec.md
+++ b/openspec/specs/traffic-assignment/spec.md
@@ -1,0 +1,90 @@
+# Traffic Assignment Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for traffic assignment and related result generation.
+
+## Requirements
+
+### Requirement: Assignments use transport classes
+
+The system SHALL model traffic assignment demand through unique transport classes.
+
+#### Scenario: Adding assignment classes
+
+- **WHEN** transport classes are assigned to a traffic assignment
+- **THEN** each class SHALL be unique within that assignment
+- **AND** each class SHALL provide a graph and demand matrix suitable for assignment
+
+#### Scenario: Rejecting duplicate classes
+
+- **WHEN** the same transport class is added more than once
+- **THEN** the system SHALL reject the assignment setup
+
+### Requirement: Assignment fields are validated
+
+The system SHALL validate graph fields used for travel time, capacity, costs, skims, and volume delay functions.
+
+#### Scenario: Setting a time field
+
+- **WHEN** a time field is set for an assignment
+- **THEN** the field SHALL exist for every class graph
+- **AND** the field SHALL not contain invalid null, zero, or negative values unless the operation explicitly allows them
+
+### Requirement: Volume delay functions are configurable
+
+The system SHALL support configuring assignment volume delay functions and their parameters.
+
+#### Scenario: Configuring a VDF
+
+- **WHEN** a supported VDF is selected for traffic assignment
+- **THEN** the system SHALL use that function to update congested travel times during assignment
+
+#### Scenario: Configuring VDF parameters
+
+- **WHEN** VDF parameters are provided
+- **THEN** the system SHALL map those parameters to graph fields or values required by the selected VDF
+
+### Requirement: Assignment algorithms are selectable
+
+The system SHALL expose supported equilibrium assignment algorithms and execute the selected algorithm.
+
+#### Scenario: Selecting an algorithm
+
+- **WHEN** a supported assignment algorithm is selected
+- **THEN** the system SHALL prepare the corresponding assignment procedure
+
+#### Scenario: Executing assignment
+
+- **WHEN** a configured assignment is executed
+- **THEN** the system SHALL load demand, update link costs, and record convergence information according to the selected algorithm
+
+### Requirement: Assignment results are available
+
+The system SHALL expose assignment outputs as tabular results and support saving them to the project results registry.
+
+#### Scenario: Reading results
+
+- **WHEN** assignment execution completes
+- **THEN** the system SHALL make link-level assignment results available as a DataFrame
+
+#### Scenario: Saving results
+
+- **WHEN** assignment results are saved with a table name
+- **THEN** the system SHALL write result data to the results database
+- **AND** register metadata in the project results table
+
+### Requirement: Skims and reports are available
+
+The system SHALL expose convergence reports and skim outputs generated during assignment.
+
+#### Scenario: Reading convergence report
+
+- **WHEN** a completed assignment is queried for its report
+- **THEN** the system SHALL return convergence data as tabular information
+
+#### Scenario: Reading class skims
+
+- **WHEN** assignment classes were configured to skim fields
+- **THEN** the system SHALL expose skim results by class identifier
+

--- a/openspec/specs/transit-gtfs/spec.md
+++ b/openspec/specs/transit-gtfs/spec.md
@@ -1,0 +1,81 @@
+# Transit GTFS Specification
+
+## Purpose
+
+This specification captures the current behavioral contract for GTFS import, transit databases, transit graph creation, and transit assignment support.
+
+## Requirements
+
+### Requirement: Transit database is available
+
+The system SHALL ensure that every loaded project has a transit database available for public transport workflows.
+
+#### Scenario: Loading transit gateway
+
+- **WHEN** a project loads its transit gateway
+- **THEN** the system SHALL create `public_transport.sqlite` if it does not exist
+- **AND** initialize transit tables and triggers
+
+### Requirement: GTFS route systems can be built
+
+The system SHALL create GTFS route-system builders configured for the active project and agency.
+
+#### Scenario: Creating a GTFS builder
+
+- **WHEN** a GTFS builder is requested with agency, file path, day, and description
+- **THEN** the system SHALL return a builder configured with default transit capacities and passenger-car equivalents
+- **AND** connect builder progress signals to the transit gateway
+
+### Requirement: Transit tables store imported service data
+
+The system SHALL store imported transit service data in the transit database using the transit table specification.
+
+#### Scenario: Storing route data
+
+- **WHEN** GTFS route data is imported
+- **THEN** the system SHALL store route patterns, agency references, route metadata, capacities, passenger-car equivalents, and route geometry
+
+#### Scenario: Storing trip schedules
+
+- **WHEN** GTFS trip schedules are imported
+- **THEN** the system SHALL store trip IDs, sequence numbers, arrivals, and departures with trip relationships
+
+### Requirement: Transit graphs are period-aware
+
+The system SHALL create, save, remove, and load transit graphs by project network period.
+
+#### Scenario: Creating a transit graph
+
+- **WHEN** a transit graph is created without an explicit period
+- **THEN** the system SHALL use the project's default period
+- **AND** store the graph in the transit graph registry for that period
+
+#### Scenario: Loading saved transit graphs
+
+- **WHEN** saved transit graphs are loaded
+- **THEN** the system SHALL load graph configurations for requested periods or all available periods
+
+### Requirement: Transit preload can be computed
+
+The system SHALL compute transit preload vectors over a requested time window.
+
+#### Scenario: Computing preload
+
+- **WHEN** transit preload is requested with start and end times
+- **THEN** the system SHALL aggregate transit trips active in the requested window into link-direction preload values
+
+#### Scenario: Selecting inclusion condition
+
+- **WHEN** an inclusion condition is specified
+- **THEN** the system SHALL include trips according to start, end, midpoint, or any-stop schedule logic as supported
+
+### Requirement: Transit assignment is supported
+
+The system SHALL support public transport assignment through transit classes and Optimal Strategies workflows.
+
+#### Scenario: Executing transit assignment
+
+- **WHEN** a transit assignment is configured with transit classes and required graph data
+- **THEN** the system SHALL execute the selected transit assignment procedure
+- **AND** expose assignment results through the assignment result interfaces
+

--- a/tests/aeq/project/test_matrices.py
+++ b/tests/aeq/project/test_matrices.py
@@ -1,10 +1,14 @@
 import string
 from math import floor
 from os.path import join
+from pathlib import Path
 from random import choice, randint
 from shutil import copyfile
 
+import numpy as np
 import pytest
+
+from aequilibrae.matrix import AequilibraeMatrix
 
 
 def randomword(length):
@@ -97,6 +101,65 @@ def test_delete(sioux_falls_example):
     assert cnt == 0, "Deleting matrix record failed"
     with pytest.raises(Exception):
         matrices.get_record("demand_omx")
+
+
+def test_import_file_omx(empty_project, omx_example):
+    matrices = empty_project.matrices
+
+    record = matrices.import_file(omx_example, name="imported_demand", file_name="imported_demand.omx")
+
+    assert record.name == "imported_demand"
+    assert record.file_name == "imported_demand.omx"
+    assert record.cores == 4
+    assert Path(matrices.fldr, "imported_demand.omx").is_file()
+
+    mat = matrices.get_matrix("imported_demand")
+    mat.computational_view(["m1"])
+    assert floor(mat.matrix_view.sum()) == 46
+    mat.close()
+
+
+def test_import_file_aem(empty_project, tmp_path):
+    source = tmp_path / "external_demand.aem"
+    source_matrix = AequilibraeMatrix()
+    source_matrix.create_empty(file_name=source, zones=2, matrix_names=["demand"], memory_only=False)
+    source_matrix.index[:] = np.array([10, 20])
+    source_matrix.matrix["demand"][:, :] = np.array([[1.0, 2.0], [3.0, 4.0]])
+    source_matrix.close()
+
+    matrices = empty_project.matrices
+    record = matrices.import_file(source, name="external_demand")
+
+    assert record.name == "external_demand"
+    assert record.file_name == "external_demand.aem"
+    assert record.cores == 1
+
+    mat = matrices.get_matrix("external_demand")
+    mat.computational_view(["demand"])
+    assert mat.matrix_view.sum() == 10.0
+    mat.close()
+
+
+def test_import_file_rejects_duplicates(empty_project, omx_example):
+    matrices = empty_project.matrices
+    matrices.import_file(omx_example, name="imported_demand", file_name="imported_demand.omx")
+
+    with pytest.raises(ValueError, match="already a matrix"):
+        matrices.import_file(omx_example, name="imported_demand", file_name="other_demand.omx")
+
+    with pytest.raises(ValueError, match="already a matrix record"):
+        matrices.import_file(omx_example, name="other_demand", file_name="imported_demand.omx")
+
+
+def test_import_file_rejects_unsupported_file(empty_project, tmp_path):
+    matrices = empty_project.matrices
+    unsupported = tmp_path / "demand.txt"
+    unsupported.write_text("not a matrix")
+
+    with pytest.raises(ValueError, match="Matrix needs to be either OMX or native AequilibraE"):
+        matrices.import_file(unsupported)
+
+    assert not Path(matrices.fldr, unsupported.name).exists()
 
 
 def test_list(sioux_falls_example):

--- a/tests/aeq/project/test_network_visum_geojson.py
+++ b/tests/aeq/project/test_network_visum_geojson.py
@@ -216,6 +216,10 @@ def test_create_from_visum_geojson_imports_network(empty_project, visum_geojson_
         assert conn.execute("select link_types is not null from nodes where node_id=1").fetchone()[0] == 1
         assert conn.execute("select a_node, b_node from links where visum_connector_no=9001").fetchone() == (1001, 1)
         assert conn.execute("select modes from links where visum_connector_no=9001").fetchone()[0] == "ch"
+        assert (
+            conn.execute("select visum_connector_key from links where visum_connector_no=9001").fetchone()[0]
+            == "connector:1001:1:B"
+        )
         assert conn.execute("select count(*) from matrices").fetchone()[0] == 0
 
     empty_project.network.build_graphs(
@@ -242,11 +246,264 @@ def test_create_from_visum_geojson_imports_network(empty_project, visum_geojson_
     assignment.set_capacity_field("capacity")
 
 
+def test_coincident_nodes_are_offset_to_preserve_topology(empty_project, visum_geojson_folder):
+    nodes = gpd.read_file(visum_geojson_folder / "node.geojson")
+    nodes.loc[len(nodes)] = {"NO": 3, "NAME": "C", "geometry": Point(0.01, 0.0)}
+    nodes = gpd.GeoDataFrame(nodes, geometry="geometry", crs="EPSG:4326")
+    nodes.to_file(visum_geojson_folder / "node.geojson", driver="GeoJSON")
+
+    links = gpd.read_file(visum_geojson_folder / "link.geojson")
+    duplicate_link = links.iloc[0].copy()
+    duplicate_link["NO"] = 101
+    duplicate_link["FROMNODENO"] = 3
+    duplicate_link["TONODENO"] = 1
+    duplicate_link["geometry"] = LineString([(0.01, 0.0, 5.0), (0.005, 0.0, 5.0), (0.0, 0.0, 5.0)])
+    links = gpd.GeoDataFrame([links.iloc[0], duplicate_link], geometry="geometry", crs="EPSG:4326")
+    links.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.imported_counts["nodes"] == 3
+    assert report.imported_counts["links"] == 2
+    assert any(diag.code == "coincident-node-offset" for diag in report.diagnostics)
+    assert report.source_references["node_coordinate_offsets"][2]["offset_m"] == 0.0
+    assert report.source_references["node_coordinate_offsets"][3]["offset_m"] == 0.25
+
+    with empty_project.db_connection_spatial as conn:
+        rows = conn.execute(
+            """
+            SELECT node_id, ST_X(geometry), ST_Y(geometry), visum_original_lon, visum_original_lat,
+                   visum_duplicate_coord_group, visum_coord_offset_m
+            FROM nodes
+            WHERE node_id in (2, 3)
+            ORDER BY node_id
+            """
+        ).fetchall()
+        link_endpoint_matches_node = conn.execute(
+            """
+            SELECT Abs(ST_X(StartPoint(links.geometry)) - ST_X(nodes.geometry)) < 1e-12
+                   AND Abs(ST_Y(StartPoint(links.geometry)) - ST_Y(nodes.geometry)) < 1e-12
+            FROM links
+            JOIN nodes ON links.a_node = nodes.node_id
+            WHERE links.link_id = 101
+            """
+        ).fetchone()[0]
+
+    assert rows[0][1:5] == (0.01, 0.0, 0.01, 0.0)
+    assert rows[0][5] == rows[1][5] == "node-coordinate-1"
+    assert rows[0][6] == 0.0
+    assert rows[1][3:5] == (0.01, 0.0)
+    assert rows[1][1] != rows[1][3] or rows[1][2] != rows[1][4]
+    assert rows[1][6] == 0.25
+    assert link_endpoint_matches_node == 1
+
+
+def test_coincident_node_error_policy_rejects_before_import(empty_project, visum_geojson_folder):
+    nodes = gpd.read_file(visum_geojson_folder / "node.geojson")
+    nodes.loc[len(nodes)] = {"NO": 3, "NAME": "C", "geometry": Point(0.01, 0.0)}
+    nodes = gpd.GeoDataFrame(nodes, geometry="geometry", crs="EPSG:4326")
+    nodes.to_file(visum_geojson_folder / "node.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="coincident-node-coordinate"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder, duplicate_node_policy="error")
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from nodes").fetchone()[0] == 0
+        assert conn.execute("select count(*) from links").fetchone()[0] == 0
+
+
+def test_source_node_id_collision_with_zone_id_is_remapped(empty_project, visum_geojson_folder):
+    nodes = gpd.read_file(visum_geojson_folder / "node.geojson")
+    nodes.loc[len(nodes)] = {"NO": 1001, "NAME": "source node with zone id", "geometry": Point(0.03, 0.0)}
+    nodes = gpd.GeoDataFrame(nodes, geometry="geometry", crs="EPSG:4326")
+    nodes.to_file(visum_geojson_folder / "node.geojson", driver="GeoJSON")
+
+    links = gpd.read_file(visum_geojson_folder / "link.geojson")
+    remapped_link = links.iloc[0].copy()
+    remapped_link["NO"] = 101
+    remapped_link["FROMNODENO"] = 1001
+    remapped_link["TONODENO"] = 1
+    remapped_link["geometry"] = LineString([(0.03, 0.0), (0.0, 0.0)])
+    links = gpd.GeoDataFrame([links.iloc[0], remapped_link], geometry="geometry", crs="EPSG:4326")
+    links.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+    remapped_node_id = report.source_references["nodes"][1001]
+
+    assert remapped_node_id != 1001
+    assert any(diag.code == "node-id-remapped" and diag.source_id == 1001 for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select is_centroid from nodes where node_id=1001").fetchone()[0] == 1
+        source_node_no = conn.execute(
+            "select visum_node_no from nodes where node_id=?", (remapped_node_id,)
+        ).fetchone()[0]
+        assert conn.execute("select a_node, b_node from links where link_id=101").fetchone() == (remapped_node_id, 1)
+
+    assert source_node_no == 1001
+
+
+def test_coincident_zone_centroid_is_offset_and_connectors_follow(empty_project, visum_geojson_folder):
+    centroids = gpd.read_file(visum_geojson_folder / "zone_centroid.geojson")
+    centroids.loc[centroids["NO"] == 1001, "geometry"] = Point(0.0, 0.0)
+    centroids.to_file(visum_geojson_folder / "zone_centroid.geojson", driver="GeoJSON")
+
+    connectors = gpd.read_file(visum_geojson_folder / "connector.geojson")
+    connectors.loc[connectors["ZONENO"] == 1001, "geometry"] = LineString([(0.0, 0.0), (0.0, 0.0)])
+    connectors.to_file(visum_geojson_folder / "connector.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert any(diag.code == "coincident-centroid-offset" and diag.source_id == 1001 for diag in report.diagnostics)
+    assert report.source_references["zone_coordinate_offsets"][1001]["offset_m"] == 0.25
+
+    with empty_project.db_connection_spatial as conn:
+        centroid = conn.execute(
+            """
+            SELECT ST_X(geometry), ST_Y(geometry), visum_original_lon, visum_original_lat,
+                   visum_duplicate_coord_group, visum_coord_offset_m
+            FROM nodes
+            WHERE node_id = 1001
+            """
+        ).fetchone()
+        connector_start_matches_centroid = conn.execute(
+            """
+            SELECT Abs(ST_X(StartPoint(links.geometry)) - ST_X(nodes.geometry)) < 1e-12
+                   AND Abs(ST_Y(StartPoint(links.geometry)) - ST_Y(nodes.geometry)) < 1e-12
+            FROM links
+            JOIN nodes ON links.a_node = nodes.node_id
+            WHERE links.visum_connector_no = 9001
+            """
+        ).fetchone()[0]
+
+    assert centroid[2:4] == (0.0, 0.0)
+    assert centroid[0] != centroid[2] or centroid[1] != centroid[3]
+    assert centroid[4] == "zone-coordinate-1"
+    assert centroid[5] == 0.25
+    assert connector_start_matches_centroid == 1
+
+
+def test_connector_without_no_gets_deterministic_source_key(empty_project, visum_geojson_folder):
+    connectors = gpd.read_file(visum_geojson_folder / "connector.geojson").drop(columns=["NO"])
+    connectors.to_file(visum_geojson_folder / "connector.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.source_references["connectors"] == {
+        "connector:1001:1:B": 101,
+        "connector:1002:2:B": 102,
+    }
+    with empty_project.db_connection as conn:
+        assert conn.execute("select visum_connector_no from links where link_id=101").fetchone()[0] is None
+        assert (
+            conn.execute("select visum_connector_key from links where link_id=101").fetchone()[0]
+            == "connector:1001:1:B"
+        )
+
+
+def test_duplicate_connector_source_keys_get_stable_suffix(empty_project, visum_geojson_folder):
+    connectors = gpd.read_file(visum_geojson_folder / "connector.geojson").drop(columns=["NO"])
+    connectors.loc[len(connectors)] = connectors.iloc[0]
+    connectors = gpd.GeoDataFrame(connectors, geometry="geometry", crs="EPSG:4326")
+    connectors.to_file(visum_geojson_folder / "connector.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.source_references["connectors"] == {
+        "connector:1001:1:B": 101,
+        "connector:1002:2:B": 102,
+        "connector:1001:1:B:2": 103,
+    }
+    with empty_project.db_connection as conn:
+        keys = conn.execute("select visum_connector_key from links where link_type='centroid_connector'").fetchall()
+
+    assert [row[0] for row in keys] == ["connector:1001:1:B", "connector:1002:2:B", "connector:1001:1:B:2"]
+
+
+def _external_visum_geojson_folder(request):
+    folder = request.config.getoption("--visum-geojson-folder")
+    if folder is None:
+        pytest.skip("Pass --visum-geojson-folder to run the external VISUM GeoJSON import smoke test")
+
+    folder = Path(folder)
+    if not folder.exists():
+        pytest.fail(f"VISUM GeoJSON folder does not exist: {folder}")
+    if not folder.is_dir():
+        pytest.fail(f"VISUM GeoJSON input must be a folder: {folder}")
+    return folder
+
+
+def _expected_external_visum_counts(request, folder):
+    option_names = {
+        "nodes": "--visum-expected-nodes",
+        "zones": "--visum-expected-zones",
+        "links": "--visum-expected-links",
+        "connectors": "--visum-expected-connectors",
+    }
+    layer_names = {
+        "nodes": "node",
+        "zones": "zone_centroid",
+        "links": "link",
+        "connectors": "connector",
+    }
+    report = discover_visum_geojson_layers(folder)
+    report.raise_for_errors()
+
+    expected = {}
+    for count_name, option_name in option_names.items():
+        option_value = request.config.getoption(option_name)
+        if option_value is not None:
+            expected[count_name] = option_value
+            continue
+
+        layer_path = report.discovered_layers[layer_names[count_name]]
+        expected[count_name] = len(gpd.read_file(layer_path))
+
+    return expected
+
+
+def test_external_visum_geojson_imports_expected_counts(empty_project, request):
+    folder = _external_visum_geojson_folder(request)
+    expected_counts = _expected_external_visum_counts(request, folder)
+
+    report = empty_project.network.create_from_visum_geojson(folder)
+
+    assert report.imported_counts == expected_counts
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from nodes").fetchone()[0] == (
+            expected_counts["nodes"] + expected_counts["zones"]
+        )
+        assert conn.execute("select count(*) from zones").fetchone()[0] == expected_counts["zones"]
+        assert conn.execute("select count(*) from links").fetchone()[0] == (
+            expected_counts["links"] + expected_counts["connectors"]
+        )
+
+
 def test_link_type_override(empty_project, visum_geojson_folder):
     empty_project.network.create_from_visum_geojson(visum_geojson_folder, link_type_mapping={"ARTERIAL": "arterial"})
 
     with empty_project.db_connection as conn:
         assert conn.execute("select link_type from links where link_id=100").fetchone()[0] == "arterial"
+
+
+def test_numeric_typeno_link_types_get_distinct_generated_names(empty_project, visum_geojson_folder):
+    link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    second = link.iloc[0].copy()
+    second["NO"] = 101
+    second["TYPENO"] = 92
+    second["R_TYPENO"] = 92
+    link = gpd.GeoDataFrame([link.iloc[0], second], geometry="geometry", crs="EPSG:4326").reset_index(drop=True)
+    link = link.drop(columns=["LC", "R_LC"])
+    link.loc[0, "TYPENO"] = 2
+    link.loc[0, "R_TYPENO"] = 2
+    link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.link_type_mapping == {"2": "visum_two", "92": "visum_nine_two"}
+    with empty_project.db_connection as conn:
+        assert conn.execute("select link_type from links where link_id=100").fetchone()[0] == "visum_two"
+        assert conn.execute("select link_type from links where link_id=101").fetchone()[0] == "visum_nine_two"
 
 
 def test_mode_override_merges_hgv_into_car(empty_project, visum_geojson_folder):
@@ -261,6 +518,82 @@ def test_mode_override_merges_hgv_into_car(empty_project, visum_geojson_folder):
     assert modes == "c"
     assert h_count == 0
     assert report.mode_mapping == {"CAR": "c", "HGV": "c"}
+
+
+def test_extra_transport_system_requires_mapping_or_ignore(empty_project, visum_geojson_folder):
+    link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    link.loc[0, "TSYSSET"] = "CAR,HGV,BUS"
+    link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="BUS"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from links").fetchone()[0] == 0
+
+
+def test_ignored_transport_system_is_reported_and_not_imported(empty_project, visum_geojson_folder):
+    link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    link.loc[0, "TSYSSET"] = "CAR,HGV,BUS"
+    link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(
+        visum_geojson_folder, ignored_transport_systems={"BUS"}
+    )
+
+    assert any(diag.code == "ignored-transport-system" and "BUS" in diag.message for diag in report.diagnostics)
+    with empty_project.db_connection as conn:
+        assert conn.execute("select modes from links where link_id=100").fetchone()[0] == "ch"
+
+
+def test_records_with_only_ignored_transport_systems_are_skipped(empty_project, visum_geojson_folder):
+    link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    link.loc[0, "TSYSSET"] = "BUS"
+    link.loc[0, "R_TSYSSET"] = "BUS"
+    link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(
+        visum_geojson_folder, ignored_transport_systems={"BUS"}
+    )
+
+    assert report.imported_counts["links"] == 0
+    assert report.imported_counts["connectors"] == 2
+    assert any(diag.code == "ignored-record" and diag.layer == "link" for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from links where visum_link_no=100").fetchone()[0] == 0
+        assert conn.execute("select count(*) from links where link_type='centroid_connector'").fetchone()[0] == 2
+
+
+def test_records_with_empty_transport_systems_are_skipped(empty_project, visum_geojson_folder):
+    link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    link.loc[0, "TSYSSET"] = ""
+    link.loc[0, "R_TSYSSET"] = None
+    link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.imported_counts["links"] == 0
+    assert any(diag.code == "empty-transport-systems" and diag.layer == "link" for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from links where visum_link_no=100").fetchone()[0] == 0
+
+
+def test_user_can_map_bus_as_assignable_mode(empty_project, visum_geojson_folder):
+    link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    link.loc[0, "TSYSSET"] = "CAR,HGV,BUS"
+    link.loc[0, "R_TSYSSET"] = "CAR,BUS"
+    link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(
+        visum_geojson_folder, mode_mapping={"CAR": "c", "HGV": "h", "BUS": "t"}
+    )
+
+    assert report.mode_mapping == {"CAR": "c", "HGV": "h", "BUS": "t"}
+    with empty_project.db_connection as conn:
+        assert conn.execute("select modes from links where link_id=100").fetchone()[0] == "cht"
+        assert conn.execute("select count(*) from modes where mode_id='t'").fetchone()[0] == 1
 
 
 def test_topology_validation_rejects_missing_node(tmp_path, visum_geojson_folder, empty_project):

--- a/tests/aeq/project/test_network_visum_geojson.py
+++ b/tests/aeq/project/test_network_visum_geojson.py
@@ -6,6 +6,8 @@ from shapely.geometry import LineString, Point, Polygon
 
 from aequilibrae import AequilibraeMatrix, TrafficAssignment, TrafficClass
 from aequilibrae.project.network.visum_geojson_importer import (
+    CONNECTOR_FALLBACK_CAPACITY,
+    CONNECTOR_FALLBACK_SPEED_KMH,
     discover_visum_geojson_layers,
     inventory_visum_layers,
     parse_visum_capacity,
@@ -198,7 +200,7 @@ def test_create_from_visum_geojson_imports_network(empty_project, visum_geojson_
     assert report.source_references["count_locations"] == [
         {
             "source_id": 5001,
-            "link_id": 100,
+            "link_id": 1,
             "counts": {"DTVW": 1300, "HVG_ORIG": 120, "MOTOR_ORIG": 1070, "CAR_ORIG": 950},
         }
     ]
@@ -206,12 +208,16 @@ def test_create_from_visum_geojson_imports_network(empty_project, visum_geojson_
 
     with empty_project.db_connection as conn:
         assert conn.execute("select count(*) from nodes").fetchone()[0] == 4
-        assert conn.execute("select count(*) from links").fetchone()[0] == 3
+        assert conn.execute("select count(*) from links").fetchone()[0] == 4
         assert conn.execute("select count(*) from zones").fetchone()[0] == 2
         assert conn.execute("select count(*) from modes where mode_id='h'").fetchone()[0] == 1
-        assert conn.execute("select visum_length_ab from links where link_id=100").fetchone()[0] == 1000
-        assert conn.execute("select a_node, b_node from links where link_id=100").fetchone() == (1, 2)
-        assert conn.execute("select distance > 0 from links where link_id=100").fetchone()[0] == 1
+        assert conn.execute("select link_id from links order by link_id").fetchall() == [(1,), (2,), (3,), (4,)]
+        assert conn.execute("select visum_link_no from links where link_id=1").fetchone()[0] == 100
+        assert conn.execute("select direction, modes from links where link_id=1").fetchone() == (1, "ch")
+        assert conn.execute("select direction, modes from links where link_id=2").fetchone() == (-1, "c")
+        assert conn.execute("select visum_length_ab from links where visum_link_no=100").fetchone()[0] == 1000
+        assert conn.execute("select a_node, b_node from links where visum_link_no=100").fetchone() == (1, 2)
+        assert conn.execute("select distance > 0 from links where visum_link_no=100").fetchone()[0] == 1
         assert conn.execute("select modes is not null from nodes where node_id=1").fetchone()[0] == 1
         assert conn.execute("select link_types is not null from nodes where node_id=1").fetchone()[0] == 1
         assert conn.execute("select a_node, b_node from links where visum_connector_no=9001").fetchone() == (1001, 1)
@@ -285,7 +291,7 @@ def test_coincident_nodes_are_offset_to_preserve_topology(empty_project, visum_g
                    AND Abs(ST_Y(StartPoint(links.geometry)) - ST_Y(nodes.geometry)) < 1e-12
             FROM links
             JOIN nodes ON links.a_node = nodes.node_id
-            WHERE links.link_id = 101
+            WHERE links.visum_link_no = 101
             """
         ).fetchone()[0]
 
@@ -296,6 +302,22 @@ def test_coincident_nodes_are_offset_to_preserve_topology(empty_project, visum_g
     assert rows[1][1] != rows[1][3] or rows[1][2] != rows[1][4]
     assert rows[1][6] == 0.25
     assert link_endpoint_matches_node == 1
+
+
+def test_sparse_visum_link_numbers_import_as_compact_link_ids(empty_project, visum_geojson_folder):
+    links = gpd.read_file(visum_geojson_folder / "link.geojson")
+    links.loc[links.index[0], "NO"] = 2_000_001_598
+    links.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.source_references["links"][2_000_001_598] == 1
+    assert report.source_references["count_locations"] == []
+    assert any(diag.code == "unresolved-count-link" for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select min(link_id), max(link_id), count(*) from links").fetchone() == (1, 4, 4)
+        assert conn.execute("select visum_link_no from links where link_id=1").fetchone()[0] == 2_000_001_598
 
 
 def test_coincident_node_error_policy_rejects_before_import(empty_project, visum_geojson_folder):
@@ -338,7 +360,10 @@ def test_source_node_id_collision_with_zone_id_is_remapped(empty_project, visum_
         source_node_no = conn.execute(
             "select visum_node_no from nodes where node_id=?", (remapped_node_id,)
         ).fetchone()[0]
-        assert conn.execute("select a_node, b_node from links where link_id=101").fetchone() == (remapped_node_id, 1)
+        assert conn.execute("select a_node, b_node from links where visum_link_no=101").fetchone() == (
+            remapped_node_id,
+            1,
+        )
 
     assert source_node_no == 1001
 
@@ -390,13 +415,13 @@ def test_connector_without_no_gets_deterministic_source_key(empty_project, visum
     report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
 
     assert report.source_references["connectors"] == {
-        "connector:1001:1:B": 101,
-        "connector:1002:2:B": 102,
+        "connector:1001:1:B": 3,
+        "connector:1002:2:B": 4,
     }
     with empty_project.db_connection as conn:
-        assert conn.execute("select visum_connector_no from links where link_id=101").fetchone()[0] is None
+        assert conn.execute("select visum_connector_no from links where link_id=3").fetchone()[0] is None
         assert (
-            conn.execute("select visum_connector_key from links where link_id=101").fetchone()[0]
+            conn.execute("select visum_connector_key from links where link_id=3").fetchone()[0]
             == "connector:1001:1:B"
         )
 
@@ -410,9 +435,9 @@ def test_duplicate_connector_source_keys_get_stable_suffix(empty_project, visum_
     report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
 
     assert report.source_references["connectors"] == {
-        "connector:1001:1:B": 101,
-        "connector:1002:2:B": 102,
-        "connector:1001:1:B:2": 103,
+        "connector:1001:1:B": 3,
+        "connector:1002:2:B": 4,
+        "connector:1001:1:B:2": 5,
     }
     with empty_project.db_connection as conn:
         keys = conn.execute("select visum_connector_key from links where link_type='centroid_connector'").fetchall()
@@ -483,7 +508,7 @@ def test_link_type_override(empty_project, visum_geojson_folder):
     empty_project.network.create_from_visum_geojson(visum_geojson_folder, link_type_mapping={"ARTERIAL": "arterial"})
 
     with empty_project.db_connection as conn:
-        assert conn.execute("select link_type from links where link_id=100").fetchone()[0] == "arterial"
+        assert conn.execute("select link_type from links where visum_link_no=100").fetchone()[0] == "arterial"
 
 
 def test_numeric_typeno_link_types_get_distinct_generated_names(empty_project, visum_geojson_folder):
@@ -502,8 +527,8 @@ def test_numeric_typeno_link_types_get_distinct_generated_names(empty_project, v
 
     assert report.link_type_mapping == {"2": "visum_two", "92": "visum_nine_two"}
     with empty_project.db_connection as conn:
-        assert conn.execute("select link_type from links where link_id=100").fetchone()[0] == "visum_two"
-        assert conn.execute("select link_type from links where link_id=101").fetchone()[0] == "visum_nine_two"
+        assert conn.execute("select link_type from links where visum_link_no=100").fetchone()[0] == "visum_two"
+        assert conn.execute("select link_type from links where visum_link_no=101").fetchone()[0] == "visum_nine_two"
 
 
 def test_mode_override_merges_hgv_into_car(empty_project, visum_geojson_folder):
@@ -512,7 +537,7 @@ def test_mode_override_merges_hgv_into_car(empty_project, visum_geojson_folder):
     )
 
     with empty_project.db_connection as conn:
-        modes = conn.execute("select modes from links where link_id=100").fetchone()[0]
+        modes = conn.execute("select modes from links where visum_link_no=100").fetchone()[0]
         h_count = conn.execute("select count(*) from modes where mode_id='h'").fetchone()[0]
 
     assert modes == "c"
@@ -543,7 +568,7 @@ def test_ignored_transport_system_is_reported_and_not_imported(empty_project, vi
 
     assert any(diag.code == "ignored-transport-system" and "BUS" in diag.message for diag in report.diagnostics)
     with empty_project.db_connection as conn:
-        assert conn.execute("select modes from links where link_id=100").fetchone()[0] == "ch"
+        assert conn.execute("select modes from links where visum_link_no=100").fetchone()[0] == "ch"
 
 
 def test_records_with_only_ignored_transport_systems_are_skipped(empty_project, visum_geojson_folder):
@@ -592,8 +617,37 @@ def test_user_can_map_bus_as_assignable_mode(empty_project, visum_geojson_folder
 
     assert report.mode_mapping == {"CAR": "c", "HGV": "h", "BUS": "t"}
     with empty_project.db_connection as conn:
-        assert conn.execute("select modes from links where link_id=100").fetchone()[0] == "cht"
+        assert conn.execute("select modes from links where visum_link_no=100").fetchone()[0] == "cht"
         assert conn.execute("select count(*) from modes where mode_id='t'").fetchone()[0] == 1
+
+
+def test_mode_excluded_missing_fields_do_not_poison_car_graph(empty_project, visum_geojson_folder):
+    links = gpd.read_file(visum_geojson_folder / "link.geojson")
+    transit_only = links.iloc[0].copy()
+    transit_only["NO"] = 200
+    transit_only["TSYSSET"] = "BUS"
+    transit_only["R_TSYSSET"] = "BUS"
+    for field in ("V0PRT", "R_V0PRT", "CAPPRT", "R_CAPPRT", "T0PRT", "R_T0PRT"):
+        if field in transit_only.index:
+            transit_only[field] = None
+    links = gpd.GeoDataFrame([links.iloc[0], transit_only], geometry="geometry", crs="EPSG:4326")
+    links.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    empty_project.network.create_from_visum_geojson(
+        visum_geojson_folder, mode_mapping={"CAR": "c", "HGV": "h", "BUS": "t"}
+    )
+    with empty_project.db_connection as conn:
+        transit_link_id = conn.execute("select link_id from links where visum_link_no=200").fetchone()[0]
+    empty_project.network.build_graphs(
+        fields=["distance", "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"], modes=["c"]
+    )
+
+    graph = empty_project.network.graphs["c"].graph
+    transit_self_loop = graph[graph.link_id == transit_link_id]
+
+    assert transit_self_loop.a_node.eq(transit_self_loop.b_node).all()
+    assert not graph.travel_time.isna().any()
+    assert not graph.capacity.isna().any()
 
 
 def test_topology_validation_rejects_missing_node(tmp_path, visum_geojson_folder, empty_project):
@@ -656,3 +710,31 @@ def test_non_positive_assignment_fields_are_diagnostic_warnings(visum_geojson_fo
     assert any(diag.code == "non-assignment-ready" and diag.field == "CAPPRT" for diag in report.diagnostics)
     assert any(diag.code == "non-assignment-ready" and diag.field == "R_T0PRT" for diag in report.diagnostics)
     assert any(diag.code == "non-assignment-ready" and diag.field == "R_CAPPRT" for diag in report.diagnostics)
+
+
+def test_connector_assignment_fields_default_when_not_exported(visum_geojson_folder, empty_project):
+    connectors = gpd.read_file(visum_geojson_folder / "connector.geojson")
+    connectors = connectors.drop(columns=["V0PRT", "R_V0PRT", "CAPPRT", "R_CAPPRT"])
+    connectors.loc[connectors.index[0], ["LENGTH", "R_LENGTH"]] = "0km"
+    connectors.to_file(visum_geojson_folder / "connector.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    expected_time = (100.0 / 1000.0) / CONNECTOR_FALLBACK_SPEED_KMH * 60.0
+
+    assert any(diag.code == "connector-length-defaulted" for diag in report.diagnostics)
+    assert any(diag.code == "connector-speed-defaulted" for diag in report.diagnostics)
+    assert any(diag.code == "connector-capacity-defaulted" for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        row = conn.execute(
+            """
+            SELECT travel_time_ab, travel_time_ba, capacity_ab, capacity_ba
+            FROM links
+            WHERE visum_connector_no=9001
+            """
+        ).fetchone()
+
+    assert row[0] > expected_time
+    assert row[1] > expected_time
+    assert row[2:] == (CONNECTOR_FALLBACK_CAPACITY, CONNECTOR_FALLBACK_CAPACITY)

--- a/tests/aeq/project/test_network_visum_geojson.py
+++ b/tests/aeq/project/test_network_visum_geojson.py
@@ -1,0 +1,325 @@
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString, Point, Polygon
+
+from aequilibrae import AequilibraeMatrix, TrafficAssignment, TrafficClass
+from aequilibrae.project.network.visum_geojson_importer import (
+    discover_visum_geojson_layers,
+    inventory_visum_layers,
+    parse_visum_capacity,
+    parse_visum_length,
+    parse_visum_speed,
+    parse_visum_time,
+    read_visum_geojson_layers,
+)
+
+
+def _write_layer(path: Path, records, crs="EPSG:4326"):
+    gdf = gpd.GeoDataFrame(records, crs=crs)
+    gdf.to_file(path, driver="GeoJSON")
+    return gdf
+
+
+@pytest.fixture
+def visum_geojson_folder(tmp_path):
+    folder = tmp_path / "visum"
+    folder.mkdir()
+    _write_layer(
+        folder / "node.geojson",
+        [
+            {"NO": 1, "NAME": "A", "geometry": Point(0.0, 0.0)},
+            {"NO": 2, "NAME": "B", "geometry": Point(0.01, 0.0)},
+        ],
+    )
+    _write_layer(
+        folder / "link.geojson",
+        [
+            {
+                "NO": 100,
+                "FROMNODENO": 1,
+                "TONODENO": 2,
+                "TSYSSET": "CAR,HGV",
+                "R_TSYSSET": "CAR",
+                "LC": "ARTERIAL",
+                "R_LC": "LOCAL",
+                "TYPENO": 10,
+                "R_TYPENO": 20,
+                "LENGTH": "1km",
+                "R_LENGTH": "1.1km",
+                "V0PRT": "60km/h",
+                "R_V0PRT": "55km/h",
+                "CAPPRT": "1200veh/h",
+                "R_CAPPRT": "1100veh/h",
+                "geometry": LineString([(0.0, 0.0), (0.01, 0.0)]),
+            }
+        ],
+    )
+    _write_layer(
+        folder / "zone_centroid.geojson",
+        [
+            {"NO": 1001, "NAME": "Z1", "geometry": Point(-0.01, 0.0)},
+            {"NO": 1002, "NAME": "Z2", "geometry": Point(0.02, 0.0)},
+        ],
+    )
+    _write_layer(
+        folder / "zone_polygon.geojson",
+        [
+            {
+                "NO": 1001,
+                "NAME": "Z1",
+                "geometry": Polygon([(-0.02, -0.01), (-0.005, -0.01), (-0.005, 0.01), (-0.02, 0.01)]),
+            },
+            {
+                "NO": 1002,
+                "NAME": "Z2",
+                "geometry": Polygon([(0.015, -0.01), (0.03, -0.01), (0.03, 0.01), (0.015, 0.01)]),
+            },
+        ],
+    )
+    _write_layer(
+        folder / "connector.geojson",
+        [
+            {
+                "NO": 9001,
+                "ZONENO": 1001,
+                "NODENO": 1,
+                "TSYSSET": "CAR,HGV",
+                "R_TSYSSET": "CAR,HGV",
+                "LENGTH": "100m",
+                "R_LENGTH": "100m",
+                "V0PRT": "30km/h",
+                "R_V0PRT": "30km/h",
+                "CAPPRT": "9999veh/h",
+                "R_CAPPRT": "9999veh/h",
+                "geometry": LineString([(-0.01, 0.0), (0.0, 0.0)]),
+            },
+            {
+                "NO": 9002,
+                "ZONENO": 1002,
+                "NODENO": 2,
+                "TSYSSET": "CAR,HGV",
+                "R_TSYSSET": "CAR,HGV",
+                "LENGTH": "100m",
+                "R_LENGTH": "100m",
+                "V0PRT": "30km/h",
+                "R_V0PRT": "30km/h",
+                "CAPPRT": "9999veh/h",
+                "R_CAPPRT": "9999veh/h",
+                "geometry": LineString([(0.02, 0.0), (0.01, 0.0)]),
+            },
+        ],
+    )
+    _write_layer(
+        folder / "countlocation.geojson",
+        [
+            {
+                "NO": 5001,
+                "LINKNO": 100,
+                "FROMNODENO": 1,
+                "TONODENO": 2,
+                "CAR_ORIG": 950,
+                "HVG_ORIG": 120,
+                "MOTOR_ORIG": 1070,
+                "DTVW": 1300,
+                "CARS_LEFT": 10,
+                "geometry": Point(0.005, 0.0),
+            }
+        ],
+    )
+    _write_layer(folder / "stop.geojson", [{"NO": 3001, "geometry": Point(0.0, 0.01)}])
+    return folder
+
+
+def test_discovery_inventory_and_deferred_layers(visum_geojson_folder):
+    report = discover_visum_geojson_layers(visum_geojson_folder)
+
+    assert not report.errors
+    assert set(report.discovered_layers) == {
+        "node",
+        "link",
+        "zone_centroid",
+        "zone_polygon",
+        "connector",
+        "countlocation",
+    }
+    assert "stop" in report.deferred_layers
+
+    layers, report = read_visum_geojson_layers(report.discovered_layers, report)
+    inventory = inventory_visum_layers(layers)
+
+    assert inventory["link"]["R_TSYSSET"]["role"] == "directional"
+    assert inventory["countlocation"]["CARS_LEFT"]["role"] == "deferred"
+
+
+def test_explicit_layer_mapping_and_missing_layer(visum_geojson_folder):
+    report = discover_visum_geojson_layers(
+        {
+            "node": visum_geojson_folder / "node.geojson",
+            "link": visum_geojson_folder / "link.geojson",
+        }
+    )
+
+    assert {diag.layer for diag in report.errors} == {"connector", "zone_centroid"}
+
+
+def test_unit_parsing():
+    assert parse_visum_length("1.5km") == 1500
+    assert parse_visum_length("25m") == 25
+    assert parse_visum_speed("10m/s") == 36
+    assert parse_visum_time("120s") == 2
+    assert parse_visum_capacity("1800veh/h") == 1800
+
+    with pytest.raises(ValueError):
+        parse_visum_speed("10furlongs/h")
+
+
+def test_crs_requires_explicit_assumption(monkeypatch, visum_geojson_folder):
+    gdf = gpd.read_file(visum_geojson_folder / "node.geojson")
+    gdf = gdf.set_crs(None, allow_override=True)
+    monkeypatch.setattr(gpd, "read_file", lambda path: gdf)
+
+    layers, report = read_visum_geojson_layers({"node": "node.geojson"})
+
+    assert "node" in layers
+    assert any(diag.code == "missing-crs" for diag in report.errors)
+
+    _, report = read_visum_geojson_layers({"node": "node.geojson"}, accept_default_crs=True)
+
+    assert not report.errors
+    assert any(diag.code == "default-crs-assumed" for diag in report.diagnostics)
+
+
+def test_create_from_visum_geojson_imports_network(empty_project, visum_geojson_folder):
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert report.imported_counts == {"nodes": 2, "zones": 2, "links": 1, "connectors": 2}
+    assert report.source_references["count_locations"] == [
+        {
+            "source_id": 5001,
+            "link_id": 100,
+            "counts": {"DTVW": 1300, "HVG_ORIG": 120, "MOTOR_ORIG": 1070, "CAR_ORIG": 950},
+        }
+    ]
+    assert any(diag.code == "deferred-count-fields" for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from nodes").fetchone()[0] == 4
+        assert conn.execute("select count(*) from links").fetchone()[0] == 3
+        assert conn.execute("select count(*) from zones").fetchone()[0] == 2
+        assert conn.execute("select count(*) from modes where mode_id='h'").fetchone()[0] == 1
+        assert conn.execute("select visum_length_ab from links where link_id=100").fetchone()[0] == 1000
+        assert conn.execute("select a_node, b_node from links where link_id=100").fetchone() == (1, 2)
+        assert conn.execute("select distance > 0 from links where link_id=100").fetchone()[0] == 1
+        assert conn.execute("select modes is not null from nodes where node_id=1").fetchone()[0] == 1
+        assert conn.execute("select link_types is not null from nodes where node_id=1").fetchone()[0] == 1
+        assert conn.execute("select a_node, b_node from links where visum_connector_no=9001").fetchone() == (1001, 1)
+        assert conn.execute("select modes from links where visum_connector_no=9001").fetchone()[0] == "ch"
+        assert conn.execute("select count(*) from matrices").fetchone()[0] == 0
+
+    empty_project.network.build_graphs(
+        fields=["distance", "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"], modes=["c"]
+    )
+    empty_project.network.set_time_field("travel_time")
+
+    assert "c" in empty_project.network.graphs
+    assert empty_project.network.graphs["c"].centroids.tolist() == [1001, 1002]
+    assert empty_project.network.count_centroids() == 2
+
+    matrix = AequilibraeMatrix()
+    matrix.create_empty(zones=2, matrix_names=["demand"])
+    matrix.index[:] = [1001, 1002]
+    matrix.matrices[:, :, 0] = 0
+    matrix.computational_view(["demand"])
+
+    graph = empty_project.network.graphs["c"]
+    graph.set_blocked_centroid_flows(False)
+    traffic_class = TrafficClass("car", graph, matrix)
+    assignment = TrafficAssignment(empty_project)
+    assignment.add_class(traffic_class)
+    assignment.set_time_field("travel_time")
+    assignment.set_capacity_field("capacity")
+
+
+def test_link_type_override(empty_project, visum_geojson_folder):
+    empty_project.network.create_from_visum_geojson(visum_geojson_folder, link_type_mapping={"ARTERIAL": "arterial"})
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select link_type from links where link_id=100").fetchone()[0] == "arterial"
+
+
+def test_mode_override_merges_hgv_into_car(empty_project, visum_geojson_folder):
+    report = empty_project.network.create_from_visum_geojson(
+        visum_geojson_folder, mode_mapping={"CAR": "c", "HGV": "c"}
+    )
+
+    with empty_project.db_connection as conn:
+        modes = conn.execute("select modes from links where link_id=100").fetchone()[0]
+        h_count = conn.execute("select count(*) from modes where mode_id='h'").fetchone()[0]
+
+    assert modes == "c"
+    assert h_count == 0
+    assert report.mode_mapping == {"CAR": "c", "HGV": "c"}
+
+
+def test_topology_validation_rejects_missing_node(tmp_path, visum_geojson_folder, empty_project):
+    bad_link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    bad_link.loc[0, "TONODENO"] = 999
+    bad_link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="missing-node-reference"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+
+def test_topology_validation_rejects_endpoint_mismatch(visum_geojson_folder, empty_project):
+    bad_link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    bad_link.loc[0, "geometry"] = LineString([(0.001, 0.0), (0.01, 0.0)])
+    bad_link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="endpoint-mismatch"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+
+def test_connector_validation_rejects_missing_zone(visum_geojson_folder, empty_project):
+    bad_connector = gpd.read_file(visum_geojson_folder / "connector.geojson")
+    bad_connector.loc[0, "ZONENO"] = 999
+    bad_connector.to_file(visum_geojson_folder / "connector.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="missing-zone-reference"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+
+def test_connector_validation_rejects_endpoint_mismatch(visum_geojson_folder, empty_project):
+    bad_connector = gpd.read_file(visum_geojson_folder / "connector.geojson")
+    bad_connector.loc[0, "geometry"] = LineString([(-0.011, 0.0), (0.0, 0.0)])
+    bad_connector.to_file(visum_geojson_folder / "connector.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="endpoint-mismatch"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+
+def test_invalid_units_are_reported_before_import(visum_geojson_folder, empty_project):
+    bad_link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    bad_link.loc[0, "V0PRT"] = "10furlongs/h"
+    bad_link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    with pytest.raises(ValueError, match="invalid-unit"):
+        empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from links").fetchone()[0] == 0
+
+
+def test_non_positive_assignment_fields_are_diagnostic_warnings(visum_geojson_folder, empty_project):
+    bad_link = gpd.read_file(visum_geojson_folder / "link.geojson")
+    bad_link.loc[0, "CAPPRT"] = "0veh/h"
+    bad_link.loc[0, "R_T0PRT"] = "-1min"
+    bad_link.loc[0, "R_CAPPRT"] = None
+    bad_link.to_file(visum_geojson_folder / "link.geojson", driver="GeoJSON")
+
+    report = empty_project.network.create_from_visum_geojson(visum_geojson_folder)
+
+    assert any(diag.code == "non-assignment-ready" and diag.field == "CAPPRT" for diag in report.diagnostics)
+    assert any(diag.code == "non-assignment-ready" and diag.field == "R_T0PRT" for diag in report.diagnostics)
+    assert any(diag.code == "non-assignment-ready" and diag.field == "R_CAPPRT" for diag in report.diagnostics)

--- a/tests/aeq/project/test_network_visum_sqlite.py
+++ b/tests/aeq/project/test_network_visum_sqlite.py
@@ -1,0 +1,239 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from aequilibrae.project.network.visum_sqlite_importer import (
+    VISUM_SQLITE_CONNECTOR_EPSILON_MINUTES,
+    discover_visum_sqlite,
+    visum_sqlite_source_connectivity,
+)
+
+
+def _create_visum_sqlite(path: Path, *, invalid_crs: bool = False, omit_table: str | None = None) -> Path:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE NETWORK(PROJECTIONDEFINITION TEXT);
+            CREATE TABLE NODE(NO INTEGER PRIMARY KEY, NAME TEXT, TYPENO INTEGER, XCOORD REAL, YCOORD REAL);
+            CREATE TABLE ZONE(
+                NO INTEGER PRIMARY KEY,
+                NAME TEXT,
+                TYPENO INTEGER,
+                XCOORD REAL,
+                YCOORD REAL,
+                SURFACEID INTEGER
+            );
+            CREATE TABLE TSYS(CODE TEXT PRIMARY KEY, NAME TEXT, TYPE TEXT, PCU REAL);
+            CREATE TABLE MODE(CODE TEXT PRIMARY KEY, NAME TEXT, TSYSSET TEXT);
+            CREATE TABLE LINKTYPE(NO INTEGER PRIMARY KEY, NAME TEXT, TSYSSET TEXT, CAPPRT INTEGER, V0PRT REAL);
+            CREATE TABLE LINK(
+                NO INTEGER,
+                FROMNODENO INTEGER,
+                TONODENO INTEGER,
+                NAME TEXT,
+                TYPENO INTEGER,
+                TSYSSET TEXT,
+                LENGTH REAL,
+                CAPPRT INTEGER,
+                V0PRT REAL,
+                LC TEXT
+            );
+            CREATE TABLE CONNECTOR(
+                ZONENO INTEGER,
+                NODENO INTEGER,
+                DIRECTION TEXT,
+                TYPENO INTEGER,
+                TSYSSET TEXT,
+                LENGTH REAL,
+                "T0_TSYS(CAR)" INTEGER,
+                "T0_TSYS(HGV)" INTEGER,
+                "WEIGHT(PRT)" INTEGER
+            );
+            CREATE TABLE LINKPOLY(FROMNODENO INTEGER, TONODENO INTEGER, "INDEX" INTEGER, XCOORD REAL, YCOORD REAL);
+            CREATE TABLE POINT(ID INTEGER PRIMARY KEY, XCOORD REAL, YCOORD REAL);
+            CREATE TABLE EDGE(ID INTEGER PRIMARY KEY, FROMPOINTID INTEGER, TOPOINTID INTEGER);
+            CREATE TABLE FACEITEM(FACEID INTEGER, "INDEX" INTEGER, EDGEID INTEGER, DIRECTION INTEGER);
+            CREATE TABLE SURFACEITEM(SURFACEID INTEGER, FACEID INTEGER, ENCLAVE INTEGER);
+            CREATE TABLE COUNTLOCATION(
+                NO INTEGER PRIMARY KEY,
+                LINKNO INTEGER,
+                FROMNODENO INTEGER,
+                TONODENO INTEGER,
+                CAR_ORIG INTEGER,
+                HVG_ORIG INTEGER,
+                MOTOR_ORIG INTEGER,
+                DTVW INTEGER,
+                CARS_LEFT INTEGER
+            );
+            CREATE TABLE STOP(NO INTEGER PRIMARY KEY);
+            """
+        )
+        crs = "not-a-crs" if invalid_crs else "EPSG:4326"
+        conn.execute("INSERT INTO NETWORK VALUES(?)", (crs,))
+        conn.executemany(
+            "INSERT INTO TSYS VALUES(?, ?, ?, ?)",
+            [
+                ("CAR", "Car", "PrT", 1.0),
+                ("HGV", "HGV", "PrT", 2.0),
+                ("BUS", "Bus", "PuT", 1.0),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO MODE VALUES(?, ?, ?)",
+            [("C", "Car", "CAR"), ("H", "HGV", "HGV"), ("PuT", "PuT", "BUS")],
+        )
+        conn.executemany(
+            "INSERT INTO LINKTYPE VALUES(?, ?, ?, ?, ?)",
+            [(10, "arterial", "CAR,HGV", 1200, 60.0), (20, "closed", "", 0, 0.0)],
+        )
+        conn.executemany(
+            "INSERT INTO NODE VALUES(?, ?, ?, ?, ?)",
+            [
+                (1, "A", 1, 0.0, 0.0),
+                (2, "B", 1, 0.01, 0.0),
+                (3, "B duplicate", 1, 0.01, 0.0),
+                (1001, "Regular node colliding with zone ID", 1, 0.03, 0.0),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO ZONE VALUES(?, ?, ?, ?, ?, ?)",
+            [(1001, "Z1", 1, -0.01, 0.0, 1), (1002, "Z2", 1, 0.02, 0.0, None)],
+        )
+        conn.executemany(
+            "INSERT INTO LINK VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (550000000, 1, 2, "L1", 10, "CAR,HGV", 1.0, 1200, 60.0, "ARTERIAL"),
+                (550000000, 2, 1, "L1", 10, "CAR", 1.1, 1100, 55.0, "LOCAL"),
+                (660000000, 2, 1001, "Closed", 20, "", 0.1, 0, 0.0, "closed"),
+                (660000000, 1001, 2, "Closed", 20, "", 0.1, 0, 0.0, "closed"),
+            ],
+        )
+        conn.execute("INSERT INTO LINKPOLY VALUES(1, 2, 1, 0.005, 0.001)")
+        conn.executemany(
+            'INSERT INTO CONNECTOR VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                (1001, 1, "O", 0, "CAR,HGV", 0.1, 60, 60, 100),
+                (1001, 1, "D", 0, "CAR,HGV", 0.1, 120, 120, 100),
+                (1002, 2, "O", 0, "CAR,HGV", 0.0, 0, 0, 100),
+                (1002, 2, "D", 0, "CAR,HGV", 0.0, 0, 0, 100),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO POINT VALUES(?, ?, ?)",
+            [(1, -0.02, -0.01), (2, 0.0, -0.01), (3, 0.0, 0.01), (4, -0.02, 0.01)],
+        )
+        conn.executemany("INSERT INTO EDGE VALUES(?, ?, ?)", [(1, 1, 2), (2, 2, 3), (3, 3, 4), (4, 4, 1)])
+        conn.executemany(
+            "INSERT INTO FACEITEM VALUES(?, ?, ?, ?)",
+            [(1, 1, 1, 0), (1, 2, 2, 0), (1, 3, 3, 0), (1, 4, 4, 0)],
+        )
+        conn.execute("INSERT INTO SURFACEITEM VALUES(1, 1, 0)")
+        conn.execute("INSERT INTO COUNTLOCATION VALUES(1, 550000000, 1, 2, 950, 120, 1070, 1300, 10)")
+        if omit_table is not None:
+            conn.execute(f'DROP TABLE "{omit_table}"')
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+@pytest.fixture
+def visum_sqlite_file(tmp_path):
+    return _create_visum_sqlite(tmp_path / "visum.sqlite3")
+
+
+def test_discover_visum_sqlite_reports_tables(visum_sqlite_file):
+    report = discover_visum_sqlite(visum_sqlite_file)
+
+    assert not report.errors
+    assert report.discovered_layers["node"] == "NODE"
+    assert "STOP" in report.deferred_layers
+    assert any(diag.code == "deferred-table" for diag in report.diagnostics)
+
+
+def test_discover_visum_sqlite_rejects_missing_required_table(tmp_path):
+    path = _create_visum_sqlite(tmp_path / "visum.sqlite3", omit_table="CONNECTOR")
+    report = discover_visum_sqlite(path)
+
+    assert {diag.code for diag in report.errors} == {"missing-table"}
+    assert {diag.layer for diag in report.errors} == {"CONNECTOR"}
+
+
+def test_create_from_visum_sqlite_imports_network(empty_project, visum_sqlite_file):
+    report = empty_project.network.create_from_visum_sqlite(visum_sqlite_file)
+
+    assert report.imported_counts == {"nodes": 4, "zones": 2, "links": 1, "connectors": 2}
+    assert report.source_references["links"] == {550000000: 1}
+    assert report.source_references["count_locations"] == [
+        {
+            "source_id": 1,
+            "link_id": 1,
+            "counts": {"DTVW": 1300, "HVG_ORIG": 120, "MOTOR_ORIG": 1070, "CAR_ORIG": 950},
+        }
+    ]
+    assert any(diag.code == "sqlite-zero-connector-time" for diag in report.diagnostics)
+    assert any(diag.code == "coincident-node-offset" for diag in report.diagnostics)
+    assert any(diag.code == "node-id-remapped" for diag in report.diagnostics)
+
+    with empty_project.db_connection as conn:
+        assert conn.execute("select count(*) from nodes").fetchone()[0] == 6
+        assert conn.execute("select count(*) from zones").fetchone()[0] == 2
+        assert conn.execute("select count(*) from links").fetchone()[0] == 4
+        assert conn.execute("select link_id from links order by link_id").fetchall() == [(1,), (2,), (3,), (4,)]
+        assert conn.execute("select visum_link_no from links where link_id=1").fetchone()[0] == 550000000
+        assert conn.execute("select direction, modes from links where link_id=1").fetchone() == (1, "ch")
+        assert conn.execute("select direction, modes from links where link_id=2").fetchone() == (-1, "c")
+        assert conn.execute("select travel_time_ab from links where link_id=1").fetchone()[0] == pytest.approx(1.0)
+        assert conn.execute("select travel_time_ba from links where link_id=2").fetchone()[0] == pytest.approx(1.2)
+        assert conn.execute("select visum_length_ab from links where link_id=1").fetchone()[0] == pytest.approx(1000.0)
+        assert conn.execute("select count(*) from nodes where node_id=1001 and is_centroid=1").fetchone()[0] == 1
+        assert conn.execute("select count(*) from nodes where visum_node_no=1001 and node_id<>1001").fetchone()[0] == 1
+        assert conn.execute(
+            "select min(travel_time_ab), min(travel_time_ba) from links where link_type='centroid_connector'"
+        ).fetchone() == pytest.approx((VISUM_SQLITE_CONNECTOR_EPSILON_MINUTES, VISUM_SQLITE_CONNECTOR_EPSILON_MINUTES))
+    with empty_project.db_connection_spatial as conn:
+        assert conn.execute("select AsText(geometry) from links where link_id=1").fetchone()[0] == (
+            "LINESTRING(0 0, 0.005 0.001, 0.01 0)"
+        )
+
+
+def test_visum_sqlite_graph_is_assignment_ready(empty_project, visum_sqlite_file):
+    empty_project.network.create_from_visum_sqlite(visum_sqlite_file)
+
+    empty_project.network.build_graphs(
+        fields=["distance", "travel_time_ab", "travel_time_ba", "capacity_ab", "capacity_ba"],
+        modes=["c"],
+    )
+    empty_project.network.set_time_field("travel_time")
+    graph = empty_project.network.graphs["c"]
+
+    assert "capacity" in graph.graph.columns
+    assert not graph.graph.travel_time.isna().any()
+    assert not graph.graph.capacity.isna().any()
+
+
+def test_visum_sqlite_source_connectivity_matches_import(empty_project, visum_sqlite_file):
+    source = visum_sqlite_source_connectivity(visum_sqlite_file)["c"]
+    empty_project.network.create_from_visum_sqlite(visum_sqlite_file)
+    imported = set()
+    with empty_project.db_connection as conn:
+        for a_node, b_node, direction, modes in conn.execute("select a_node, b_node, direction, modes from links"):
+            if "c" not in modes:
+                continue
+            if direction in (0, 1):
+                imported.add((a_node, b_node))
+            if direction in (0, -1):
+                imported.add((b_node, a_node))
+
+    assert imported == source
+    assert (2, 1001) not in imported
+    assert (1001, 2) not in imported
+
+
+def test_visum_sqlite_rejects_unparseable_crs(tmp_path, empty_project):
+    path = _create_visum_sqlite(tmp_path / "visum.sqlite3", invalid_crs=True)
+
+    with pytest.raises(ValueError, match="invalid-crs"):
+        empty_project.network.create_from_visum_sqlite(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,44 @@ DEFAULT_PROJECT = siouxfalls_project
 ensure_spatialite_binaries()
 
 
+def pytest_addoption(parser):
+    group = parser.getgroup("aequilibrae")
+    group.addoption(
+        "--visum-geojson-folder",
+        action="store",
+        default=None,
+        help="Folder with external VISUM GeoJSON files for opt-in importer smoke tests.",
+    )
+    group.addoption(
+        "--visum-expected-nodes",
+        action="store",
+        type=int,
+        default=None,
+        help="Expected imported node count for --visum-geojson-folder.",
+    )
+    group.addoption(
+        "--visum-expected-zones",
+        action="store",
+        type=int,
+        default=None,
+        help="Expected imported zone count for --visum-geojson-folder.",
+    )
+    group.addoption(
+        "--visum-expected-links",
+        action="store",
+        type=int,
+        default=None,
+        help="Expected imported link count for --visum-geojson-folder.",
+    )
+    group.addoption(
+        "--visum-expected-connectors",
+        action="store",
+        type=int,
+        default=None,
+        help="Expected imported connector count for --visum-geojson-folder.",
+    )
+
+
 @pytest.fixture(scope="session")
 def cache_path(tmp_path_factory):
     return tmp_path_factory.mktemp("cache", numbered=True)


### PR DESCRIPTION
## Summary

This PR adds VISUM network import support for AequilibraE projects through two source formats:

- VISUM GeoJSON exports
- VISUM SQLite exports

The import pipeline creates AequilibraE nodes, links, zones, centroids, centroid connectors, modes, and link types from VISUM private-traffic network data. SQLite import supports richer source reconstruction than GeoJSON, including relational link geometry, connector travel times, CRS metadata, zone surface reconstruction where available, and source-table diagnostics.

## Highlights

- Adds `Project.network.create_from_visum_geojson(...)`
- Adds `Project.network.create_from_visum_sqlite(...)`
- Preserves VISUM source identifiers for traceability
- Handles sparse VISUM link IDs with compact AequilibraE link IDs
- Handles duplicate VISUM node coordinates and node/zone ID collisions
- Maps VISUM transport systems into AequilibraE modes with configurable mappings
- Imports assignment-ready distance, speed, capacity, and travel-time fields where available
- Reports unsupported/deferred VISUM layers and tables instead of silently pretending full coverage

## Scope Notes

Turn restrictions, lane-turn semantics, public transport schedules, OD matrices, and demand calibration workflows are intentionally deferred. The current implementation imports link/connector modal connectivity, not turn-level movement constraints.

## Verification

- Added focused tests for VISUM GeoJSON import
- Added focused tests for VISUM SQLite import
- Validated generated Karlsruhe example projects from both GeoJSON and SQLite sources
- Confirmed SQLite and GeoJSON imports preserve equivalent link/connector connectivity for the supported private-traffic scope