### PR TITLE
Sorting optimization to fix windows qsort slowdown

### DIFF
--- a/aequilibrae/paths/cython/hyperpath.pyx
+++ b/aequilibrae/paths/cython/hyperpath.pyx
@@ -190,6 +190,7 @@ cdef void compute_SF_in_parallel(
     uint32_t[::1] head_view,
     uint32_t[:] d_vert_ids_view,  # destination vertices
     uint32_t[:] destination_vertex_indices_view,
+    uint32_t[:] demand_indptr_view,  # start of each destination's slice in the destination-sorted demand arrays
     uint32_t[:] rest_of_destinations_view,  # Used when skimming to lookup the rest of the destinations to skim from
     uint32_t[::1] o_vert_ids_view,  # origin vertices
     double[::1] demand_vls_view,  # volume
@@ -273,15 +274,16 @@ cdef void compute_SF_in_parallel(
 
             if i < destination_vertex_indices_view.shape[0]:
                 demand_size = 0
-                for j in range(d_vert_ids_view.shape[0]):
-                    if d_vert_ids_view[j] == destination_vertex:
-                        if nodes_to_indices[o_vert_ids_view[j]] == -1:
-                            continue
+                # the demand arrays are sorted by destination, so this destination's
+                # demand is the contiguous slice demand_indptr[i]:demand_indptr[i + 1]
+                for j in range(<size_t>demand_indptr_view[i], <size_t>demand_indptr_view[i + 1]):
+                    if nodes_to_indices[o_vert_ids_view[j]] == -1:
+                        continue
 
-                        thread_demand_origins[demand_size] = nodes_to_indices[o_vert_ids_view[j]]
-                        thread_demand_values[demand_size] = demand_vls_view[j]
-                        # demand_size += 1 is not allowed as cython believes this is a reduction
-                        demand_size = demand_size + 1
+                    thread_demand_origins[demand_size] = nodes_to_indices[o_vert_ids_view[j]]
+                    thread_demand_values[demand_size] = demand_vls_view[j]
+                    # demand_size += 1 is not allowed as cython believes this is a reduction
+                    demand_size = demand_size + 1
             else:
                 demand_size = o_vert_ids_view.shape[0]
                 for j in range(demand_size):
@@ -387,6 +389,8 @@ cdef void compute_SF_in(
         DATATYPE_t u_r, u_i
         size_t i, j, h_a_count
         uint32_t vert_idx
+        uint32_t *hyperpath_order
+        uint32_t *hyperpath_ids
         int cent_dest
         double tmp
 
@@ -463,23 +467,30 @@ cdef void compute_SF_in(
             if f_i_vec[i] < MIN_FREQ:
                 f_i_vec[i] = MIN_FREQ
 
+        # Sort only the edges on the hyperpath with decreasing order of u_j + c_a
+        # (the sort function sorts in increasing order, so we sort on the negated
+        # values). Compacting the hyperpath edges first, rather than sorting the
+        # full edge array, avoids sorting the ~O(edge_count) edges that are not on
+        # the hyperpath at all. Those all carried the same placeholder key, and a
+        # quicksort-based qsort (e.g. MSVC's) degrades toward quadratic time on
+        # such tie-heavy input, which dominated the entire assignment runtime.
         h_a_count = 0
         for i in range(<size_t>edge_count):
-            u_j_c_a_vec[i] *= -1.0
-            h_a_count += <size_t>h_a_vec[i]
+            if h_a_vec[i] != 0:
+                # in-place compaction is safe: h_a_count <= i on every iteration
+                u_j_c_a_vec[h_a_count] = -u_j_c_a_vec[i]
+                edge_indices[h_a_count] = <uint32_t>i
+                h_a_count = h_a_count + 1
 
-        # Sort the links with decreasing order of u_j + c_a.
-        # Because the sort function sorts in increasing order, we sort a
-        # transformed array, multiplied by -1, and set the items
-        # corresponding to edges that are not in the hyperpath to a
-        # positive value (they will be at the end of the sorted array).
-        # The items corresponding to edges that are in the hyperpath have a
-        # negative transformed value.
-        for i in range(<size_t>edge_count):
-            if h_a_vec[i] == 0:  # if the edge is not on the hyperpath
-                u_j_c_a_vec[i] = 1.0
-
-        argsort(u_j_c_a_vec, edge_indices, edge_count)
+        hyperpath_order = <uint32_t *> malloc(sizeof(uint32_t) * h_a_count)
+        hyperpath_ids = <uint32_t *> malloc(sizeof(uint32_t) * h_a_count)
+        argsort(u_j_c_a_vec, hyperpath_order, h_a_count)
+        for i in range(h_a_count):
+            hyperpath_ids[i] = edge_indices[hyperpath_order[i]]
+        for i in range(h_a_count):
+            edge_indices[i] = hyperpath_ids[i]
+        free(hyperpath_order)
+        free(hyperpath_ids)
 
         _SF_in_second_pass(
             edge_indices,

--- a/aequilibrae/paths/cython/public_transport.pyx
+++ b/aequilibrae/paths/cython/public_transport.pyx
@@ -281,6 +281,15 @@ class HyperpathGenerating:
         if check_demand:
             self._check_demand(origin_column, destination_column, demand_column)
 
+        # Sort the demand by destination so that each destination's demand is a
+        # contiguous slice (located via demand_indptr below) instead of requiring a
+        # scan of the full demand arrays for every destination. The stable sort
+        # preserves within-destination ordering, so results are unchanged.
+        order = np.argsort(self.destination_column, kind="stable")
+        self.origin_column = self.origin_column[order]
+        self.destination_column = self.destination_column[order]
+        self.demand_column = self.demand_column[order]
+
         if threads is None:
             threads = 0  # Default to all threads
 
@@ -292,6 +301,11 @@ class HyperpathGenerating:
 
         # get the list of all destinations, we use "rest of" for skimming
         destinations = np.unique(self.destination_column)
+        # start of each destination's slice in the (destination-sorted) demand arrays
+        demand_indptr = np.concatenate(
+            [np.searchsorted(self.destination_column, destinations),
+             [self.destination_column.shape[0]]]
+        ).astype(np.uint32)
         if self._skimming:
             rest_of_destinations = self._d_vert_ids[
                 np.isin(self._d_vert_ids, destinations, invert=True, assume_unique=True)
@@ -317,6 +331,7 @@ class HyperpathGenerating:
             self._head[:],
             self.destination_column[:],
             destinations[:],
+            demand_indptr[:],
             rest_of_destinations[:],
             self.origin_column[:],
             self.demand_column[:],


### PR DESCRIPTION
Sorry to throw this PR out of left field, but this one of those satisfyingly tiny fixes with a massive impact (like 300x speedup) for those unfortunate souls that are Windows bound. It now outperforms legacy commercial software that rhymes with tube.

I found that when I ran transit assignment it was absurdly slow, which was surprising because I know this to be fast. Even weirder was it was faster on the same machine when run via WSL. So with a little help from the robots for profiling and a few hours digging into the absurd details of sorting algorithms, it turns out it was a Windows specific bug (of course).

In the robot's words:
> For every destination, the code sorted the entire edge array (say 500k edges), even though only the few hundred hyperpath edges (h_a_vec == 1) needed ordering. All non-hyperpath edges got the same placeholder key 1.0. MSVC's qsort is a quicksort, which degrades toward O(n²) on input that's almost all ties — glibc's is a mergesort, which doesn't, hence Windows-only pain.

> Fix (hyperpath.pyx): Compact the hyperpath edges to the front of the array first, then sort only those. Sorting ~200 distinct keys instead of ~500k mostly-tied ones — the pathology can't trigger and the work shrinks by orders of magnitude.

> Bonus fix (public_transport.pyx): The demand table was also being fully re-scanned once per destination to find its rows. Now it's sorted by destination once up front, so each destination's demand is a contiguous slice found via demand_indptr — O(1) lookup instead of a full scan. The stable sort keeps results identical.

> Sorting context: 

> * glibc (Linux): implements qsort as a mergesort (falling back to quicksort only if memory allocation fails). Mergesort is O(n log n) no matter what the input looks like — ties are irrelevant.
> * MSVC (Windows): implements qsort as an actual quicksort. Classic quicksort has a known worst case: when the array is dominated by equal keys, partitioning stops making progress (every element compares equal to the pivot, so the splits are maximally unbalanced) and runtime degrades toward O(n²).