### PR TITLE
Sorting optimization to fix windows qsort slowdown

### DIFF
--- a/aequilibrae/paths/cython/hyperpath.pyx
+++ b/aequilibrae/paths/cython/hyperpath.pyx
@@ -190,6 +190,7 @@ cdef void compute_SF_in_parallel(
     uint32_t[::1] head_view,
     uint32_t[:] d_vert_ids_view,  # destination vertices
     uint32_t[:] destination_vertex_indices_view,
+    uint32_t[:] demand_indptr_view,  # start of each destination's slice in the destination-sorted demand arrays
     uint32_t[:] rest_of_destinations_view,  # Used when skimming to lookup the rest of the destinations to skim from
     uint32_t[::1] o_vert_ids_view,  # origin vertices
     double[::1] demand_vls_view,  # volume
@@ -273,15 +274,16 @@ cdef void compute_SF_in_parallel(
 
             if i < destination_vertex_indices_view.shape[0]:
                 demand_size = 0
-                for j in range(d_vert_ids_view.shape[0]):
-                    if d_vert_ids_view[j] == destination_vertex:
-                        if nodes_to_indices[o_vert_ids_view[j]] == -1:
-                            continue
+                # the demand arrays are sorted by destination, so this destination's
+                # demand is the contiguous slice demand_indptr[i]:demand_indptr[i + 1]
+                for j in range(<size_t>demand_indptr_view[i], <size_t>demand_indptr_view[i + 1]):
+                    if nodes_to_indices[o_vert_ids_view[j]] == -1:
+                        continue
 
-                        thread_demand_origins[demand_size] = nodes_to_indices[o_vert_ids_view[j]]
-                        thread_demand_values[demand_size] = demand_vls_view[j]
-                        # demand_size += 1 is not allowed as cython believes this is a reduction
-                        demand_size = demand_size + 1
+                    thread_demand_origins[demand_size] = nodes_to_indices[o_vert_ids_view[j]]
+                    thread_demand_values[demand_size] = demand_vls_view[j]
+                    # demand_size += 1 is not allowed as cython believes this is a reduction
+                    demand_size = demand_size + 1
             else:
                 demand_size = o_vert_ids_view.shape[0]
                 for j in range(demand_size):
@@ -387,6 +389,8 @@ cdef void compute_SF_in(
         DATATYPE_t u_r, u_i
         size_t i, j, h_a_count
         uint32_t vert_idx
+        uint32_t *hyperpath_order
+        uint32_t *hyperpath_ids
         int cent_dest
         double tmp
 
@@ -463,23 +467,30 @@ cdef void compute_SF_in(
             if f_i_vec[i] < MIN_FREQ:
                 f_i_vec[i] = MIN_FREQ
 
+        # Sort only the edges on the hyperpath with decreasing order of u_j + c_a
+        # (the sort function sorts in increasing order, so we sort on the negated
+        # values). Compacting the hyperpath edges first, rather than sorting the
+        # full edge array, avoids sorting the ~O(edge_count) edges that are not on
+        # the hyperpath at all. Those all carried the same placeholder key, and a
+        # quicksort-based qsort (e.g. MSVC's) degrades toward quadratic time on
+        # such tie-heavy input, which dominated the entire assignment runtime.
         h_a_count = 0
         for i in range(<size_t>edge_count):
-            u_j_c_a_vec[i] *= -1.0
-            h_a_count += <size_t>h_a_vec[i]
+            if h_a_vec[i] != 0:
+                # in-place compaction is safe: h_a_count <= i on every iteration
+                u_j_c_a_vec[h_a_count] = -u_j_c_a_vec[i]
+                edge_indices[h_a_count] = <uint32_t>i
+                h_a_count = h_a_count + 1
 
-        # Sort the links with decreasing order of u_j + c_a.
-        # Because the sort function sorts in increasing order, we sort a
-        # transformed array, multiplied by -1, and set the items
-        # corresponding to edges that are not in the hyperpath to a
-        # positive value (they will be at the end of the sorted array).
-        # The items corresponding to edges that are in the hyperpath have a
-        # negative transformed value.
-        for i in range(<size_t>edge_count):
-            if h_a_vec[i] == 0:  # if the edge is not on the hyperpath
-                u_j_c_a_vec[i] = 1.0
-
-        argsort(u_j_c_a_vec, edge_indices, edge_count)
+        hyperpath_order = <uint32_t *> malloc(sizeof(uint32_t) * h_a_count)
+        hyperpath_ids = <uint32_t *> malloc(sizeof(uint32_t) * h_a_count)
+        argsort(u_j_c_a_vec, hyperpath_order, h_a_count)
+        for i in range(h_a_count):
+            hyperpath_ids[i] = edge_indices[hyperpath_order[i]]
+        for i in range(h_a_count):
+            edge_indices[i] = hyperpath_ids[i]
+        free(hyperpath_order)
+        free(hyperpath_ids)
 
         _SF_in_second_pass(
             edge_indices,

--- a/aequilibrae/paths/cython/hyperpath.pyx
+++ b/aequilibrae/paths/cython/hyperpath.pyx
@@ -45,9 +45,12 @@ cdef struct IndexedElement:
     size_t index
     DATATYPE_t value
 
-cdef int _compare(const_void *a, const_void *b) noexcept:
-    cdef DATATYPE_t v = (<IndexedElement*> a).value-(<IndexedElement*> b).value
-    if v < 0:
+cdef int _compare(const_void *a, const_void *b) noexcept nogil:
+    cdef DATATYPE_t a_v = (<IndexedElement*> a).value
+    cdef DATATYPE_t b_v = (<IndexedElement*> b).value
+    if a_v == b_v:
+        return 0
+    elif a_v < b_v:
         return -1
     else:
         return 1
@@ -222,6 +225,8 @@ cdef void compute_SF_in_parallel(
         double *thread_v_i_vec
         uint8_t *thread_h_a_vec
         uint32_t *thread_edge_indices
+        uint32_t *thread_hyperpath_order
+        uint32_t *thread_hyperpath_ids
 
         double *thread_skim_i_vec
         double *thread_skim_j_vec
@@ -254,6 +259,8 @@ cdef void compute_SF_in_parallel(
         thread_v_i_vec      = <double *> malloc(sizeof(double) * vertex_count)
         thread_h_a_vec      = <uint8_t   *> malloc(sizeof(uint8_t)   * edge_count)
         thread_edge_indices = <uint32_t  *> malloc(sizeof(uint32_t)  * edge_count)
+        thread_hyperpath_order = <uint32_t *> malloc(sizeof(uint32_t) * edge_count)
+        thread_hyperpath_ids   = <uint32_t *> malloc(sizeof(uint32_t) * edge_count)
 
         thread_skim_j_vec = <double *> calloc(edge_count, sizeof(double) * n_skim_cols)
 
@@ -285,13 +292,15 @@ cdef void compute_SF_in_parallel(
                     # demand_size += 1 is not allowed as cython believes this is a reduction
                     demand_size = demand_size + 1
             else:
-                demand_size = o_vert_ids_view.shape[0]
-                for j in range(demand_size):
+                demand_size = 0
+                for j in range(o_vert_ids_view.shape[0]):
                     if nodes_to_indices[o_vert_ids_view[j]] == -1:
                         continue
 
-                    thread_demand_origins[j] = nodes_to_indices[o_vert_ids_view[j]]
-                    thread_demand_values[j] = 0.0
+                    thread_demand_origins[demand_size] = nodes_to_indices[o_vert_ids_view[j]]
+                    thread_demand_values[demand_size] = 0.0
+                    # demand_size += 1 is not allowed as cython believes this is a reduction
+                    demand_size = demand_size + 1
 
             # S&F
             compute_SF_in(
@@ -311,6 +320,8 @@ cdef void compute_SF_in_parallel(
                 thread_v_i_vec,
                 thread_h_a_vec,
                 thread_edge_indices,
+                thread_hyperpath_order,
+                thread_hyperpath_ids,
                 vertex_count,
                 nodes_to_indices[destination_vertex],
                 skim_col_view,
@@ -332,6 +343,8 @@ cdef void compute_SF_in_parallel(
         free(thread_v_i_vec)
         free(thread_h_a_vec)
         free(thread_edge_indices)
+        free(thread_hyperpath_order)
+        free(thread_hyperpath_ids)
         free(thread_skim_j_vec)
 
     # Accumulate results into output buffer. This could be parallelised over the output indexes but
@@ -370,6 +383,8 @@ cdef void compute_SF_in(
     double *v_i_vec,
     uint8_t *h_a_vec,
     uint32_t *edge_indices,
+    uint32_t *hyperpath_order,
+    uint32_t *hyperpath_ids,
     size_t vertex_count,
     int dest_vert_index,
     double[:, ::1] skim_col_vec,
@@ -389,8 +404,6 @@ cdef void compute_SF_in(
         DATATYPE_t u_r, u_i
         size_t i, j, h_a_count
         uint32_t vert_idx
-        uint32_t *hyperpath_order
-        uint32_t *hyperpath_ids
         int cent_dest
         double tmp
 
@@ -482,15 +495,13 @@ cdef void compute_SF_in(
                 edge_indices[h_a_count] = <uint32_t>i
                 h_a_count = h_a_count + 1
 
-        hyperpath_order = <uint32_t *> malloc(sizeof(uint32_t) * h_a_count)
-        hyperpath_ids = <uint32_t *> malloc(sizeof(uint32_t) * h_a_count)
+        # hyperpath_order/hyperpath_ids are thread-local scratch buffers sized
+        # edge_count, preallocated once per thread by the caller (h_a_count <= edge_count).
         argsort(u_j_c_a_vec, hyperpath_order, h_a_count)
         for i in range(h_a_count):
             hyperpath_ids[i] = edge_indices[hyperpath_order[i]]
         for i in range(h_a_count):
             edge_indices[i] = hyperpath_ids[i]
-        free(hyperpath_order)
-        free(hyperpath_ids)
 
         _SF_in_second_pass(
             edge_indices,

--- a/aequilibrae/paths/cython/public_transport.pyx
+++ b/aequilibrae/paths/cython/public_transport.pyx
@@ -301,8 +301,8 @@ class HyperpathGenerating:
 
         # get the list of all destinations, we use "rest of" for skimming
         # and the start of each destination's slice in the (destination-sorted) demand arrays
-        destinations, demand_indptr = np.unique(destination_column, return_index=True)
-        demand_indptr = demand_indptr.astype(np.uint32)
+destinations, demand_indptr = np.unique(destination_column, return_index=True)
+demand_indptr = np.append(demand_indptr, destination_column.size).astype(np.uint32)
         if self._skimming:
             rest_of_destinations = self._d_vert_ids[
                 np.isin(self._d_vert_ids, destinations, invert=True, assume_unique=True)

--- a/aequilibrae/paths/cython/public_transport.pyx
+++ b/aequilibrae/paths/cython/public_transport.pyx
@@ -281,6 +281,15 @@ class HyperpathGenerating:
         if check_demand:
             self._check_demand(origin_column, destination_column, demand_column)
 
+        # Sort the demand by destination so that each destination's demand is a
+        # contiguous slice (located via demand_indptr below) instead of requiring a
+        # scan of the full demand arrays for every destination. The stable sort
+        # preserves within-destination ordering, so results are unchanged.
+        order = np.argsort(self.destination_column, kind="stable")
+        self.origin_column = self.origin_column[order]
+        self.destination_column = self.destination_column[order]
+        self.demand_column = self.demand_column[order]
+
         if threads is None:
             threads = 0  # Default to all threads
 
@@ -292,6 +301,11 @@ class HyperpathGenerating:
 
         # get the list of all destinations, we use "rest of" for skimming
         destinations = np.unique(self.destination_column)
+        # start of each destination's slice in the (destination-sorted) demand arrays
+        demand_indptr = np.concatenate(
+            [np.searchsorted(self.destination_column, destinations),
+             [self.destination_column.shape[0]]]
+        ).astype(np.uint32)
         if self._skimming:
             rest_of_destinations = self._d_vert_ids[
                 np.isin(self._d_vert_ids, destinations, invert=True, assume_unique=True)
@@ -317,6 +331,7 @@ class HyperpathGenerating:
             self._head[:],
             self.destination_column[:],
             destinations[:],
+            demand_indptr[:],
             rest_of_destinations[:],
             self.origin_column[:],
             self.demand_column[:],

--- a/aequilibrae/paths/cython/public_transport.pyx
+++ b/aequilibrae/paths/cython/public_transport.pyx
@@ -274,9 +274,9 @@ class HyperpathGenerating:
 
         """
 
-        self.origin_column = origin_column.astype(np.uint32)
-        self.destination_column = destination_column.astype(np.uint32)
-        self.demand_column = demand_column.astype(DATATYPE_PY)
+        origin_column = origin_column.astype(np.uint32)
+        destination_column = destination_column.astype(np.uint32)
+        demand_column = demand_column.astype(DATATYPE_PY)
         # check the input demand parameter
         if check_demand:
             self._check_demand(origin_column, destination_column, demand_column)
@@ -285,10 +285,10 @@ class HyperpathGenerating:
         # contiguous slice (located via demand_indptr below) instead of requiring a
         # scan of the full demand arrays for every destination. The stable sort
         # preserves within-destination ordering, so results are unchanged.
-        order = np.argsort(self.destination_column, kind="stable")
-        self.origin_column = self.origin_column[order]
-        self.destination_column = self.destination_column[order]
-        self.demand_column = self.demand_column[order]
+        order = np.argsort(destination_column, kind="stable")
+        origin_column = origin_column[order]
+        destination_column = destination_column[order]
+        demand_column = demand_column[order]
 
         if threads is None:
             threads = 0  # Default to all threads
@@ -300,12 +300,9 @@ class HyperpathGenerating:
         self.u_i_vec = np.zeros(self.vertex_count, dtype=DATATYPE_PY)
 
         # get the list of all destinations, we use "rest of" for skimming
-        destinations = np.unique(self.destination_column)
-        # start of each destination's slice in the (destination-sorted) demand arrays
-        demand_indptr = np.concatenate(
-            [np.searchsorted(self.destination_column, destinations),
-             [self.destination_column.shape[0]]]
-        ).astype(np.uint32)
+        # and the start of each destination's slice in the (destination-sorted) demand arrays
+        destinations, demand_indptr = np.unique(destination_column, return_index=True)
+        demand_indptr = demand_indptr.astype(np.uint32)
         if self._skimming:
             rest_of_destinations = self._d_vert_ids[
                 np.isin(self._d_vert_ids, destinations, invert=True, assume_unique=True)
@@ -329,12 +326,12 @@ class HyperpathGenerating:
             self._freq[:],
             self._tail[:],
             self._head[:],
-            self.destination_column[:],
+            destination_column[:],
             destinations[:],
             demand_indptr[:],
             rest_of_destinations[:],
-            self.origin_column[:],
-            self.demand_column[:],
+            origin_column[:],
+            demand_column[:],
             volume,
             self.vertex_count,
             volume.shape[0],

--- a/aequilibrae/paths/cython/public_transport.pyx
+++ b/aequilibrae/paths/cython/public_transport.pyx
@@ -301,8 +301,8 @@ class HyperpathGenerating:
 
         # get the list of all destinations, we use "rest of" for skimming
         # and the start of each destination's slice in the (destination-sorted) demand arrays
-destinations, demand_indptr = np.unique(destination_column, return_index=True)
-demand_indptr = np.append(demand_indptr, destination_column.size).astype(np.uint32)
+        destinations, demand_indptr = np.unique(destination_column, return_index=True)
+        demand_indptr = np.append(demand_indptr, destination_column.size).astype(np.uint32)
         if self._skimming:
             rest_of_destinations = self._d_vert_ids[
                 np.isin(self._d_vert_ids, destinations, invert=True, assume_unique=True)


### PR DESCRIPTION
Closes #805 

This contains @nick-fournier's commit, plus some additional changes, I've
- moved the allocation out of a loop and into the initial scratch allocations,
- removed the assignment of `origin_column`, `destination_column`, and `demand_column` to the `HyperpathGenerating` object, we shouldn't be storing them and mutating them. These are pretty far down in the library so I'm not worried that removing these will break peoples code, however, anyone or @nick-fournier depends on them we can restore them, and
- made the comparator function passed to qsort to return 0 when objects are actually equal. This brings the runtime down from 3-4mins to ~5s alone, before any other changes. The reduced sorting changes still provide another ~2s of runtime improvement.

Thank you brings this to our attention @nick-forunier, this code was definitely profiled and tested by myself on linux-only systems.