### PR TITLE
Allow override to_parquet arguments in route choice route set saving

### DIFF
--- a/aequilibrae/paths/cython/route_choice_set.pyx
+++ b/aequilibrae/paths/cython/route_choice_set.pyx
@@ -170,6 +170,7 @@ cdef class RouteChoiceSet:
         bfsle: bool = True,
         penalty: float = 1.0,
         where: Optional[str] = None,
+        to_parquet_kwargs: dict | None = None,
         store_results: bool = True,
         path_size_logit: bool = False,
         beta: float = 1.0,
@@ -196,6 +197,7 @@ cdef class RouteChoiceSet:
                 penalisation. Default ``True``.
             **penalty** (:obj:`float`): Penalty to use for Link Penalisation and BFSLE with LP.
             **where** (:obj:`str`): Optional file path to save results to immediately. Will return None.
+            **to_parquet_kwargs** (:obj:`dict`): Keyword arguments to supply to the underlying ``to_parquet`` call.
         """
         cdef:
             long long origin, dest
@@ -381,7 +383,7 @@ cdef class RouteChoiceSet:
             if store_results:
                 self.get_results()
                 if where is not None:
-                    self.results.write(where)
+                    self.results.write(where, to_parquet_kwargs if to_parquet_kwargs is not None else {})
 
         if path_size_logit:
             self.ll_results.reduce_link_loading()
@@ -869,7 +871,7 @@ cdef class RouteChoiceSet:
 
         return self.ll_results.sl_od_matrices_structs_to_objects()
 
-    def write_path_files(RouteChoiceSet self, where):
+    def write_path_files(RouteChoiceSet self, where, to_parquet_kwargs):
         """
         Write the path-files to the directory specified
 
@@ -879,4 +881,4 @@ cdef class RouteChoiceSet:
         if self.results is None:
             raise RuntimeError("Route Choice results not computed yet")
 
-        self.results.write(where)
+        self.results.write(where, to_parquet_kwargs)

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -94,7 +94,7 @@ cdef class RouteChoiceSetResults:
                 self.__path_overlap_set[i] = make_shared[vector[double]]()
                 self.__prob_set[i] = make_shared[vector[double]]()
 
-    def write(self, where):
+    def write(self, where, to_parquet_kwargs):
         table = self.make_df_from_results()
 
         engine_name = pd.get_option("io.parquet.engine")
@@ -109,21 +109,27 @@ cdef class RouteChoiceSetResults:
                     "Please install one with: pip install pyarrow OR pip install fastparquet"
                 )
 
+        kwargs = {
+            "path": where,
+            "compression": "zstd",
+            "index": False,
+            "partition_cols": ["origin id"],
+        }
+
         if engine_name == "pyarrow":
-            kwargs = dict(
+            kwargs |= {
                 # can't provide partitioning_flavor and partition_cols through the Pandas API
-                use_threads=True,
-                existing_data_behavior="overwrite_or_ignore",
-                file_visitor=lambda written_file: logger.info(f"Wrote partition dataset at {written_file.path}")
-            )
+                "use_threads": True,
+                "existing_data_behavior": "overwrite_or_ignore",
+            }
         elif engine_name == "fastparquet":
             logger.info("FastParquet back-end doesn't support individual partition logging, writing table now...")
-            kwargs = dict(
-                file_scheme="hive",
+            kwargs |= {
+                "file_scheme": "hive",
                 # no threads option
-                append=False,
+                "append": False,
                 # no visitor option
-            )
+            }
             logger.warn(
                 "FastParquet back-end doesn't support writing a NumPy arrays as Parquet list types, converting to Python lists. "
                 "Watch out for memory consumption..."
@@ -134,13 +140,7 @@ cdef class RouteChoiceSetResults:
                 "encountered unknown Pandas parquet engine, please report this as a bug to the AequilibraE issues page"
             )
 
-        table.to_parquet(
-            path=where,
-            compression="zstd",
-            index=False,
-            partition_cols=["origin id"],
-            **kwargs,
-        )
+        table.to_parquet(**(kwargs | to_parquet_kwargs))
 
     @classmethod
     def read_dataset(cls, where):

--- a/aequilibrae/paths/cython/route_choice_set_results.pyx
+++ b/aequilibrae/paths/cython/route_choice_set_results.pyx
@@ -130,7 +130,7 @@ cdef class RouteChoiceSetResults:
                 "append": False,
                 # no visitor option
             }
