### PR TITLE
Ties centroids to zones

### DIFF
--- a/aequilibrae/project/database_specification/network/migrations/004_tag_zone_centroids.py
+++ b/aequilibrae/project/database_specification/network/migrations/004_tag_zone_centroids.py
@@ -1,0 +1,28 @@
+import pathlib
+import sqlite3
+from typing import Optional
+
+from aequilibrae.log import logger
+from aequilibrae.project.project_creation import run_queries_from_sql_file
+
+
+def migrate(
+    *,
+    project_conn: sqlite3.Connection,
+    transit_conn: Optional[sqlite3.Connection] = None,
+    results_conn: Optional[sqlite3.Connection] = None,
+):
+    logger.info("Beginning migration to enforce the centroid flag on nodes that share their ID with a zone")
+
+    sql = "SELECT count(*) FROM sqlite_master WHERE type='table' AND lower(name)='zones'"
+    if project_conn.execute(sql).fetchone()[0] == 0:
+        logger.info("Migration finished, no 'zones' table found.")
+        return
+
+    # Nodes that already share their ID with a zone are tagged before the triggers that enforce it are added
+    sql = "UPDATE nodes SET is_centroid=1 WHERE is_centroid != 1 AND node_id IN (SELECT zone_id FROM zones)"
+    tagged = project_conn.execute(sql).rowcount
+    logger.info(f"{tagged} nodes were tagged as centroids")
+
+    triggers = pathlib.Path(__file__).parent.parent / "triggers" / "zones_triggers.sql"
+    run_queries_from_sql_file(project_conn, logger, triggers)

--- a/aequilibrae/project/database_specification/network/migrations/migrations.py
+++ b/aequilibrae/project/database_specification/network/migrations/migrations.py
@@ -6,4 +6,5 @@ migrations: tuple[int, pathlib.Path] = [
     path / "000_initial_migration.sql",
     path / "001_add_cols_to_results.sql",
     path / "002_add_scenario_table.py",
+    path / "004_tag_zone_centroids.py",
 ]

--- a/aequilibrae/project/database_specification/network/tables/nodes.sql
+++ b/aequilibrae/project/database_specification/network/tables/nodes.sql
@@ -5,6 +5,10 @@
 --@ The **is_centroid** field holds information if the node is a centroid
 --@ of a network or not. Assumes values 0 or 1. Defaults to **0**.
 --@
+--@ A node that shares its **node_id** with the **zone_id** of an existing zone is the
+--@ centroid of that zone, so database triggers tag it with **is_centroid** equal to 1
+--@ and block any attempt to untag it while the zone exists.
+--@
 --@ The **modes** field identifies all modes connected to the node.
 --@
 --@ The **link_types** field identifies all link types connected

--- a/aequilibrae/project/database_specification/network/tables/zones.sql
+++ b/aequilibrae/project/database_specification/network/tables/zones.sql
@@ -1,7 +1,9 @@
 --@ The *zones* table holds information on the Traffic Analysis Zones (TAZs) 
 --@ in AequilibraE's model.
 --@
---@ The **zone_id** field identifies the zone.
+--@ The **zone_id** field identifies the zone. The centroid of a zone is the node
+--@ with **node_id** equal to this zone's **zone_id**, and database triggers guarantee
+--@ that such a node is always tagged as a centroid.
 --@
 --@ The **area** field corresponds to the area of the zone in **km2**.
 --@ TAZs' area is automatically updated by triggers.

--- a/aequilibrae/project/database_specification/network/triggers/triggers_list.txt
+++ b/aequilibrae/project/database_specification/network/triggers/triggers_list.txt
@@ -3,3 +3,4 @@ modes_table_triggers
 network_triggers
 periods_triggers
 scenarios_triggers
+zones_triggers

--- a/aequilibrae/project/database_specification/network/triggers/zones_triggers.sql
+++ b/aequilibrae/project/database_specification/network/triggers/zones_triggers.sql
@@ -1,0 +1,45 @@
+-- In AequilibraE a zone's centroid is the node whose node_id matches the zone_id, so any node that
+-- shares its ID with an existing zone MUST be flagged as a centroid.
+--
+-- Nodes that land on an existing zone ID (either because they were created or renumbered) are tagged
+-- automatically, and so are the nodes a new zone is created on top of. Removing the centroid flag from
+-- a node while its zone exists is blocked, as that would leave the zone without a centroid (and would
+-- delete the node altogether when it has no links attached to it).
+
+--#
+-- Tags a node created on top of an existing zone ID as a centroid
+create trigger aequilibrae_new_node_zone_centroid after insert on nodes
+when new.is_centroid != 1 and exists (select 1 from zones where zones.zone_id = new.node_id)
+begin
+  update nodes set is_centroid = 1 where nodes.rowid = new.rowid;
+end;
+
+--#
+-- Tags a node renumbered onto an existing zone ID as a centroid
+create trigger aequilibrae_updated_node_id_zone_centroid after update of node_id on nodes
+when new.is_centroid != 1 and exists (select 1 from zones where zones.zone_id = new.node_id)
+begin
+  update nodes set is_centroid = 1 where nodes.rowid = new.rowid;
+end;
+
+--#
+-- Guarantees that a node cannot stop being a centroid while its zone exists
+create trigger aequilibrae_nodes_iscentroid_zone_update before update of is_centroid on nodes
+when new.is_centroid != 1 and exists (select 1 from zones where zones.zone_id = new.node_id)
+begin
+  select RAISE(ABORT,'Nodes that share their ID with a zone must be centroids. Delete the zone first');
+end;
+
+--#
+-- Tags the node a new zone was created on top of as a centroid
+create trigger aequilibrae_new_zone_centroid after insert on zones
+begin
+  update nodes set is_centroid = 1 where nodes.node_id = new.zone_id and nodes.is_centroid != 1;
+end;
+
+--#
+-- Tags the node a zone was renumbered on top of as a centroid
+create trigger aequilibrae_updated_zone_id_centroid after update of zone_id on zones
+begin
+  update nodes set is_centroid = 1 where nodes.node_id = new.zone_id and nodes.is_centroid != 1;
+end;