-            logger.warn(
+            logger.warning(
                 "FastParquet back-end doesn't support writing a NumPy arrays as Parquet list types, converting to Python lists. "
                 "Watch out for memory consumption..."
             )
@@ -150,7 +150,7 @@ cdef class RouteChoiceSetResults:
         # FastParquet is stupid and encodes Parquet list objects as json strings!!!
         is_json_encoded = df["route set"].map(lambda x: isinstance(x, (str, bytes)))
         if is_json_encoded.any():
-            logger.warn("Found JSON encoded route sets. Parsing into a NumPy array...")
+            logger.warning("Found JSON encoded route sets. Parsing into a NumPy array...")
             if not is_json_encoded.all():
                 raise TypeError(
                     f"route sets must either be encoded properly as list[int64], or json lists (by FastParquet). The two cannot be mixed"

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -287,6 +287,7 @@ class RouteChoice:
             path_size_logit=bool(demand),
             cores=self.cores,
             where=str(self.where) if self.where is not None else None,
+            to_parquet_kwargs=self.to_parquet_kwargs,
             sl_link_loading=self.sl_link_loading,
             **self.parameters,
         )

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -61,6 +61,7 @@ class RouteChoice:
         self.sl_link_loads: Optional[Dict[str, np.array]] = None
 
         self.where: Optional[pathlib.Path] = None
+        self.to_parquet_kwargs = {}
         self.index_name = "route_choice_sl_index"
 
         self._config = {}
@@ -177,7 +178,7 @@ class RouteChoice:
         """
         self.cores = cores
 
-    def set_save_routes(self, where: Optional[str] = None) -> None:
+    def set_save_routes(self, where: Optional[str] = None, **to_parquet_kwargs) -> None:
         """
         Set save path for route choice results. Provide ``None`` to disable.
 
@@ -187,7 +188,8 @@ class RouteChoice:
             the results from disk first.
 
         :Arguments:
-            **save_it** (:obj:`bool`): Boolean to indicate whether routes should be saved
+            **where** (:obj:`Optional[pathlib.Path]`): Directory to save the dataset to.
+            **to_parquet_kwargs** (:obj:`dict`): Keyword arguments to supply to the underlying ``to_parquet`` call.
         """
 
         if where is not None:
@@ -195,6 +197,7 @@ class RouteChoice:
             if not where.exists():
                 raise ValueError(f"Path does not exist `{where}`")
         self.where = where
+        self.to_parquet_kwargs = to_parquet_kwargs
 
     def add_demand(self, demand, fill: float = 0.0):
         """
@@ -312,6 +315,7 @@ class RouteChoice:
             path_size_logit=perform_assignment,
             cores=self.cores,
             where=str(self.where) if self.where is not None else None,
+            to_parquet_kwargs=self.to_parquet_kwargs,
             sl_link_loading=self.sl_link_loading,
             **self.parameters,
         )
@@ -445,7 +449,7 @@ class RouteChoice:
 
         return results
 
-    def save_path_files(self, where: Optional[pathlib.Path] = None):
+    def save_path_files(self, where: Optional[pathlib.Path] = None, **to_parquet_kwargs):
         """
         Save path-files to the directory specific.
 
@@ -454,12 +458,13 @@ class RouteChoice:
 
         :Arguments:
             **where** (:obj:`Optional[pathlib.Path]`): Directory to save the dataset to.
+            **to_parquet_kwargs** (:obj:`dict`): Keyword arguments to supply to the underlying ``to_parquet`` call.
         """
         where = where if where is not None else self.where
         if where is None:
             raise ValueError("either the 'where' argument or 'self.where' property must not None")
 
-        self.__rc.write_path_files(where)
+        self.__rc.write_path_files(where, to_parquet_kwargs)
 
     def get_load_results(self) -> pd.DataFrame:
         """

--- a/aequilibrae/paths/route_choice.py
+++ b/aequilibrae/paths/route_choice.py
@@ -7,7 +7,7 @@ import warnings
 from collections.abc import Hashable
 from datetime import datetime
 from functools import cached_property
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 import numpy as np
@@ -178,7 +178,7 @@ class RouteChoice:
         """
         self.cores = cores
 
-    def set_save_routes(self, where: Optional[str] = None, **to_parquet_kwargs) -> None:
+    def set_save_routes(self, where: Optional[str] = None, to_parquet_kwargs: dict[str, Any] | None = None) -> None:
         """
         Set save path for route choice results. Provide ``None`` to disable.
 
@@ -197,7 +197,7 @@ class RouteChoice:
             if not where.exists():
                 raise ValueError(f"Path does not exist `{where}`")
         self.where = where
-        self.to_parquet_kwargs = to_parquet_kwargs
+        self.to_parquet_kwargs = to_parquet_kwargs if to_parquet_kwargs is not None else {}
 
     def add_demand(self, demand, fill: float = 0.0):
         """

--- a/tests/aeq/paths/test_route_choice.py
+++ b/tests/aeq/paths/test_route_choice.py
@@ -227,6 +227,55 @@ def test_round_trip(route_choice_setup):
     pd.testing.assert_frame_equal(table, table2)
 
 
+def test_to_parquet_kwargs(route_choice_setup):
+    pq = pytest.importorskip("pyarrow.parquet")
+    project = route_choice_setup["project"]
+    mat = route_choice_setup["mat"]
+    rc = route_choice_setup["rc"]
+
+    rc.add_demand(mat)
+    rc.set_choice_set_generation("link-penalization", max_routes=5, penalty=1.1)
+    rc.prepare()
+
+    def compressions(where):
+        files = list(pathlib.Path(where).rglob("*.parquet"))
+        assert files, f"no parquet files written to `{where}`"
+        codecs = set()
+        for f in files:
+            metadata = pq.ParquetFile(f).metadata
+            for i in range(metadata.num_row_groups):
+                for j in range(metadata.num_columns):
+                    codecs.add(metadata.row_group(i).column(j).compression)
+        return codecs
+
+    # Without kwargs the default compression applies
+    default_path = pathlib.Path(project.project_base_path) / "default kwargs"
+    default_path.mkdir()
+    rc.set_save_routes(default_path)
+    rc.execute(perform_assignment=True)
+    assert compressions(default_path) == {"ZSTD"}
+
+    # kwargs provided to set_save_routes override the defaults of the underlying to_parquet call
+    snappy_path = pathlib.Path(project.project_base_path) / "snappy kwargs"
+    snappy_path.mkdir()
+    rc.set_save_routes(snappy_path, compression="snappy")
+    rc.execute(perform_assignment=True)
+    assert compressions(snappy_path) == {"SNAPPY"}
+
+    # Non-overridden defaults still apply, the dataset remains hive partitioned by origin
+    assert all(d.name.startswith("origin id=") for d in snappy_path.iterdir())
+    pd.testing.assert_frame_equal(
+        pd.read_parquet(default_path).sort_values(by=["origin id", "destination id", "cost"]).reset_index(drop=True),
+        pd.read_parquet(snappy_path).sort_values(by=["origin id", "destination id", "cost"]).reset_index(drop=True),
+    )
+
+    # save_path_files forwards kwargs in the same manner
+    path_files = pathlib.Path(project.project_base_path) / "path files kwargs"
+    path_files.mkdir()
+    rc.save_path_files(path_files, compression="gzip")
+    assert compressions(path_files) == {"GZIP"}
+
+
 def test_assign_from_df(route_choice_setup):
     graph = route_choice_setup["graph"]
     rc = RouteChoiceSet(graph)

--- a/tests/aeq/paths/test_route_choice.py
+++ b/tests/aeq/paths/test_route_choice.py
@@ -5,10 +5,10 @@ from os.path import join
 import numpy as np
 import pandas as pd
 import pytest
+from aequilibrae.paths.cython.route_choice_set import RouteChoiceSet
 
 from aequilibrae.matrix import AequilibraeMatrix, GeneralisedCOODemand
 from aequilibrae.paths.route_choice import RouteChoice
-from aequilibrae.paths.cython.route_choice_set import RouteChoiceSet
 
 
 @pytest.fixture(scope="function")
@@ -248,17 +248,17 @@ def test_to_parquet_kwargs(route_choice_setup):
                     codecs.add(metadata.row_group(i).column(j).compression)
         return codecs
 
-    # Without kwargs the default compression applies
+    # Without to_parquet_kwargs the default compression applies
     default_path = pathlib.Path(project.project_base_path) / "default kwargs"
     default_path.mkdir()
     rc.set_save_routes(default_path)
     rc.execute(perform_assignment=True)
     assert compressions(default_path) == {"ZSTD"}
 
-    # kwargs provided to set_save_routes override the defaults of the underlying to_parquet call
+    # to_parquet_kwargs provided to set_save_routes override the defaults of the underlying to_parquet call
     snappy_path = pathlib.Path(project.project_base_path) / "snappy kwargs"
     snappy_path.mkdir()
-    rc.set_save_routes(snappy_path, compression="snappy")
+    rc.set_save_routes(snappy_path, to_parquet_kwargs={"compression": "snappy"})
     rc.execute(perform_assignment=True)
     assert compressions(snappy_path) == {"SNAPPY"}
 
@@ -269,7 +269,7 @@ def test_to_parquet_kwargs(route_choice_setup):
         pd.read_parquet(snappy_path).sort_values(by=["origin id", "destination id", "cost"]).reset_index(drop=True),
     )
 
-    # save_path_files forwards kwargs in the same manner
+    # save_path_files forwards to_parquet_kwargs in the same manner
     path_files = pathlib.Path(project.project_base_path) / "path files kwargs"
     path_files.mkdir()
     rc.save_path_files(path_files, compression="gzip")


### PR DESCRIPTION
Allows the user to override all arguments used to save the route choice sets. A user ran into this when saving choice sets for more origins than the default `max_partitions`.