--- a/aequilibrae/project/project_creation.py
+++ b/aequilibrae/project/project_creation.py
@@ -55,31 +55,38 @@ def remove_triggers(
     with open(spec_folder / "triggers_list.txt", "r") as file_list:
         all_trigger_sets = file_list.readlines()
 
-    create_drop_regex = re.compile(r"create\s+trigger\s+(\w+)", flags=re.I)
     for table in all_trigger_sets:
         qry_file = spec_folder / f"{table.rstrip()}.sql"
+        drop_triggers_from_sql_file(conn, logger, qry_file, use_aequilibrae_prefix)
 
-        with open(qry_file, "r") as sql_file:
-            query_list = sql_file.read()
 
-        for cmd in query_list.split("--#"):
-            for qry in cmd.split("\n"):
-                if qry[:2] == "--":
-                    continue
-                while "  " in qry:
-                    qry = qry.replace("  ", " ")
+def drop_triggers_from_sql_file(
+    conn: Connection, logger: logging.Logger, qry_file: Path, use_aequilibrae_prefix: bool = True
+) -> None:
+    """Drops all triggers created by a single trigger specification file"""
+    create_drop_regex = re.compile(r"create\s+trigger\s+(\w+)", flags=re.I)
 
-                m = re.search(create_drop_regex, qry)
-                if m:
-                    name = m.group(1).lower()
-                    if not use_aequilibrae_prefix:
-                        name = name.removeprefix("aequilibrae_")
+    with open(qry_file, "r") as sql_file:
+        query_list = sql_file.read()
 
-                    try:
-                        conn.execute(f"drop trigger if exists {name}")
-                    except Exception as e:
-                        logger.error(f"Failed removing triggers table - > {e.args}")
-                        logger.error(f"Point of failure - > {qry}")
+    for cmd in query_list.split("--#"):
+        for qry in cmd.split("\n"):
+            if qry[:2] == "--":
+                continue
+            while "  " in qry:
+                qry = qry.replace("  ", " ")
+
+            m = re.search(create_drop_regex, qry)
+            if m:
+                name = m.group(1).lower()
+                if not use_aequilibrae_prefix:
+                    name = name.removeprefix("aequilibrae_")
+
+                try:
+                    conn.execute(f"drop trigger if exists {name}")
+                except Exception as e:
+                    logger.error(f"Failed removing triggers table - > {e.args}")
+                    logger.error(f"Point of failure - > {qry}")
 
 
 def run_queries_from_sql_file(conn: Connection, logger: logging.Logger, qry_file: Path) -> None:

--- a/aequilibrae/project/zoning.py
+++ b/aequilibrae/project/zoning.py
@@ -12,7 +12,7 @@ from shapely.geometry import Point, Polygon, LineString, MultiLineString
 from aequilibrae.project.basic_table import BasicTable
 from aequilibrae.project.data_loader import DataLoader
 from aequilibrae.project.network.connector_creation import connector_creation, bulk_connector_creation
-from aequilibrae.project.project_creation import run_queries_from_sql_file
+from aequilibrae.project.project_creation import drop_triggers_from_sql_file, run_queries_from_sql_file
 from aequilibrae.project.table_loader import TableLoader
 from aequilibrae.project.zone import Zone
 from aequilibrae.utils.aeq_signal import SIGNAL, simple_progress
@@ -71,9 +71,15 @@ class Zoning(BasicTable):
         """Creates the 'zones' table for project files that did not previously contain it"""
 
         if not self.__has_zoning():
-            qry_file = Path(__file__).parent.joinpath("database_specification", "network", "tables", "zones.sql")
+            spec_folder = Path(__file__).parent.joinpath("database_specification", "network")
+            qry_file = spec_folder.joinpath("tables", "zones.sql")
+            trigger_file = spec_folder.joinpath("triggers", "zones_triggers.sql")
             with self.network.project.db_connection as conn:
                 run_queries_from_sql_file(conn, self.project.logger, qry_file)
+                # The triggers on the nodes table survive the zones table being dropped, so we clear them
+                # before recreating the whole set
+                drop_triggers_from_sql_file(conn, self.project.logger, trigger_file)
+                run_queries_from_sql_file(conn, self.project.logger, trigger_file)
             self.__load()
         else:
             self.project.warning("zones table already exists. Nothing was done", Warning)

--- a/docs/source/network_manipulation/dealing_with_geometries.rst
+++ b/docs/source/network_manipulation/dealing_with_geometries.rst
@@ -310,3 +310,16 @@ The user should not change the a_node and b_node fields, as they are controlled
 by the triggers that govern the consistency between links and nodes. It is not
 possible to enforce that users do not change these two fields, as it is not
 possible to choose the trigger application sequence in SQLite.
+
+.. _is_centroid_field:
+
+Field 'is_centroid' (nodes layer)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The centroid of a zone is the node whose ``node_id`` matches that zone's ``zone_id``,
+so triggers set ``is_centroid=1`` for every node that shares its ID with an existing
+zone. That happens when such a node is created or renumbered onto the zone's ID, and
+also when a zone is created or renumbered on top of an existing node.
+
+Removing the centroid flag from one of these nodes results in an SQL exception, as
+that would leave the zone without a centroid. The zone has to be deleted first.

--- a/tests/aeq/project/test_zones_triggers.py
+++ b/tests/aeq/project/test_zones_triggers.py
@@ -1,0 +1,143 @@
+import inspect
+import sqlite3
+from pathlib import Path
+
+import pytest
+from shapely.geometry import MultiPolygon, Point
+
+from aequilibrae.project import about
+
+
+@pytest.fixture
+def queries():
+    qry = Path(inspect.getfile(about)).parent / "database_specification/network/triggers/zones_triggers.sql"
+    with open(qry, "r") as sql_file:
+        queries = sql_file.read()
+    return list(queries.split("#"))
+
+
+def add_zone(conn, zone_id: int, x=0.0, y=0.0):
+    geo = MultiPolygon([Point(x, y).buffer(0.01)])
+    conn.execute("INSERT INTO zones (zone_id, geometry) VALUES(?, GeomFromWKB(?, 4326))", [zone_id, geo.wkb])
+
+
+def add_node(conn, node_id: int, is_centroid=0, x=0.0, y=0.0):
+    sql = "INSERT INTO nodes (node_id, is_centroid, geometry) VALUES(?, ?, GeomFromWKB(?, 4326))"
+    conn.execute(sql, [node_id, is_centroid, Point(x, y).wkb])
+
+
+def is_centroid(conn, node_id: int):
+    return conn.execute("SELECT is_centroid FROM nodes WHERE node_id=?", [node_id]).fetchone()
+
+
+def test_all_tests_considered(queries):
+    """Test that every trigger in the zones triggers specification file has a test of its own."""
+    import sys
+
+    current_module = sys.modules[__name__]
+    tests_added = dir(current_module)
+    tests_added = [x[5:] for x in tests_added if x[:5] == "test_"]
+
+    for trigger in queries:
+        if "TRIGGER" in trigger.upper():
+            found = [x for x in tests_added if x in trigger]
+            if not found:
+                pytest.fail(f"Trigger not tested. {trigger}")
+
+
+def test_new_node_zone_centroid(empty_project):
+    """Test that a node created with the ID of an existing zone is tagged as a centroid."""
+    with empty_project.db_connection as conn:
+        add_zone(conn, 1)
+        add_node(conn, 1)
+        assert is_centroid(conn, 1) == (1,), "Node created over an existing zone was not tagged as a centroid"
+
+        add_node(conn, 2, x=1.0)
+        assert is_centroid(conn, 2) == (0,), "Node without a matching zone was tagged as a centroid"
+
+
+def test_updated_node_id_zone_centroid(empty_project):
+    """Test that a node renumbered to the ID of an existing zone is tagged as a centroid."""
+    with empty_project.db_connection as conn:
+        add_zone(conn, 10)
+        add_node(conn, 55)
+        assert is_centroid(conn, 55) == (0,), "Node without a matching zone was tagged as a centroid"
+
+        conn.execute("UPDATE nodes SET node_id=10 WHERE node_id=55")
+        assert is_centroid(conn, 10) == (1,), "Node renumbered onto an existing zone was not tagged as a centroid"
+
+
+def test_nodes_iscentroid_zone_update(empty_project):
+    """Test that a centroid cannot be untagged while the zone it belongs to still exists."""
+    with empty_project.db_connection as conn:
+        add_zone(conn, 1)
+        add_node(conn, 1, is_centroid=1)
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("UPDATE nodes SET is_centroid=0 WHERE node_id=1")
+        assert is_centroid(conn, 1) == (1,), "Centroid was untagged while its zone still existed"
+
+        # Centroids that do not match a zone are not protected, so the existing triggers delete this one
+        add_node(conn, 2, is_centroid=1, x=1.0)
+        conn.execute("UPDATE nodes SET is_centroid=0 WHERE node_id=2")
+        assert is_centroid(conn, 2) is None, "Centroid without a matching zone could not be untagged"
+
+
+def test_new_zone_centroid(empty_project):
+    """Test that creating a zone over an existing node tags that node as the zone's centroid."""
+    with empty_project.db_connection as conn:
+        add_node(conn, 7)
+        assert is_centroid(conn, 7) == (0,), "Node without a matching zone was tagged as a centroid"
+
+        add_zone(conn, 7)
+        assert is_centroid(conn, 7) == (1,), "Node was not tagged as a centroid when its zone was created"
+
+
+def test_updated_zone_id_centroid(empty_project):
+    """Test that renumbering a zone onto an existing node tags that node as the zone's centroid."""
+    with empty_project.db_connection as conn:
+        add_node(conn, 5)
+        add_zone(conn, 50)
+        assert is_centroid(conn, 5) == (0,), "Node without a matching zone was tagged as a centroid"
+
+        conn.execute("UPDATE zones SET zone_id=5 WHERE zone_id=50")
+        assert is_centroid(conn, 5) == (1,), "Node was not tagged as a centroid when its zone was renumbered onto it"
+
+
+def test_zone_centroid_triggers_added_with_zoning_layer(empty_project):
+    """Test that recreating the zoning layer brings back the triggers that tag centroids."""
+    tables = [
+        "zones",
+        "idx_zones_geometry",
+        "idx_zones_geometry_node",
+        "idx_zones_geometry_parent",
+        "idx_zones_geometry_rowid",
+    ]
+    with empty_project.db_connection as conn:
+        for table in tables:
+            conn.execute(f"DROP TABLE IF EXISTS {table};")
+        conn.execute("DELETE FROM attributes_documentation WHERE name_table LIKE 'zones'")
+
+    empty_project.zoning.create_zoning_layer()
+
+    with empty_project.db_connection as conn:
+        add_zone(conn, 3)
+        add_node(conn, 3)
+        assert is_centroid(conn, 3) == (1,), "Zone centroid triggers were not recreated with the zoning layer"
+
+
+def test_zone_centroid_migration(sioux_falls_example):
+    """Test that upgrading a project tags every node that shares its ID with a zone as a centroid."""
+    with sioux_falls_example.db_connection as conn:
+        # Nodes 1 and 2 have links attached to them, so untagging them does not delete them
+        conn.execute("UPDATE nodes SET is_centroid=0 WHERE node_id in (1, 2)")
+        assert is_centroid(conn, 1) == (0,), "Could not untag the centroid before upgrading the project"
+
+    sioux_falls_example.upgrade(ignore_transit=True, ignore_results=True)
+
+    with sioux_falls_example.db_connection as conn:
+        untagged = conn.execute("SELECT count(*) FROM nodes WHERE is_centroid != 1").fetchone()[0]
+        assert untagged == 0, "Upgrading the project did not tag the nodes that share their ID with a zone"
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("UPDATE nodes SET is_centroid=0 WHERE node_id=1")


### PR DESCRIPTION
Nodes with node_id equal to existing zones (zone_id) MUST be tagged as centroids (is_centroid=1).

A series of new triggers make this enforcement

This is a first stab at the problem with heavy AI support